### PR TITLE
Support URNs properly

### DIFF
--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -139,7 +139,7 @@ func applicationResource() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				ValidateDiagFunc: validate.URLIsHTTPOrHTTPS,
+				ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
 			},
 
 			"identifier_uris": {
@@ -148,7 +148,7 @@ func applicationResource() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
-					ValidateDiagFunc: validate.URLIsAppURI,
+					ValidateDiagFunc: validate.IsAppURI,
 				},
 			},
 
@@ -156,7 +156,7 @@ func applicationResource() *schema.Resource {
 			"logout_url": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: validate.URLIsHTTPOrHTTPS,
+				ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
 			},
 
 			// TODO: v2.0 put this in an `implicit_grant` block and rename to `access_token_issuance_enabled`

--- a/internal/validate/uri.go
+++ b/internal/validate/uri.go
@@ -10,19 +10,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func URLIsHTTPS(i interface{}, path cty.Path) diag.Diagnostics {
-	return URLWithScheme([]string{"https"})(i, path)
+func IsHTTPSURL(i interface{}, path cty.Path) diag.Diagnostics {
+	return IsURI([]string{"https"}, false)(i, path)
 }
 
-func URLIsHTTPOrHTTPS(i interface{}, path cty.Path) diag.Diagnostics {
-	return URLWithScheme([]string{"http", "https"})(i, path)
+func IsHTTPOrHTTPSURL(i interface{}, path cty.Path) diag.Diagnostics {
+	return IsURI([]string{"http", "https"}, false)(i, path)
 }
 
-func URLIsAppURI(i interface{}, path cty.Path) diag.Diagnostics {
-	return URLWithScheme([]string{"http", "https", "api", "urn", "ms-appx"})(i, path)
+func IsAppURI(i interface{}, path cty.Path) diag.Diagnostics {
+	return IsURI([]string{"http", "https", "api", "ms-appx"}, true)(i, path)
 }
 
-func URLWithScheme(validSchemes []string) schema.SchemaValidateDiagFunc {
+func IsURI(validURLSchemes []string, URNAllowed bool) schema.SchemaValidateDiagFunc {
 	return func(i interface{}, path cty.Path) (ret diag.Diagnostics) {
 		v, ok := i.(string)
 		if !ok {
@@ -41,6 +41,13 @@ func URLWithScheme(validSchemes []string) schema.SchemaValidateDiagFunc {
 				AttributePath: path,
 			})
 			return
+		}
+
+		if URNAllowed {
+			parts := strings.Split(v, ":")
+			if len(parts) == 3 && parts[0] == "urn" {
+				return
+			}
 		}
 
 		u, err := url.Parse(v)
@@ -63,7 +70,7 @@ func URLWithScheme(validSchemes []string) schema.SchemaValidateDiagFunc {
 			return
 		}
 
-		for _, s := range validSchemes {
+		for _, s := range validURLSchemes {
 			if u.Scheme == s {
 				return
 			}
@@ -71,7 +78,7 @@ func URLWithScheme(validSchemes []string) schema.SchemaValidateDiagFunc {
 
 		ret = append(ret, diag.Diagnostic{
 			Severity:      diag.Error,
-			Summary:       fmt.Sprintf("Expected URL to have a schema of: %s", strings.Join(validSchemes, ", ")),
+			Summary:       fmt.Sprintf("Expected URL to have a schema of: %s", strings.Join(validURLSchemes, ", ")),
 			AttributePath: path,
 		})
 		return

--- a/internal/validate/uri.go
+++ b/internal/validate/uri.go
@@ -45,7 +45,7 @@ func IsURI(validURLSchemes []string, URNAllowed bool) schema.SchemaValidateDiagF
 
 		if URNAllowed {
 			parts := strings.Split(v, ":")
-			if len(parts) == 3 && parts[0] == "urn" {
+			if len(parts) >= 3 && parts[0] == "urn" {
 				return
 			}
 		}

--- a/internal/validate/uri_test.go
+++ b/internal/validate/uri_test.go
@@ -128,6 +128,10 @@ func TestIsAppURI(t *testing.T) {
 			Errors: 0,
 		},
 		{
+			Url:    "urn:nbn:de:bvb:19-146642",
+			Errors: 0,
+		},
+		{
 			Url:    "ms-appx://www.example.com",
 			Errors: 0,
 		},

--- a/internal/validate/uri_test.go
+++ b/internal/validate/uri_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 )
 
-func TestURLIsHTTPS(t *testing.T) {
+func TestIsHTTPSURL(t *testing.T) {
 	cases := []struct {
 		Url    string
 		Errors int
@@ -39,7 +39,7 @@ func TestURLIsHTTPS(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Url, func(t *testing.T) {
-			diags := URLIsHTTPS(tc.Url, cty.Path{})
+			diags := IsHTTPSURL(tc.Url, cty.Path{})
 
 			if len(diags) != tc.Errors {
 				t.Fatalf("Expected URLIsHTTPS to have %d not %d errors for %q", tc.Errors, len(diags), tc.Url)
@@ -48,7 +48,7 @@ func TestURLIsHTTPS(t *testing.T) {
 	}
 }
 
-func TestURLIsHTTPOrHTTPS(t *testing.T) {
+func TestIsHTTPOrHTTPSURL(t *testing.T) {
 	cases := []struct {
 		Url    string
 		Errors int
@@ -81,7 +81,7 @@ func TestURLIsHTTPOrHTTPS(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Url, func(t *testing.T) {
-			diags := URLIsHTTPOrHTTPS(tc.Url, cty.Path{})
+			diags := IsHTTPOrHTTPSURL(tc.Url, cty.Path{})
 
 			if len(diags) != tc.Errors {
 				t.Fatalf("Expected URLIsHTTPOrHTTPS to have %d not %d errors for %q", tc.Errors, len(diags), tc.Url)
@@ -90,7 +90,7 @@ func TestURLIsHTTPOrHTTPS(t *testing.T) {
 	}
 }
 
-func TestURLIsAppURI(t *testing.T) {
+func TestIsAppURI(t *testing.T) {
 	cases := []struct {
 		Url    string
 		Errors int
@@ -135,7 +135,7 @@ func TestURLIsAppURI(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Url, func(t *testing.T) {
-			diags := URLIsAppURI(tc.Url, cty.Path{})
+			diags := IsAppURI(tc.Url, cty.Path{})
 
 			if len(diags) != tc.Errors {
 				t.Fatalf("Expected URLIsAppURI to have %d not %d errors for %q", tc.Errors, len(diags), tc.Url)

--- a/internal/validate/url_test.go
+++ b/internal/validate/url_test.go
@@ -124,7 +124,7 @@ func TestURLIsAppURI(t *testing.T) {
 			Errors: 0,
 		},
 		{
-			Url:    "urn://www.example.com",
+			Url:    "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
 			Errors: 0,
 		},
 		{


### PR DESCRIPTION
Fixes #425 by refactoring the URL validation to support both URLs & URNs.

I looked for Go packages that do URN validation, and found [voicera/gooseberry urn#TryParseString](https://pkg.go.dev/github.com/voicera/gooseberry@v0.0.0-20181223025147-dc233900870c/urn#TryParseString) and [leodido/go-urn#Parse](https://pkg.go.dev/github.com/leodido/go-urn#Parse). Neither seemed worth adding as a dependency, so I used the simple validation logic from the former.