### PR TITLE
Bugfix: suppress spurious deprecation notice for `metadata_host` provider field even when not set

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ For more advanced scenarios, the following additional arguments are supported:
 
 * `disable_terraform_partner_id` - (Optional) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified. The default Partner ID allows Microsoft to better understand the usage of Terraform and does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
 
-* `metadata_host` - (Optional) The Hostname of the Azure Metadata Service (for example `management.azure.com`), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the `ARM_METADATA_HOST` Environment Variable.
+* `metadata_host` - (Optional, **Deprecated**) The Hostname of the Azure Metadata Service (for example `management.azure.com`), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the `ARM_METADATA_HOST` Environment Variable. This property is deprecated and will be removed in version 2.0 of the provider.
 
 ~> **Note:** `environment` must be set to the requested environment name in the list of available environments held in the `metadata_host`.
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -84,15 +84,14 @@ func AzureADProvider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ARM_TENANT_ID", ""),
-				Description: "The Tenant ID which should be used. Works with all authentication methods except MSI.",
+				Description: "The Tenant ID which should be used. Works with all authentication methods except Managed Identity.",
 			},
 
 			"metadata_host": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ARM_METADATA_HOSTNAME", ""),
-				Deprecated:  "The `metadata_host` provider attribute is deprecated and will be removed in version 2.0",
-				Description: "The Hostname which should be used for the Azure Metadata Service.",
+				Description: "[DEPRECATED] The Hostname which should be used for the Azure Metadata Service.",
 			},
 
 			"environment": {
@@ -132,19 +131,19 @@ func AzureADProvider() *schema.Provider {
 				Description: "Allow Azure CLI to be used for Authentication.",
 			},
 
-			// Managed Service Identity specific fields
+			// Managed Identity specific fields
 			"use_msi": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_MSI", false),
-				Description: "Allow Managed Service Identity to be used for Authentication.",
+				Description: "Allow Managed Identity to be used for Authentication.",
 			},
 
 			"msi_endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ARM_MSI_ENDPOINT", ""),
-				Description: "The path to a custom endpoint for Managed Service Identity - in most circumstances this should be detected automatically. ",
+				Description: "The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically. ",
 			},
 
 			// Managed Tracking GUID for User-agent


### PR DESCRIPTION
Provider schema validation raises a warning diagnostic for deprecated fields even if a property isn't present in configuration (or it's corresponding env var is also not set). This removes the Deprecation field from `metadata_host` and updates the documentation.

Closes #437