### PR TITLE
user: support the `mail` property

### DIFF
--- a/internal/services/aadgraph/user_resource_test.go
+++ b/internal/services/aadgraph/user_resource_test.go
@@ -181,6 +181,7 @@ resource "azuread_user" "test" {
   display_name    = "acctestUser-%[1]d-Updated"
   given_name      = "acctestUser-%[1]d-GivenName"
   surname         = "acctestUser-%[1]d-Surname"
+  mail            = "acctestUser.%[1]d.Updated@${data.azuread_domains.tenant_domain.domains.0.domain_name}"
   mail_nickname   = "acctestUser-%[1]d-Updated"
   account_enabled = false
   password        = "%[2]s"


### PR DESCRIPTION
With this Terraform operators will be able to also set/modify the primary email address for the users.

Change explicitly depends on acceptance of https://github.com/Azure/azure-rest-api-specs/pull/12127 which will make the Mail field available for updates.