### PR TITLE
📝 Fix wrong parameter in `azuread_application` resource

### DIFF
--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -12,7 +12,7 @@ Manages a Service Principal associated with an Application within Azure Active D
 
 ```terraform
 resource "azuread_application" "example" {
-  name                       = "example"
+  display_name               = "example"
   homepage                   = "http://homepage"
   identifier_uris            = ["http://uri"]
   reply_urls                 = ["http://replyurl"]


### PR DESCRIPTION
The `name` in the `azuread_application` resource mentioned with the `azuread_service_principal` docs should be `display_name`.