### PR TITLE
fix gomodule export path & update to Go 1.16

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,4 +37,4 @@ linters-settings:
   misspell:
     locale: UK
   goimports:
-    local-prefixes: github.com/terraform-providers/terraform-provider-azuread/azuread
+    local-prefixes: github.com/hashicorp/terraform-provider-azuread/azuread

--- a/.teamcity/components/vcs_root.kt
+++ b/.teamcity/components/vcs_root.kt
@@ -2,7 +2,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 
 object providerRepository : GitVcsRoot({
     name = "terraform-provider-azuread"
-    url = "https://github.com/terraform-providers/terraform-provider-azuread.git"
+    url = "https://github.com/hashicorp/terraform-provider-azuread.git"
     agentCleanPolicy = AgentCleanPolicy.ALWAYS
     agentCleanFilesPolicy = AgentCleanFilesPolicy.ALL_UNTRACKED
     branchSpec = "+:*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
-* dependencies: updating to build using Go 1.16 which adds support for `darwin/arm64` (Apple Silicon) ([#403](https://github.com/terraform-providers/terraform-provider-azuread/issues/403))
-* Data Source: `azuread_group` - support for the `mail_enabled` and `security_enabled` properties ([#393](https://github.com/terraform-providers/terraform-provider-azuread/issues/393))
-* `azuread_group` - support for the `mail_enabled` and `security_enabled` attributes ([#393](https://github.com/terraform-providers/terraform-provider-azuread/issues/393))
+* dependencies: updating to build using Go 1.16 which adds support for `darwin/arm64` (Apple Silicon) ([#403](https://github.com/hashicorp/terraform-provider-azuread/issues/403))
+* Data Source: `azuread_group` - support for the `mail_enabled` and `security_enabled` properties ([#393](https://github.com/hashicorp/terraform-provider-azuread/issues/393))
+* `azuread_group` - support for the `mail_enabled` and `security_enabled` attributes ([#393](https://github.com/hashicorp/terraform-provider-azuread/issues/393))
 
 ## 1.3.0 (January 28, 2021)
 
 IMPROVEMENTS:
 
-* `azuread_application_certificate` - support for base64 and hex encoded certificate values ([#386](https://github.com/terraform-providers/terraform-provider-azuread/issues/386))
-* `azuread_service_principal_certificate` - support for base64 and hex encoded certificate values ([#386](https://github.com/terraform-providers/terraform-provider-azuread/issues/386))
+* `azuread_application_certificate` - support for base64 and hex encoded certificate values ([#386](https://github.com/hashicorp/terraform-provider-azuread/issues/386))
+* `azuread_service_principal_certificate` - support for base64 and hex encoded certificate values ([#386](https://github.com/hashicorp/terraform-provider-azuread/issues/386))
 
 ## 1.2.2 (January 16, 2021)
 
@@ -57,26 +57,26 @@ DEPRECATIONS:
 
 BUG FIXES:
 
-* `azuread_application` - resolves an issue where setting `prevent_duplicate_names = true` causes an error for new applications ([#367](https://github.com/terraform-providers/terraform-provider-azuread/issues/367))
-* `azuread_application` - fixes a bug where the default owner for a new application is removed ([#366](https://github.com/terraform-providers/terraform-provider-azuread/issues/366))
+* `azuread_application` - resolves an issue where setting `prevent_duplicate_names = true` causes an error for new applications ([#367](https://github.com/hashicorp/terraform-provider-azuread/issues/367))
+* `azuread_application` - fixes a bug where the default owner for a new application is removed ([#366](https://github.com/hashicorp/terraform-provider-azuread/issues/366))
 
 ## 1.1.0 (November 25, 2020)
 
 FEATURES:
 
-* Added a flag to allow users to customize the Partner ID or opt-out of the default Terraform Partner ID ([#350](https://github.com/terraform-providers/terraform-provider-azuread/issues/350))
+* Added a flag to allow users to customize the Partner ID or opt-out of the default Terraform Partner ID ([#350](https://github.com/hashicorp/terraform-provider-azuread/issues/350))
 * This release includes updated support for working directly with tenants using Azure CLI authentication. We recommend the use of `az login --allow-no-subscription` to populate tenant-level accounts (which have no subscriptions).
 
 IMPROVEMENTS:
 
-* `data.azuread_user` - support the `given_name`, `surname`, `job_title`, `department`, `company_name`, `physical_delivery_office_name`, `street_address`, `city`, `state`, `country`, `postal_code` and `mobile` attribute ([#351](https://github.com/terraform-providers/terraform-provider-azuread/issues/351))
-* `azuread_user` - support the `given_name`, `surname`, `job_title`, `department`, `company_name`, `physical_delivery_office_name`, `street_address`, `city`, `state`, `country`, `postal_code` and `mobile` properties ([#351](https://github.com/terraform-providers/terraform-provider-azuread/issues/351))
+* `data.azuread_user` - support the `given_name`, `surname`, `job_title`, `department`, `company_name`, `physical_delivery_office_name`, `street_address`, `city`, `state`, `country`, `postal_code` and `mobile` attribute ([#351](https://github.com/hashicorp/terraform-provider-azuread/issues/351))
+* `azuread_user` - support the `given_name`, `surname`, `job_title`, `department`, `company_name`, `physical_delivery_office_name`, `street_address`, `city`, `state`, `country`, `postal_code` and `mobile` properties ([#351](https://github.com/hashicorp/terraform-provider-azuread/issues/351))
 
 BUG FIXES:
 
-* **Provider:** Fixed an issue where CLI authentication produced a `parsing json result` error during provider initialization ([#358](https://github.com/terraform-providers/terraform-provider-azuread/issues/358))
-* `azuread_application` - enable removal of owners on existing applications, and creation of applications with no owners ([#355](https://github.com/terraform-providers/terraform-provider-azuread/issues/355))
-* `azuread_application` - fixed a bug where specifying the `prevent_duplicate_names` property would report a false positive on update. ([#338](https://github.com/terraform-providers/terraform-provider-azuread/issues/338))
+* **Provider:** Fixed an issue where CLI authentication produced a `parsing json result` error during provider initialization ([#358](https://github.com/hashicorp/terraform-provider-azuread/issues/358))
+* `azuread_application` - enable removal of owners on existing applications, and creation of applications with no owners ([#355](https://github.com/hashicorp/terraform-provider-azuread/issues/355))
+* `azuread_application` - fixed a bug where specifying the `prevent_duplicate_names` property would report a false positive on update. ([#338](https://github.com/hashicorp/terraform-provider-azuread/issues/338))
 
 ## 1.0.0 (September 03, 2020)
 
@@ -87,33 +87,33 @@ NOTES:
 
 FEATURES:
 
-* New resource: `azuread_application_app_role` ([#150](https://github.com/terraform-providers/terraform-provider-azuread/issues/150)] [[#306](https://github.com/terraform-providers/terraform-provider-azuread/issues/306))
-* New resource: `azuread_application_oauth2_permission` ([#267](https://github.com/terraform-providers/terraform-provider-azuread/issues/267))
+* New resource: `azuread_application_app_role` ([#150](https://github.com/hashicorp/terraform-provider-azuread/issues/150)] [[#306](https://github.com/hashicorp/terraform-provider-azuread/issues/306))
+* New resource: `azuread_application_oauth2_permission` ([#267](https://github.com/hashicorp/terraform-provider-azuread/issues/267))
 
 BREAKING CHANGES:
 
-* `azuread_application` - a default value for the `homepage` property is no longer derived when unspecified ([#268](https://github.com/terraform-providers/terraform-provider-azuread/issues/268))
+* `azuread_application` - a default value for the `homepage` property is no longer derived when unspecified ([#268](https://github.com/hashicorp/terraform-provider-azuread/issues/268))
 * `azuread_application_password` - the deprecated `application_id` property has been removed
-* `data.azuread_group` - the `name` property is now case-insensitive ([#246](https://github.com/terraform-providers/terraform-provider-azuread/issues/246))
+* `data.azuread_group` - the `name` property is now case-insensitive ([#246](https://github.com/hashicorp/terraform-provider-azuread/issues/246))
 * `data.azuread_groups` and `data.azuread_users` will not error if no results found
 
 ## 0.11.0 (July 09, 2020)
 
 IMPROVEMENTS:
 
-* Provider: no longer require configuring `subscription_id` (configuration value) / `ARM_SUBSCRIPTION_ID` (environment variable). ([#271](https://github.com/terraform-providers/terraform-provider-azuread/issues/271))
-* `data.azuread_client_config` - deprecate the `subscription_id` property. For compatibility, still populates `subscription_id` if the provider is configured with a subscription ID ([#271](https://github.com/terraform-providers/terraform-provider-azuread/issues/271))
-* `data.azuread_application` - support for the `application_id` property ([#274](https://github.com/terraform-providers/terraform-provider-azuread/issues/274))
-* `data.azuread_users` - support the `ignore_missing` property ([#256](https://github.com/terraform-providers/terraform-provider-azuread/issues/256))
-* `data.azuread_users` - export the `users` attribute containing a list of users with additional properties ([#256](https://github.com/terraform-providers/terraform-provider-azuread/issues/256))
-* `azuread_application` - support the `prevent_duplicate_names` property ([#279](https://github.com/terraform-providers/terraform-provider-azuread/issues/279))
-* `azuread_application` - validate `app_roles` and `oauth2_permissions` to check for duplicate `value`s ([#287](https://github.com/terraform-providers/terraform-provider-azuread/issues/287))
-* `azuread_group` - support the `prevent_duplicate_names` property ([#279](https://github.com/terraform-providers/terraform-provider-azuread/issues/279))
+* Provider: no longer require configuring `subscription_id` (configuration value) / `ARM_SUBSCRIPTION_ID` (environment variable). ([#271](https://github.com/hashicorp/terraform-provider-azuread/issues/271))
+* `data.azuread_client_config` - deprecate the `subscription_id` property. For compatibility, still populates `subscription_id` if the provider is configured with a subscription ID ([#271](https://github.com/hashicorp/terraform-provider-azuread/issues/271))
+* `data.azuread_application` - support for the `application_id` property ([#274](https://github.com/hashicorp/terraform-provider-azuread/issues/274))
+* `data.azuread_users` - support the `ignore_missing` property ([#256](https://github.com/hashicorp/terraform-provider-azuread/issues/256))
+* `data.azuread_users` - export the `users` attribute containing a list of users with additional properties ([#256](https://github.com/hashicorp/terraform-provider-azuread/issues/256))
+* `azuread_application` - support the `prevent_duplicate_names` property ([#279](https://github.com/hashicorp/terraform-provider-azuread/issues/279))
+* `azuread_application` - validate `app_roles` and `oauth2_permissions` to check for duplicate `value`s ([#287](https://github.com/hashicorp/terraform-provider-azuread/issues/287))
+* `azuread_group` - support the `prevent_duplicate_names` property ([#279](https://github.com/hashicorp/terraform-provider-azuread/issues/279))
 
 BUG FIXES:
 
-* `azuread_group` - remediate AAD replication delays when adding/removing group members ([#283](https://github.com/terraform-providers/terraform-provider-azuread/issues/283))
-* `azuread_group` - remediate AAD replication delays after group creation, before setting owners/members ([#290](https://github.com/terraform-providers/terraform-provider-azuread/issues/290))
+* `azuread_group` - remediate AAD replication delays when adding/removing group members ([#283](https://github.com/hashicorp/terraform-provider-azuread/issues/283))
+* `azuread_group` - remediate AAD replication delays after group creation, before setting owners/members ([#290](https://github.com/hashicorp/terraform-provider-azuread/issues/290))
 
 ## 0.10.0 (June 05, 2020)
 
@@ -133,114 +133,114 @@ BREAKING CHANGES:
 
 FEATURES:
 
-* **New Resource:** `azuread_application_certificate` ([#262](https://github.com/terraform-providers/terraform-provider-azuread/issues/262))
-* **New Resource:** `azuread_service_principal_certificate` ([#262](https://github.com/terraform-providers/terraform-provider-azuread/issues/262))
+* **New Resource:** `azuread_application_certificate` ([#262](https://github.com/hashicorp/terraform-provider-azuread/issues/262))
+* **New Resource:** `azuread_service_principal_certificate` ([#262](https://github.com/hashicorp/terraform-provider-azuread/issues/262))
 
 IMPROVEMENTS:
 
-* `azuread_application` - support for the `optional_claims` property, for access tokens and ID tokens ([#260](https://github.com/terraform-providers/terraform-provider-azuread/issues/260))
-* `azuread_application` - support for the `oauth2_permissions` property ([#252](https://github.com/terraform-providers/terraform-provider-azuread/issues/252))
-* `azuread_application_password` - support the `description` property ([#253](https://github.com/terraform-providers/terraform-provider-azuread/issues/253))
-* `azuread_service_principal_password` - support the `description` property ([#253](https://github.com/terraform-providers/terraform-provider-azuread/issues/253))
-* `data.azuread_users` - support empty lists for `user_principal_names`/`object_ids`/`mail_nicknames` properties ([#258](https://github.com/terraform-providers/terraform-provider-azuread/issues/258))
-* `data.azuread_groups` - support empty lists for `names`/`object_ids` properties ([#257](https://github.com/terraform-providers/terraform-provider-azuread/issues/257))
+* `azuread_application` - support for the `optional_claims` property, for access tokens and ID tokens ([#260](https://github.com/hashicorp/terraform-provider-azuread/issues/260))
+* `azuread_application` - support for the `oauth2_permissions` property ([#252](https://github.com/hashicorp/terraform-provider-azuread/issues/252))
+* `azuread_application_password` - support the `description` property ([#253](https://github.com/hashicorp/terraform-provider-azuread/issues/253))
+* `azuread_service_principal_password` - support the `description` property ([#253](https://github.com/hashicorp/terraform-provider-azuread/issues/253))
+* `data.azuread_users` - support empty lists for `user_principal_names`/`object_ids`/`mail_nicknames` properties ([#258](https://github.com/hashicorp/terraform-provider-azuread/issues/258))
+* `data.azuread_groups` - support empty lists for `names`/`object_ids` properties ([#257](https://github.com/hashicorp/terraform-provider-azuread/issues/257))
 
 BUG FIXES:
 
-* `azuread_application_password` and `azuread_service_principal_password` - Plan-time validation for `end_date` / `end_date_relative` ([#261](https://github.com/terraform-providers/terraform-provider-azuread/issues/261))
-* `azuread_application_password` and `azuread_service_principal_password` - Change the resource ID format to mitigate potential UUID collision ([#264](https://github.com/terraform-providers/terraform-provider-azuread/issues/264))
+* `azuread_application_password` and `azuread_service_principal_password` - Plan-time validation for `end_date` / `end_date_relative` ([#261](https://github.com/hashicorp/terraform-provider-azuread/issues/261))
+* `azuread_application_password` and `azuread_service_principal_password` - Change the resource ID format to mitigate potential UUID collision ([#264](https://github.com/hashicorp/terraform-provider-azuread/issues/264))
 
 ## 0.9.0 (May 15, 2020)
 
 DEPENDENCIES:
 
-* upgrade `azure-sdk-for-go` to `v42.1.0` ([#247](https://github.com/terraform-providers/terraform-provider-azuread/issues/247))
+* upgrade `azure-sdk-for-go` to `v42.1.0` ([#247](https://github.com/hashicorp/terraform-provider-azuread/issues/247))
 
 IMPROVEMENTS:
 
-* `azuread_application` - the `group_membership_claims` property now supports `ApplicationGroup` ([#238](https://github.com/terraform-providers/terraform-provider-azuread/issues/238))
-* `azuread_service_principal` - changing the `tags` property no longer forces a new resource ([#245](https://github.com/terraform-providers/terraform-provider-azuread/issues/245))
+* `azuread_application` - the `group_membership_claims` property now supports `ApplicationGroup` ([#238](https://github.com/hashicorp/terraform-provider-azuread/issues/238))
+* `azuread_service_principal` - changing the `tags` property no longer forces a new resource ([#245](https://github.com/hashicorp/terraform-provider-azuread/issues/245))
 
 BUG FIXES:
 
-* `data.azuread_user` - use `equals` instead of `startsWith` when looking uo users by `mailNickname` ([#251](https://github.com/terraform-providers/terraform-provider-azuread/issues/251))
-* `data.azuread_users` - use `equals` instead of `startsWith` when looking uo users by `mailNickname` ([#251](https://github.com/terraform-providers/terraform-provider-azuread/issues/251))
+* `data.azuread_user` - use `equals` instead of `startsWith` when looking uo users by `mailNickname` ([#251](https://github.com/hashicorp/terraform-provider-azuread/issues/251))
+* `data.azuread_users` - use `equals` instead of `startsWith` when looking uo users by `mailNickname` ([#251](https://github.com/hashicorp/terraform-provider-azuread/issues/251))
 
 ## 0.8.0 (March 16, 2020)
 
 FEATURES:
 
-* **New Data Source:** `azuread_client_config` ([#229](https://github.com/terraform-providers/terraform-provider-azuread/issues/229))
+* **New Data Source:** `azuread_client_config` ([#229](https://github.com/hashicorp/terraform-provider-azuread/issues/229))
 
 IMPROVEMENTS:
 
-* dependencies: upgrade `azure-sdk-for-go` to `v40.3.0` ([#225](https://github.com/terraform-providers/terraform-provider-azuread/issues/225))
-* dependencies: upgrade `go-autorest/autorest` to `v0.10.0` ([#225](https://github.com/terraform-providers/terraform-provider-azuread/issues/225))
-* dependencies: upgrade `terraform-plugin-sdk` to `v1.6.0` ([#225](https://github.com/terraform-providers/terraform-provider-azuread/issues/225))
-* `azuread_application` - support for the `logout_url` property ([#226](https://github.com/terraform-providers/terraform-provider-azuread/issues/226))
-* `azuread_group` - support for the `description` property ([#216](https://github.com/terraform-providers/terraform-provider-azuread/issues/216))
-* `azuread_user` - support for the `onpremises_sam_account_name` and `onpremises_user_principal_name` properties ([#222](https://github.com/terraform-providers/terraform-provider-azuread/issues/222))
-* `azuread_user` - support for the `immutable_id` property ([#207](https://github.com/terraform-providers/terraform-provider-azuread/issues/207))
+* dependencies: upgrade `azure-sdk-for-go` to `v40.3.0` ([#225](https://github.com/hashicorp/terraform-provider-azuread/issues/225))
+* dependencies: upgrade `go-autorest/autorest` to `v0.10.0` ([#225](https://github.com/hashicorp/terraform-provider-azuread/issues/225))
+* dependencies: upgrade `terraform-plugin-sdk` to `v1.6.0` ([#225](https://github.com/hashicorp/terraform-provider-azuread/issues/225))
+* `azuread_application` - support for the `logout_url` property ([#226](https://github.com/hashicorp/terraform-provider-azuread/issues/226))
+* `azuread_group` - support for the `description` property ([#216](https://github.com/hashicorp/terraform-provider-azuread/issues/216))
+* `azuread_user` - support for the `onpremises_sam_account_name` and `onpremises_user_principal_name` properties ([#222](https://github.com/hashicorp/terraform-provider-azuread/issues/222))
+* `azuread_user` - support for the `immutable_id` property ([#207](https://github.com/hashicorp/terraform-provider-azuread/issues/207))
 
 BUG FIXES:
 
-* `azuread_application` - ensure all owners are added before removed ([#226](https://github.com/terraform-providers/terraform-provider-azuread/issues/226))
-* `azuread_application_password` - validate the `length` property is less then `863` ([#228](https://github.com/terraform-providers/terraform-provider-azuread/issues/228))
-* `azuread_group` - the `owners` property is now additive during creation allowing an existing owner to be provided ([#211](https://github.com/terraform-providers/terraform-provider-azuread/issues/211))
-* `azuread_group_member` - mark as missing when member cannot be found instead of erroring ([#227](https://github.com/terraform-providers/terraform-provider-azuread/issues/227))
-* `azuread_service_principal_password` - validate the `length` property is less then `863` ([#228](https://github.com/terraform-providers/terraform-provider-azuread/issues/228))
+* `azuread_application` - ensure all owners are added before removed ([#226](https://github.com/hashicorp/terraform-provider-azuread/issues/226))
+* `azuread_application_password` - validate the `length` property is less then `863` ([#228](https://github.com/hashicorp/terraform-provider-azuread/issues/228))
+* `azuread_group` - the `owners` property is now additive during creation allowing an existing owner to be provided ([#211](https://github.com/hashicorp/terraform-provider-azuread/issues/211))
+* `azuread_group_member` - mark as missing when member cannot be found instead of erroring ([#227](https://github.com/hashicorp/terraform-provider-azuread/issues/227))
+* `azuread_service_principal_password` - validate the `length` property is less then `863` ([#228](https://github.com/hashicorp/terraform-provider-azuread/issues/228))
 
 ## 0.7.0 (November 15, 2019)
 
 IMPROVEMENTS:
 
-* provider: migrate to standalone plugin SDK v1.1.0 ([#154](https://github.com/terraform-providers/terraform-provider-azuread/issues/154))
-* provider: using the current (rather than the vendored) version of Terraform Core in user agents ([#154](https://github.com/terraform-providers/terraform-provider-azuread/issues/154))
-* `azuread_application` - adds ability to build homepage with HTTP in addition to HTTPS ([#155](https://github.com/terraform-providers/terraform-provider-azuread/issues/155))
-* `azuread_application` - allow the `app_role` block `value` property to be nil ([#157](https://github.com/terraform-providers/terraform-provider-azuread/issues/157))
-* `azuread_user` - support for the `usage_location` property ([#141](https://github.com/terraform-providers/terraform-provider-azuread/issues/141))
-* `data.azuread_user` - support looking up a user with `mail_nickname` ([#161](https://github.com/terraform-providers/terraform-provider-azuread/issues/161))
-* `data.azuread_users` - support looking up users with `mail_nicknames` ([#161](https://github.com/terraform-providers/terraform-provider-azuread/issues/161))
+* provider: migrate to standalone plugin SDK v1.1.0 ([#154](https://github.com/hashicorp/terraform-provider-azuread/issues/154))
+* provider: using the current (rather than the vendored) version of Terraform Core in user agents ([#154](https://github.com/hashicorp/terraform-provider-azuread/issues/154))
+* `azuread_application` - adds ability to build homepage with HTTP in addition to HTTPS ([#155](https://github.com/hashicorp/terraform-provider-azuread/issues/155))
+* `azuread_application` - allow the `app_role` block `value` property to be nil ([#157](https://github.com/hashicorp/terraform-provider-azuread/issues/157))
+* `azuread_user` - support for the `usage_location` property ([#141](https://github.com/hashicorp/terraform-provider-azuread/issues/141))
+* `data.azuread_user` - support looking up a user with `mail_nickname` ([#161](https://github.com/hashicorp/terraform-provider-azuread/issues/161))
+* `data.azuread_users` - support looking up users with `mail_nicknames` ([#161](https://github.com/hashicorp/terraform-provider-azuread/issues/161))
 
 ## 0.6.0 (August 21, 2019)
 
 IMPROVEMENTS:
 
-* dependencies: upgrading `github.com/Azure/azure-sdk-for-go` to `v32.5.0` ([#140](https://github.com/terraform-providers/terraform-provider-azuread/issues/140))
-* dependencies: upgrading `github.com/Azure/go-autorest` to `v13.0.0` ([#140](https://github.com/terraform-providers/terraform-provider-azuread/issues/140))
-* dependencies: upgrading `github.com/hashicorp/go-azure-helpers` to `v0.7.0` ([#140](https://github.com/terraform-providers/terraform-provider-azuread/issues/140))
-* dependencies: upgrading `github.com/hashicorp/terraform` to `0.12.6` ([#133](https://github.com/terraform-providers/terraform-provider-azuread/issues/133))
-* `azuread_service_principal` - support for the `app_role_assignment_required` property ([#127](https://github.com/terraform-providers/terraform-provider-azuread/issues/127))
+* dependencies: upgrading `github.com/Azure/azure-sdk-for-go` to `v32.5.0` ([#140](https://github.com/hashicorp/terraform-provider-azuread/issues/140))
+* dependencies: upgrading `github.com/Azure/go-autorest` to `v13.0.0` ([#140](https://github.com/hashicorp/terraform-provider-azuread/issues/140))
+* dependencies: upgrading `github.com/hashicorp/go-azure-helpers` to `v0.7.0` ([#140](https://github.com/hashicorp/terraform-provider-azuread/issues/140))
+* dependencies: upgrading `github.com/hashicorp/terraform` to `0.12.6` ([#133](https://github.com/hashicorp/terraform-provider-azuread/issues/133))
+* `azuread_service_principal` - support for the `app_role_assignment_required` property ([#127](https://github.com/hashicorp/terraform-provider-azuread/issues/127))
 
 
 ## 0.5.1 (July 24, 2019)
 
 BUG FIXES:
 
-* `azuread_application_password` - fix incorrect conflicts with ([#129](https://github.com/terraform-providers/terraform-provider-azuread/issues/129))
+* `azuread_application_password` - fix incorrect conflicts with ([#129](https://github.com/hashicorp/terraform-provider-azuread/issues/129))
 
 ## 0.5.0 (July 24, 2019)
 
 FEATURES:
 
-* **New Data Source:** `azuread_users` ([#109](https://github.com/terraform-providers/terraform-provider-azuread/issues/109))
-* **New Resource:** `azuread_group_member` ([#100](https://github.com/terraform-providers/terraform-provider-azuread/issues/100))
+* **New Data Source:** `azuread_users` ([#109](https://github.com/hashicorp/terraform-provider-azuread/issues/109))
+* **New Resource:** `azuread_group_member` ([#100](https://github.com/hashicorp/terraform-provider-azuread/issues/100))
 
 IMPROVEMENTS:
 
-* `azuread_application` - support for the `app_roles` property ([#98](https://github.com/terraform-providers/terraform-provider-azuread/issues/98))
-* `azuread_application` - the `identifier_uris` property now allows `api`,`urn`, and `ms-appx` URI schemas ([#115](https://github.com/terraform-providers/terraform-provider-azuread/issues/115))
-* `azuread_application_password` - deprecation of `application_id` in favour of `application_object_id` ([#107](https://github.com/terraform-providers/terraform-provider-azuread/issues/107))
-* `azuread_group` - support for the `members` property ([#100](https://github.com/terraform-providers/terraform-provider-azuread/issues/100))
-* `azuread_group` - support for the `owners` property ([#62](https://github.com/terraform-providers/terraform-provider-azuread/issues/62))
-* `azuread_service_principal` - export the `oauth2_permissions` property ([#103](https://github.com/terraform-providers/terraform-provider-azuread/issues/103))
-* `data.azuread_application` - support for the `app_roles` property ([#110](https://github.com/terraform-providers/terraform-provider-azuread/issues/110))
-* `data.azuread_service_principal` - export the `app_roles` property ([#110](https://github.com/terraform-providers/terraform-provider-azuread/issues/110))
+* `azuread_application` - support for the `app_roles` property ([#98](https://github.com/hashicorp/terraform-provider-azuread/issues/98))
+* `azuread_application` - the `identifier_uris` property now allows `api`,`urn`, and `ms-appx` URI schemas ([#115](https://github.com/hashicorp/terraform-provider-azuread/issues/115))
+* `azuread_application_password` - deprecation of `application_id` in favour of `application_object_id` ([#107](https://github.com/hashicorp/terraform-provider-azuread/issues/107))
+* `azuread_group` - support for the `members` property ([#100](https://github.com/hashicorp/terraform-provider-azuread/issues/100))
+* `azuread_group` - support for the `owners` property ([#62](https://github.com/hashicorp/terraform-provider-azuread/issues/62))
+* `azuread_service_principal` - export the `oauth2_permissions` property ([#103](https://github.com/hashicorp/terraform-provider-azuread/issues/103))
+* `data.azuread_application` - support for the `app_roles` property ([#110](https://github.com/hashicorp/terraform-provider-azuread/issues/110))
+* `data.azuread_service_principal` - export the `app_roles` property ([#110](https://github.com/hashicorp/terraform-provider-azuread/issues/110))
 
 BUG FIXES:
 
-* `azuread_application_password` - will now wait for replication on resource creation ([#118](https://github.com/terraform-providers/terraform-provider-azuread/issues/118))
-* `azuread_service_principal_password` - will now wait for replication on resource creation ([#117](https://github.com/terraform-providers/terraform-provider-azuread/issues/117))
+* `azuread_application_password` - will now wait for replication on resource creation ([#118](https://github.com/hashicorp/terraform-provider-azuread/issues/118))
+* `azuread_service_principal_password` - will now wait for replication on resource creation ([#117](https://github.com/hashicorp/terraform-provider-azuread/issues/117))
 
 ## 0.4.0 (June 06, 2019)
 
@@ -250,25 +250,25 @@ NOTES:
 
 FEATURES:
 
-* **New Resource:** `azuread_application_password` ([#71](https://github.com/terraform-providers/terraform-provider-azuread/issues/71))
+* **New Resource:** `azuread_application_password` ([#71](https://github.com/hashicorp/terraform-provider-azuread/issues/71))
 
 IMPROVEMENTS:
 
-* dependencies: upgrading to `v0.12.0` of `github.com/hashicorp/terraform` ([#82](https://github.com/terraform-providers/terraform-provider-azuread/issues/82))
-* `azuread_application` - support for the `group_membership_claims` property ([#78](https://github.com/terraform-providers/terraform-provider-azuread/issues/78))
-* `azuread_application` - now exports the `oauth2_permissions` property ([#79](https://github.com/terraform-providers/terraform-provider-azuread/issues/79))
-* `azuread_application` - now exports the `object_id` property ([#99](https://github.com/terraform-providers/terraform-provider-azuread/issues/99))
-* `azuread_application` - support for the `type` property enabling the creation of `native` applications ([#74](https://github.com/terraform-providers/terraform-provider-azuread/issues/74))
-* `azuread_application` - will now wait for replication by waiting for 10 successful reads after creation ([#93](https://github.com/terraform-providers/terraform-provider-azuread/issues/93))
-* `azuread_group` - will now wait for replication by waiting for 10 successful reads after creation ([#91](https://github.com/terraform-providers/terraform-provider-azuread/issues/91))
-* `azuread_group` - now exports the `object_id` property ([#99](https://github.com/terraform-providers/terraform-provider-azuread/issues/99))
-* `azuread_service_principal` - will now wait for replication by waiting for 10 successful reads after creation ([#93](https://github.com/terraform-providers/terraform-provider-azuread/issues/93))
-* `azuread_service_principal` - now exports the `object_id` property ([#99](https://github.com/terraform-providers/terraform-provider-azuread/issues/99))
-* `azuread_user` - will now wait for replication by waiting for 10 successful reads after creation ([#91](https://github.com/terraform-providers/terraform-provider-azuread/issues/91))
-* `azuread_user` - increase the maximum allowed length of `password` to 256 ([#81](https://github.com/terraform-providers/terraform-provider-azuread/issues/81))
-* `azuread_user` - now exports the `object_id` property ([#99](https://github.com/terraform-providers/terraform-provider-azuread/issues/99))
-* `data.azuread_application` - now exports the `group_membership_claims` property ([#78](https://github.com/terraform-providers/terraform-provider-azuread/issues/78))
-* `data.azuread_application` - now exports the `oauth2_permissions` property ([#79](https://github.com/terraform-providers/terraform-provider-azuread/issues/79))
+* dependencies: upgrading to `v0.12.0` of `github.com/hashicorp/terraform` ([#82](https://github.com/hashicorp/terraform-provider-azuread/issues/82))
+* `azuread_application` - support for the `group_membership_claims` property ([#78](https://github.com/hashicorp/terraform-provider-azuread/issues/78))
+* `azuread_application` - now exports the `oauth2_permissions` property ([#79](https://github.com/hashicorp/terraform-provider-azuread/issues/79))
+* `azuread_application` - now exports the `object_id` property ([#99](https://github.com/hashicorp/terraform-provider-azuread/issues/99))
+* `azuread_application` - support for the `type` property enabling the creation of `native` applications ([#74](https://github.com/hashicorp/terraform-provider-azuread/issues/74))
+* `azuread_application` - will now wait for replication by waiting for 10 successful reads after creation ([#93](https://github.com/hashicorp/terraform-provider-azuread/issues/93))
+* `azuread_group` - will now wait for replication by waiting for 10 successful reads after creation ([#91](https://github.com/hashicorp/terraform-provider-azuread/issues/91))
+* `azuread_group` - now exports the `object_id` property ([#99](https://github.com/hashicorp/terraform-provider-azuread/issues/99))
+* `azuread_service_principal` - will now wait for replication by waiting for 10 successful reads after creation ([#93](https://github.com/hashicorp/terraform-provider-azuread/issues/93))
+* `azuread_service_principal` - now exports the `object_id` property ([#99](https://github.com/hashicorp/terraform-provider-azuread/issues/99))
+* `azuread_user` - will now wait for replication by waiting for 10 successful reads after creation ([#91](https://github.com/hashicorp/terraform-provider-azuread/issues/91))
+* `azuread_user` - increase the maximum allowed length of `password` to 256 ([#81](https://github.com/hashicorp/terraform-provider-azuread/issues/81))
+* `azuread_user` - now exports the `object_id` property ([#99](https://github.com/hashicorp/terraform-provider-azuread/issues/99))
+* `data.azuread_application` - now exports the `group_membership_claims` property ([#78](https://github.com/hashicorp/terraform-provider-azuread/issues/78))
+* `data.azuread_application` - now exports the `oauth2_permissions` property ([#79](https://github.com/hashicorp/terraform-provider-azuread/issues/79))
 
 ## 0.3.1 (April 18, 2019)
 
@@ -280,33 +280,33 @@ BUG FIXES:
 
 NOTES:
 
-* This release includes a Terraform SDK upgrade with compatibility for Terraform v0.12. The provider remains backwards compatible with Terraform v0.11 and there should not be any significant behavioural changes. ([#56](https://github.com/terraform-providers/terraform-provider-azuread/issues/56))
+* This release includes a Terraform SDK upgrade with compatibility for Terraform v0.12. The provider remains backwards compatible with Terraform v0.11 and there should not be any significant behavioural changes. ([#56](https://github.com/hashicorp/terraform-provider-azuread/issues/56))
 
 BUG FIXES:
 
-* `azuread_application` - the order of the `reply_urls` property no longer matters ([#61](https://github.com/terraform-providers/terraform-provider-azuread/issues/61))
+* `azuread_application` - the order of the `reply_urls` property no longer matters ([#61](https://github.com/hashicorp/terraform-provider-azuread/issues/61))
 
 ## 0.2.0 (March 12, 2019)
 
 FEATURES:
 
-* **New Data Source:** `azuread_domains` ([#27](https://github.com/terraform-providers/terraform-provider-azuread/issues/27))
-* **New Data Source:** `azuread_group` ([#14](https://github.com/terraform-providers/terraform-provider-azuread/issues/14))
-* **New Resource:** `azuread_group` ([#14](https://github.com/terraform-providers/terraform-provider-azuread/issues/14))
+* **New Data Source:** `azuread_domains` ([#27](https://github.com/hashicorp/terraform-provider-azuread/issues/27))
+* **New Data Source:** `azuread_group` ([#14](https://github.com/hashicorp/terraform-provider-azuread/issues/14))
+* **New Resource:** `azuread_group` ([#14](https://github.com/hashicorp/terraform-provider-azuread/issues/14))
 
 IMPROVEMENTS:
 
-* dependencies: switching to use Go Modules ([#26](https://github.com/terraform-providers/terraform-provider-azuread/issues/26))
-* dependencies: updating `github.com/Azure/azure-sdk-for-go` to v24.1.0 ([#25](https://github.com/terraform-providers/terraform-provider-azuread/issues/25))
-* dependencies: updating `github.com/Azure/go-autorest` to v11.2.8 ([#24](https://github.com/terraform-providers/terraform-provider-azuread/issues/24))
-* validation: adding validation to all fields ([#30](https://github.com/terraform-providers/terraform-provider-azuread/issues/30))
-* `azuread_application` - support for `required_resource_access` property ([#23](https://github.com/terraform-providers/terraform-provider-azuread/issues/23))
-* `azuread_service_principal` - support for the `tags` property ([#31](https://github.com/terraform-providers/terraform-provider-azuread/issues/31))
-* `azuread_service_principal_password` - support for realitive ends dates with the `end_date_relative` property ([#53](https://github.com/terraform-providers/terraform-provider-azuread/issues/53))
+* dependencies: switching to use Go Modules ([#26](https://github.com/hashicorp/terraform-provider-azuread/issues/26))
+* dependencies: updating `github.com/Azure/azure-sdk-for-go` to v24.1.0 ([#25](https://github.com/hashicorp/terraform-provider-azuread/issues/25))
+* dependencies: updating `github.com/Azure/go-autorest` to v11.2.8 ([#24](https://github.com/hashicorp/terraform-provider-azuread/issues/24))
+* validation: adding validation to all fields ([#30](https://github.com/hashicorp/terraform-provider-azuread/issues/30))
+* `azuread_application` - support for `required_resource_access` property ([#23](https://github.com/hashicorp/terraform-provider-azuread/issues/23))
+* `azuread_service_principal` - support for the `tags` property ([#31](https://github.com/hashicorp/terraform-provider-azuread/issues/31))
+* `azuread_service_principal_password` - support for realitive ends dates with the `end_date_relative` property ([#53](https://github.com/hashicorp/terraform-provider-azuread/issues/53))
 
 BUG FIXES:
 
-* `azuread_application` - correctly reading back the `reply_urls` property into state ([#21](https://github.com/terraform-providers/terraform-provider-azuread/issues/21))
+* `azuread_application` - correctly reading back the `reply_urls` property into state ([#21](https://github.com/hashicorp/terraform-provider-azuread/issues/21))
 
 
 ## 0.1.0 (January 09, 2019)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,7 +39,7 @@ fmtcheck:
 
 goimports:
 	@echo "==> Fixing imports code with goimports..."
-	goimports -local "github.com/terraform-providers/terraform-provider-azuread" -w $(PKG_NAME)/
+	goimports -local "github.com/hashicorp/terraform-provider-azuread" -w $(PKG_NAME)/
 
 lint:
 	@echo "==> Checking source code against linters..."
@@ -78,10 +78,10 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=10
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azuread/version.ProviderVersion=acc"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azuread/version.ProviderVersion=acc"
 
 acctests: fmtcheck
-	TF_ACC=1 go test -v ./internal/services/$(SERVICE)/tests/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azuread/version.ProviderVersion=acc"
+	TF_ACC=1 go test -v ./internal/services/$(SERVICE)/tests/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/hashicorp/terraform-provider-azuread/version.ProviderVersion=acc"
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [Terraform Website](https://www.terraform.io)
 - [AzureAD Provider Documentation](https://terraform.io/docs/providers/azuread/)
-- [AzureAD Provider Usage Examples](https://github.com/terraform-providers/terraform-provider-azuread/tree/main/examples)
+- [AzureAD Provider Usage Examples](https://github.com/hashicorp/terraform-provider-azuread/tree/main/examples)
 - [Slack Workspace for Contributors](https://terraform-azure.slack.com) ([Request Invite](https://join.slack.com/t/terraform-azure/shared_invite/enQtNDMzNjQ5NzcxMDc3LWNiY2ZhNThhNDgzNmY0MTM0N2MwZjE4ZGU0MjcxYjUyMzRmN2E5NjZhZmQ0ZTA1OTExMGNjYzA4ZDkwZDYxNDE))
 
 
@@ -68,11 +68,11 @@ For *Git Bash for Windows*, at the step of "Adjusting your PATH environment", pl
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.16+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
-Clone the repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-azuread`
+Clone the repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-azuread`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone github.com/terraform-providers/terraform-provider-azuread
+$ git clone github.com/hashicorp/terraform-provider-azuread
 ```
 
 Change to the clone directory and run `make tools` to install the dependent tooling needed to test and build the provider.

--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -10,7 +10,7 @@ Use this data source to access information about an existing Application within 
 
 ## Example Usage
 
-```hcl
+```terraform
 data "azuread_application" "example" {
   display_name = "My First AzureAD Application"
 }

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -10,7 +10,7 @@ Use this data source to access information about existing Domains within Azure A
 
 ## Example Usage
 
-```hcl
+```terraform
 data "azuread_domains" "aad_domains" {}
 
 output "domains" {

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -10,7 +10,7 @@ Gets information about an Azure Active Directory group.
 
 ## Example Usage (by Group Display Name)
 
-```hcl
+```terraform
 data "azuread_group" "example" {
   display_name     = "MyGroupName"
   security_enabled = true

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -10,7 +10,7 @@ Gets Object IDs or Display Names for multiple Azure Active Directory groups.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "azuread_groups" "groups" {
   names = ["group-a", "group-b"]
 }

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -10,7 +10,7 @@ Gets information about an existing Service Principal associated with an Applicat
 
 ## Example Usage (by Application Display Name)
 
-```hcl
+```terraform
 data "azuread_service_principal" "example" {
   display_name = "my-awesome-application"
 }
@@ -18,7 +18,7 @@ data "azuread_service_principal" "example" {
 
 ## Example Usage (by Application ID)
 
-```hcl
+```terraform
 data "azuread_service_principal" "example" {
   application_id = "00000000-0000-0000-0000-000000000000"
 }
@@ -26,7 +26,7 @@ data "azuread_service_principal" "example" {
 
 ## Example Usage (by Object ID)
 
-```hcl
+```terraform
 data "azuread_service_principal" "example" {
   object_id = "00000000-0000-0000-0000-000000000000"
 }

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -10,7 +10,7 @@ Gets information about an Azure Active Directory user.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "azuread_user" "example" {
   user_principal_name = "user@hashicorp.com"
 }

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -10,7 +10,7 @@ Gets Object IDs or UPNs for multiple Azure Active Directory users.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "azuread_users" "users" {
   user_principal_names = ["kat@hashicorp.com", "byte@hashicorp.com"]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 The Azure Provider can be used to configure infrastructure in [Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) using the Azure Resource Manager API's. Documentation regarding the [Data Sources](/docs/configuration/data-sources.html) and [Resources](/docs/configuration/resources.html) supported by the Azure Active Directory Provider can be found in the navigation to the left.
 
-Interested in the provider's latest features, or want to make sure you're up to date? Check out the [changelog](https://github.com/terraform-providers/terraform-provider-azuread/blob/main/CHANGELOG.md) for version information and release notes.
+Interested in the provider's latest features, or want to make sure you're up to date? Check out the [changelog](https://github.com/hashicorp/terraform-provider-azuread/blob/main/CHANGELOG.md) for version information and release notes.
 
 ## Authenticating to Azure Active Directory
 
@@ -38,7 +38,7 @@ resource "azuread_service_principal" "example" {
 
 ## Features and Bug Requests
 
-The Azure Active Directory provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/terraform-providers/terraform-provider-azuread/issues).
+The Azure Active Directory provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/hashicorp/terraform-provider-azuread/issues).
 Please avoid "me too" or "+1" comments. Instead, use a thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
 on enhancement requests. Provider maintainers will often prioritise work based on the number of thumbs on an issue.
 
@@ -48,9 +48,9 @@ experience for you using the Azure Active Directory provider.
 
 If you have a bug or feature request without an existing issue
 
-* if an existing resource or field is working in an unexpected way, [file a bug](https://github.com/terraform-providers/terraform-provider-azuread/issues/new?template=bug.md).
+* if an existing resource or field is working in an unexpected way, [file a bug](https://github.com/hashicorp/terraform-provider-azuread/issues/new?template=bug.md).
 
-* if you'd like the provider to support a new resource or field, [file an enhancement/feature request](https://github.com/terraform-providers/terraform-provider-azuread/issues/new?template=enhancement.md).
+* if you'd like the provider to support a new resource or field, [file an enhancement/feature request](https://github.com/hashicorp/terraform-provider-azuread/issues/new?template=enhancement.md).
 
 The provider maintainers will often use the assignee field on an issue to mark
 who is working on it.

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -10,7 +10,7 @@ Manages an Application within Azure Active Directory.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   display_name               = "example"
   homepage                   = "https://homepage"

--- a/docs/resources/application_app_role.md
+++ b/docs/resources/application_app_role.md
@@ -10,7 +10,7 @@ Manages an App Role associated with an Application within Azure Active Directory
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }

--- a/docs/resources/application_certificate.md
+++ b/docs/resources/application_certificate.md
@@ -12,7 +12,7 @@ Manages a Certificate associated with an Application within Azure Active Directo
 
 *Using a PEM certificate*
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }
@@ -27,7 +27,7 @@ resource "azuread_application_certificate" "example" {
 
 *Using a DER certificate*
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }
@@ -43,7 +43,7 @@ resource "azuread_application_certificate" "example" {
 
 ### Using a certificate from Azure Key Vault
 
-```hcl
+```terraform
 resource "azurerm_key_vault_certificate" "example" {
   name         = "generated-cert"
   key_vault_id = azurerm_key_vault.example.id

--- a/docs/resources/application_oauth2_permission.md
+++ b/docs/resources/application_oauth2_permission.md
@@ -10,7 +10,7 @@ Manages an OAuth2 Permission (also known as a Scope) associated with an Applicat
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }

--- a/docs/resources/application_password.md
+++ b/docs/resources/application_password.md
@@ -10,7 +10,7 @@ Manages a Password associated with an Application within Azure Active Directory.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -12,7 +12,7 @@ Manages a Group within Azure Active Directory.
 
 *Basic example*
 
-```hcl
+```terraform
 resource "azuread_group" "example" {
   display_name = "A-AD-Group"
 }
@@ -20,7 +20,7 @@ resource "azuread_group" "example" {
 
 *A group with members*
 
-```hcl
+```terraform
 resource "azuread_user" "example" {
   display_name        = "J Doe"
   password            = "notSecure123"

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -10,7 +10,7 @@ Manages a single Group Membership within Azure Active Directory.
 
 ## Example Usage
 
-```hcl
+```terraform
 
 data "azuread_user" "example" {
   user_principal_name = "jdoe@hashicorp.com"

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -10,7 +10,7 @@ Manages a Service Principal associated with an Application within Azure Active D
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name                       = "example"
   homepage                   = "http://homepage"

--- a/docs/resources/service_principal_certificate.md
+++ b/docs/resources/service_principal_certificate.md
@@ -12,7 +12,7 @@ Manages a Certificate associated with a Service Principal within Azure Active Di
 
 *Using a PEM certificate*
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }
@@ -31,7 +31,7 @@ resource "azuread_service_principal_certificate" "example" {
 
 *Using a DER certificate*
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }

--- a/docs/resources/service_principal_password.md
+++ b/docs/resources/service_principal_password.md
@@ -10,7 +10,7 @@ Manages a Password associated with a Service Principal within Azure Active Direc
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_application" "example" {
   name = "example"
 }

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -10,7 +10,7 @@ Manages a User within Azure Active Directory.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "azuread_user" "example" {
   user_principal_name = "jdoe@hashicorp.com"
   display_name        = "J. Doe"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-azuread
+module github.com/hashicorp/terraform-provider-azuread
 
 require (
 	github.com/Azure/azure-sdk-for-go v47.1.0+incompatible
@@ -11,4 +11,4 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 )
 
-go 1.14
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -292,8 +291,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/hashicorp/terraform-provider-azuread v1.4.0 h1:znGLegISaZ1nCtl5qBoZbWz1PP1hQ6AJakbD95TJ5n8=
-github.com/hashicorp/terraform-provider-azuread v1.4.0/go.mod h1:d1LNrgnJ25DXzPYXL74mgunQ5+05m/f2pbddG8K5hr4=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/hashicorp/terraform-provider-azuread v1.4.0 h1:znGLegISaZ1nCtl5qBoZbWz1PP1hQ6AJakbD95TJ5n8=
+github.com/hashicorp/terraform-provider-azuread v1.4.0/go.mod h1:d1LNrgnJ25DXzPYXL74mgunQ5+05m/f2pbddG8K5hr4=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/internal/acceptance/acceptance.go
+++ b/internal/acceptance/acceptance.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/provider"
+	"github.com/hashicorp/terraform-provider-azuread/internal/provider"
 )
 
 var AzureADProvider *schema.Provider

--- a/internal/acceptance/check/that.go
+++ b/internal/acceptance/check/that.go
@@ -6,10 +6,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/helpers"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 type thatType struct {

--- a/internal/acceptance/data.go
+++ b/internal/acceptance/data.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 )
 
 type TestData struct {

--- a/internal/acceptance/helpers/check_destroyed.go
+++ b/internal/acceptance/helpers/check_destroyed.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 // CheckDestroyedFunc returns a TestCheckFunc which validates the resource no longer exists

--- a/internal/acceptance/helpers/delete.go
+++ b/internal/acceptance/helpers/delete.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 // DeleteResourceFunc returns a TestCheckFunc which deletes the resource within Azure

--- a/internal/acceptance/helpers/exists.go
+++ b/internal/acceptance/helpers/exists.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 func ExistsInAzure(client *clients.Client, testResource types.TestResource, resourceName string) resource.TestCheckFunc {

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/helpers"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {

--- a/internal/acceptance/types/resource.go
+++ b/internal/acceptance/types/resource.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
 
 type TestResource interface {

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type ClientBuilder struct {

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -6,12 +6,12 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
-	applications "github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/client"
-	domains "github.com/terraform-providers/terraform-provider-azuread/internal/services/domains/client"
-	groups "github.com/terraform-providers/terraform-provider-azuread/internal/services/groups/client"
-	serviceprincipals "github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals/client"
-	users "github.com/terraform-providers/terraform-provider-azuread/internal/services/users/client"
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+	applications "github.com/hashicorp/terraform-provider-azuread/internal/services/applications/client"
+	domains "github.com/hashicorp/terraform-provider-azuread/internal/services/domains/client"
+	groups "github.com/hashicorp/terraform-provider-azuread/internal/services/groups/client"
+	serviceprincipals "github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/client"
+	users "github.com/hashicorp/terraform-provider-azuread/internal/services/users/client"
 )
 
 // Client contains the handles to all the specific Azure AD resource classes' respective clients

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 
-	"github.com/terraform-providers/terraform-provider-azuread/version"
+	"github.com/hashicorp/terraform-provider-azuread/version"
 )
 
 type ClientOptions struct {

--- a/internal/helpers/aadgraph/application.go
+++ b/internal/helpers/aadgraph/application.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func FlattenAppRoles(in *[]graphrbac.AppRole) []map[string]interface{} {

--- a/internal/helpers/aadgraph/credentials.go
+++ b/internal/helpers/aadgraph/credentials.go
@@ -17,8 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 // valid types are `application` and `service_principal`

--- a/internal/helpers/aadgraph/group.go
+++ b/internal/helpers/aadgraph/group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func GroupGetByDisplayName(ctx context.Context, client *graphrbac.GroupsClient, displayName string, mailEnabled *bool, securityEnabled *bool) (*graphrbac.ADGroup, error) {

--- a/internal/helpers/aadgraph/replication.go
+++ b/internal/helpers/aadgraph/replication.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func WaitForCreationReplication(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {

--- a/internal/helpers/aadgraph/user.go
+++ b/internal/helpers/aadgraph/user.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func UserGetByObjectId(ctx context.Context, client *graphrbac.UsersClient, objectId string) (*graphrbac.User, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 )
 
 // Microsoft’s Terraform Partner ID is this specific GUID

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -1,11 +1,11 @@
 package provider
 
 import (
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/domains"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/groups"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/users"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/domains"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/groups"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/users"
 )
 
 func SupportedServices() []ServiceRegistration {

--- a/internal/services/applications/application_app_role_resource.go
+++ b/internal/services/applications/application_app_role_resource.go
@@ -10,12 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func applicationAppRoleResource() *schema.Resource {

--- a/internal/services/applications/application_app_role_resource_test.go
+++ b/internal/services/applications/application_app_role_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ApplicationAppRoleResource struct{}

--- a/internal/services/applications/application_certificate_resource.go
+++ b/internal/services/applications/application_certificate_resource.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func applicationCertificateResource() *schema.Resource {

--- a/internal/services/applications/application_certificate_resource_test.go
+++ b/internal/services/applications/application_certificate_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 const applicationCertificatePem string = `-----BEGIN CERTIFICATE-----

--- a/internal/services/applications/application_data_source.go
+++ b/internal/services/applications/application_data_source.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func applicationDataSource() *schema.Resource {

--- a/internal/services/applications/application_data_source_test.go
+++ b/internal/services/applications/application_data_source_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type ApplicationDataSource struct{}

--- a/internal/services/applications/application_oauth2_permission_resource.go
+++ b/internal/services/applications/application_oauth2_permission_resource.go
@@ -10,12 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func applicationOAuth2PermissionResource() *schema.Resource {

--- a/internal/services/applications/application_oauth2_permission_resource_test.go
+++ b/internal/services/applications/application_oauth2_permission_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ApplicationOAuth2PermissionResource struct{}

--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func applicationPasswordResource() *schema.Resource {

--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/applications/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ApplicationPasswordResource struct{}

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 const resourceApplicationName = "azuread_application"

--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ApplicationResource struct{}

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {

--- a/internal/services/domains/client/client.go
+++ b/internal/services/domains/client/client.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {

--- a/internal/services/domains/domains_data_source.go
+++ b/internal/services/domains/domains_data_source.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 )
 
 func domainsData() *schema.Resource {

--- a/internal/services/domains/domains_data_source_test.go
+++ b/internal/services/domains/domains_data_source_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type DomainsDataSource struct{}

--- a/internal/services/groups/client/client.go
+++ b/internal/services/groups/client/client.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {

--- a/internal/services/groups/group_data_source.go
+++ b/internal/services/groups/group_data_source.go
@@ -10,11 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func groupDataSource() *schema.Resource {

--- a/internal/services/groups/group_data_source_test.go
+++ b/internal/services/groups/group_data_source_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type GroupDataSource struct{}

--- a/internal/services/groups/group_member_resource.go
+++ b/internal/services/groups/group_member_resource.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/groups/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/groups/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 const groupMemberResourceName = "azuread_group_member"

--- a/internal/services/groups/group_member_resource_test.go
+++ b/internal/services/groups/group_member_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/groups/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/groups/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type GroupMemberResource struct{}

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func groupResource() *schema.Resource {

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type GroupResource struct{}

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func groupsDataSource() *schema.Resource {

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type GroupsDataSource struct{}

--- a/internal/services/serviceprincipals/client/client.go
+++ b/internal/services/serviceprincipals/client/client.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {

--- a/internal/services/serviceprincipals/client_config_data_source.go
+++ b/internal/services/serviceprincipals/client_config_data_source.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 )
 
 func clientConfigDataSource() *schema.Resource {

--- a/internal/services/serviceprincipals/client_config_data_source_test.go
+++ b/internal/services/serviceprincipals/client_config_data_source_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type ClientConfigDataSource struct{}

--- a/internal/services/serviceprincipals/service_principal_certificate_resource.go
+++ b/internal/services/serviceprincipals/service_principal_certificate_resource.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 func servicePrincipalCertificateResource() *schema.Resource {

--- a/internal/services/serviceprincipals/service_principal_certificate_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_certificate_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 const servicePrincipalCertificatePem string = `-----BEGIN CERTIFICATE-----

--- a/internal/services/serviceprincipals/service_principal_data_source.go
+++ b/internal/services/serviceprincipals/service_principal_data_source.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func servicePrincipalData() *schema.Resource {

--- a/internal/services/serviceprincipals/service_principal_data_source_test.go
+++ b/internal/services/serviceprincipals/service_principal_data_source_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type ServicePrincipalDataSource struct{}

--- a/internal/services/serviceprincipals/service_principal_password_resource.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func servicePrincipalPasswordResource() *schema.Resource {

--- a/internal/services/serviceprincipals/service_principal_password_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/services/serviceprincipals/parse"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ServicePrincipalPasswordResource struct{}

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 const servicePrincipalResourceName = "azuread_service_principal"

--- a/internal/services/serviceprincipals/service_principal_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_resource_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type ServicePrincipalResource struct{}

--- a/internal/services/users/client/client.go
+++ b/internal/services/users/client/client.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/common"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {

--- a/internal/services/users/user_data_source.go
+++ b/internal/services/users/user_data_source.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func userData() *schema.Resource {

--- a/internal/services/users/user_data_source_test.go
+++ b/internal/services/users/user_data_source_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type UserDataSource struct{}

--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func userResource() *schema.Resource {

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type UserResource struct{}

--- a/internal/services/users/users_data_source.go
+++ b/internal/services/users/users_data_source.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/helpers/aadgraph"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/tf"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/utils"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/aadgraph"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
 func usersData() *schema.Resource {

--- a/internal/services/users/users_data_source_test.go
+++ b/internal/services/users/users_data_source_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 )
 
 type UsersDataSource struct{}

--- a/provider.go
+++ b/provider.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azuread/internal/provider"
+	"github.com/hashicorp/terraform-provider-azuread/internal/provider"
 )
 
 func Provider() *schema.Provider {


### PR DESCRIPTION
Fixes go.mod post org move.

Bumps Go version to 1.16 in line with AzureRM