### PR TITLE
docs/data-sources/groups.md: Fix property name that wasn't renamed

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -23,7 +23,7 @@ The following arguments are supported:
 * `display_names` - (Optional) The Display Names of the Azure AD Groups.
 * `object_ids` - (Optional) The Object IDs of the Azure AD Groups.
 
-~> **NOTE:** Either `names` or `object_ids` should be specified. Either of these _may_ be specified as an empty list, in which case no results will be returned.
+~> **NOTE:** Either `display_names` or `object_ids` should be specified. Either of these _may_ be specified as an empty list, in which case no results will be returned.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This [commit](https://github.com/hashicorp/terraform-provider-azuread/commit/4bfce613d6260852e8f4d99bc54f8e49dc285a79#diff-20e1b0b3a19616f5586877bf83247b078abe90d7249d02222ba79751db540857) forgot to rename property names in other places this fixes it