### PR TITLE
Bugfix: error on password creation when `description` set for MS Graph

### DIFF
--- a/docs/guides/microsoft-graph.md
+++ b/docs/guides/microsoft-graph.md
@@ -178,6 +178,8 @@ The deprecated field `is_enabled` has been replaced by the `enabled` field and w
 
 The deprecated field `description` has been replaced by the `display_name` field and will be removed.
 
+-> The following also applies when the Microsoft Graph beta is enabled in version 1.5 or later
+
 The `display_name` field will become read-only as Azure Active Directory no longer respects user-supplied display names for passwords.
 
 The `key_id` field will become read-only as Azure Active Directory no longer allows user-specified key IDs for passwords. This also means that the `azuread_application_password` resource no longer supports importing in version 2.0 of the provider.
@@ -195,6 +197,8 @@ The deprecated field `name` has been replaced by the `display_name` field and wi
 ### Resource: `azuread_service_principal_password`
 
 The deprecated field `description` has been replaced by the `display_name` field and will be removed.
+
+-> The following also applies when the Microsoft Graph beta is enabled in version 1.5 or later
 
 The `display_name` field will become read-only as Azure Active Directory no longer respects user-supplied display names for passwords.
 

--- a/docs/resources/application_password.md
+++ b/docs/resources/application_password.md
@@ -22,7 +22,7 @@ resource "azuread_application_password" "example" {
 
 ## Argument Reference
 
-~> **IMPORTANT:** In version 2.0 of the provider, the `key_id`, `display_name`, `start_date`, `end_date`, `end_date_relative` and `value` properties will all become read-only. For more information, see the [Upgrade Guide for v2.0](../guides/microsoft-graph.html).
+~> **IMPORTANT:** In version 2.0 of the provider, or when using the Microsoft Graph beta in version 1.5 or later, the `key_id`, `display_name` / `description`, `start_date`, `end_date` / `end_date_relative` and `value` properties will all become read-only and should not be specified. For more information, see the [Upgrade Guide for v2.0](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/microsoft-graph#resource-azuread_application_password).
 
 The following arguments are supported:
 

--- a/docs/resources/service_principal_password.md
+++ b/docs/resources/service_principal_password.md
@@ -26,7 +26,7 @@ resource "azuread_service_principal_password" "example" {
 
 ## Argument Reference
 
-~> **IMPORTANT:** In version 2.0 of the provider, the `key_id`, `display_name`, `start_date`, `end_date`, `end_date_relative` and `value` properties will all become read-only. For more information, see the [Upgrade Guide for v2.0](../guides/microsoft-graph.html).
+~> **IMPORTANT:** In version 2.0 of the provider, or when using the Microsoft Graph beta in version 1.5 or later, the `key_id`, `display_name` / `description`, `start_date`, `end_date` / `end_date_relative` and `value` properties will all become read-only and should not be specified. For more information, see the [Upgrade Guide for v2.0](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/microsoft-graph#resource-azuread_service_principal_password).
 
 The following arguments are supported:
 

--- a/internal/services/applications/application_password_resource_msgraph.go
+++ b/internal/services/applications/application_password_resource_msgraph.go
@@ -22,6 +22,10 @@ func applicationPasswordResourceCreateMsGraph(ctx context.Context, d *schema.Res
 	client := meta.(*clients.Client).Applications.MsClient
 	objectId := d.Get("application_object_id").(string)
 
+	if val, ok := d.GetOk("description"); ok && val.(string) != "" {
+		return tf.ErrorDiagPathF(fmt.Errorf("`description` is a read-only field when using Microsoft Graph. Please remove the `description` field from your configuration"), "description", "Creating application password")
+	}
+
 	if val, ok := d.GetOk("display_name"); ok && val.(string) != "" {
 		return tf.ErrorDiagPathF(fmt.Errorf("`display_name` is a read-only field when using Microsoft Graph. Please remove the `display_name` field from your configuration"), "display_name", "Creating application password")
 	}

--- a/internal/services/serviceprincipals/service_principal_password_resource_msgraph.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource_msgraph.go
@@ -22,6 +22,10 @@ func servicePrincipalPasswordResourceCreateMsGraph(ctx context.Context, d *schem
 	client := meta.(*clients.Client).ServicePrincipals.MsClient
 	objectId := d.Get("service_principal_id").(string)
 
+	if val, ok := d.GetOk("description"); ok && val.(string) != "" {
+		return tf.ErrorDiagPathF(fmt.Errorf("`description` is a read-only field when using Microsoft Graph. Please remove the `description` field from your configuration"), "description", "Creating service principal password")
+	}
+
 	if val, ok := d.GetOk("display_name"); ok && val.(string) != "" {
 		return tf.ErrorDiagPathF(fmt.Errorf("`display_name` is a read-only field when using Microsoft Graph. Please remove the `display_name` field from your configuration"), "display_name", "Creating service principal password")
 	}


### PR DESCRIPTION
- Don't allow `description` to be set in configuration when using MS Graph
- Clarify the situation regarding the field changes for `azuread_application_password` and `azuread_service_principal_password`
Closes: #438 