### PR TITLE
Revert support for setting `user_type` to `Guest`

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -43,7 +43,6 @@ The following arguments are supported:
 * `surname` - (Optional) The user's surname (family name or last name).
 * `usage_location` - (Optional) The usage location of the User. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: `NO`, `JP`, and `GB`. Cannot be reset to null once set. 
 * `user_principal_name` - (Required) The User Principal Name of the User.
-* `user_type` - (Optional) The user type in the directory. Valid values are `Guest` and `Member`. Defaults to `Member`.
 
 ~> Note on Guest Users: Due to API limitations, when configuring a Guest user, `password` must be specified. Since the password isn't used for authenticating the user, it's suggested to specify a placeholder string. This will be fixed in version 2.0 of the provider.
 
@@ -55,6 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 * `object_id` - The Object ID of the User.
 * `onpremises_sam_account_name` - The on-premise SAM account name of the User.
 * `onpremises_user_principal_name` - The on-premise user principal name of the User.
+* `user_type` - The user type in the directory. One of `Guest` or `Member`.
 
 ## Import
 

--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -197,10 +197,8 @@ func userResource() *schema.Resource {
 			},
 
 			"user_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          "Member",
-				ValidateDiagFunc: validate.ValidateDiag(validation.StringInSlice([]string{"Member", "Guest"}, false)),
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -226,7 +224,6 @@ func userResourceCreate(ctx context.Context, d *schema.ResourceData, meta interf
 			Password:                     utils.String(d.Get("password").(string)),
 		},
 		UserPrincipalName:    &upn,
-		UserType:             graphrbac.UserType(d.Get("user_type").(string)),
 		AdditionalProperties: map[string]interface{}{},
 	}
 

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -31,19 +31,6 @@ func TestAccUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccUser_guest(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azuread_user", "test")
-	r := UserResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.guest(data),
-			Check:  resource.ComposeTestCheckFunc(check.That(data.ResourceName).ExistsInAzure(r)),
-		},
-		data.ImportStep("force_password_change", "password"),
-	})
-}
-
 func TestAccUser_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_user", "test")
 	r := UserResource{}
@@ -193,21 +180,6 @@ resource "azuread_user" "testC" {
   user_principal_name = "acctestUser.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
   display_name        = "acctestUser-%[1]d-C"
   password            = "%[2]s"
-}
-`, data.RandomInteger, data.RandomPassword)
-}
-
-func (UserResource) guest(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-data "azuread_domains" "test" {
-  only_initial = true
-}
-
-resource "azuread_user" "test" {
-  user_principal_name = "acctestUser.%[1]d_example.com#EXT#@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "acctestUser-%[1]d"
-  password            = "%[2]s"
-  user_type           = "Guest"
 }
 `, data.RandomInteger, data.RandomPassword)
 }


### PR DESCRIPTION
- Adding users in this way bypasses the invitations API and creates broken accounts
- No invitation email is sent, which is sort of expected but not great UX
- The guest user can browse to the inviting tenant in the Portal, but cannot see it, or any linked subscriptions, in their global filter list
- AAD roles assigned to such a user do not work
- RBAC roles assigned to such a user do not work
- Subscriptions do not work

We will reserve this functionality for MS Graph when we have access to the invitations API which processes guest accounts correctly.

Example:

![Screenshot 2021-03-08 at 16 22 20](https://user-images.githubusercontent.com/251987/110352639-10954100-802e-11eb-95e3-36f22b81a227.png)
