### PR TITLE
azuread_group: add mail_enabled and security_enabled attributes

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -12,7 +12,8 @@ Gets information about an Azure Active Directory group.
 
 ```hcl
 data "azuread_group" "example" {
-  display_name = "A-AD-Group"
+  display_name     = "MyGroupName"
+  security_enabled = true
 }
 ```
 
@@ -20,8 +21,10 @@ data "azuread_group" "example" {
 
 The following arguments are supported:
 
-* `display_name` - (Optional) The splay name of the Group within Azure Active Directory.
-* `object_id` - (Optional) Specifies the Object ID of the Group within Azure Active Directory.
+* `display_name` - (Optional) The display name for the Group.
+* `mail_enabled` - (Optional) Whether the group is mail-enabled.
+* `object_id` - (Optional) Specifies the Object ID of the Group.
+* `security_enabled` - (Optional) Whether the group is a security group.
 
 ~> **NOTE:** One of `display_name` or `object_id` must be specified.
 
@@ -29,9 +32,10 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `description` - The description of the AD Group.
-* `display_name` - The name of the Azure AD Group.
+* `description` - The optional description of the Group.
+* `display_name` - The display name for the Group.
 * `id` - The Object ID of the Azure AD Group.
-* `members` - The Object IDs of the Azure AD Group members.
-* `owners` - The Object IDs of the Azure AD Group owners.
-
+* `mail_enabled` - Whether the group is mail-enabled.
+* `members` - The Object IDs of the Group members.
+* `owners` - The Object IDs of the Group owners.
+* `security_enabled` - Whether the group is a security group.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -54,7 +54,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `mail_enabled` - Whether the group is mail-enabled.
 * `object_id` - The Object ID of the Group.
+* `security_enabled` - Whether the group is a security group.
+
+~> **NOTE:** Due to API limitations, this resource only supports the creation of security-only groups.
 
 ## Import
 

--- a/internal/helpers/aadgraph/group.go
+++ b/internal/helpers/aadgraph/group.go
@@ -13,8 +13,16 @@ import (
 	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
 )
 
-func GroupGetByDisplayName(ctx context.Context, client *graphrbac.GroupsClient, displayName string) (*graphrbac.ADGroup, error) {
+func GroupGetByDisplayName(ctx context.Context, client *graphrbac.GroupsClient, displayName string, mailEnabled *bool, securityEnabled *bool) (*graphrbac.ADGroup, error) {
 	filter := fmt.Sprintf("displayName eq '%s'", displayName)
+
+	if mailEnabled != nil {
+		filter = fmt.Sprintf("%s and mailEnabled eq %t", filter, *mailEnabled)
+	}
+
+	if securityEnabled != nil {
+		filter = fmt.Sprintf("%s and securityEnabled eq %t", filter, *securityEnabled)
+	}
 
 	resp, err := client.ListComplete(ctx, filter)
 	if err != nil {

--- a/internal/services/groups/group_data_source_test.go
+++ b/internal/services/groups/group_data_source_test.go
@@ -24,6 +24,18 @@ func TestAccGroupDataSource_byName(t *testing.T) {
 		},
 	})
 }
+func TestAccGroupDataSource_byNameWithSecurity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.nameSecurity(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
 
 func TestAccGroupDataSource_byNameDeprecated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
@@ -57,6 +69,19 @@ func TestAccGroupDataSource_byObjectId(t *testing.T) {
 	data.DataSourceTest(t, []resource.TestStep{
 		{
 			Config: GroupDataSource{}.objectId(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
+
+func TestAccGroupDataSource_byObjectIdWithSecurity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.objectIdSecurity(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
 			),
@@ -112,6 +137,18 @@ data "azuread_group" "test" {
 `, GroupResource{}.basic(data))
 }
 
+func (GroupDataSource) nameSecurity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_group" "test" {
+  display_name     = azuread_group.test.name
+  mail_enabled     = false
+  security_enabled = true
+}
+`, GroupResource{}.basic(data))
+}
+
 func (GroupDataSource) caseInsensitiveName(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -127,6 +164,18 @@ func (GroupDataSource) objectId(data acceptance.TestData) string {
 
 data "azuread_group" "test" {
   object_id = azuread_group.test.object_id
+}
+`, GroupResource{}.basic(data))
+}
+
+func (GroupDataSource) objectIdSecurity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_group" "test" {
+  object_id        = azuread_group.test.object_id
+  mail_enabled     = false
+  security_enabled = true
 }
 `, GroupResource{}.basic(data))
 }

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -58,6 +58,11 @@ func groupResource() *schema.Resource {
 				Optional: true,
 			},
 
+			"mail_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"members": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -84,10 +89,16 @@ func groupResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"prevent_duplicate_names": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+
+			"security_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
 			},
 		},
 	}
@@ -196,6 +207,8 @@ func groupResourceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	tf.Set(d, "object_id", resp.ObjectID)
 	tf.Set(d, "display_name", resp.DisplayName)
 	tf.Set(d, "name", resp.DisplayName)
+	tf.Set(d, "mail_enabled", resp.MailEnabled)
+	tf.Set(d, "security_enabled", resp.SecurityEnabled)
 
 	description := ""
 	if v, ok := resp.AdditionalProperties["description"]; ok {

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -81,7 +81,7 @@ func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if len(names) > 0 {
 		expectedCount = len(names)
 		for _, name := range names {
-			g, err := aadgraph.GroupGetByDisplayName(ctx, client, name.(string))
+			g, err := aadgraph.GroupGetByDisplayName(ctx, client, name.(string), nil, nil)
 			if err != nil {
 				return tf.ErrorDiagPathF(err, "name", "No group found with display name: %q", name)
 			}


### PR DESCRIPTION
Adds `mail_enabled` and `security_enabled` to the resource and data source. Due to API limitations, only security groups can be created, so these are computed for now.

Closes: #391