### PR TITLE
Migrate from GitHub HashiBot lock behavior to GitHub Actions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,23 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-comment: >
+            I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-lock-inactive-days: '30'
+          pr-lock-comment: >
+            I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active contributions.
+
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-lock-inactive-days: '30'

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -11,16 +11,3 @@ queued_behavior "release_commenter" "releases" {
     ```
   EOF
 }
-
-poll "closed_issue_locker" "locker" {
-  schedule             = "0 50 16 * * *"
-  closed_for           = "720h" # 30 days
-  max_issues           = 500
-  sleep_between_issues = "5s"
-
-  message = <<-EOF
-    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
-
-    If you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. If you feel I made an error 🤖 🙉 , please reach out to my human friends 👉  hashibot-feedback@hashicorp.com. Thanks!
-  EOF
-}


### PR DESCRIPTION
There is not an equivalent for the `release_commenter` behavior yet to fully remove the configuration (unless you are okay without it for now, then happy to just remove the whole thing 👍 ).