### PR TITLE
applications schema - add on_premise_security_identifier

### DIFF
--- a/internal/services/applications/schema.go
+++ b/internal/services/applications/schema.go
@@ -43,6 +43,7 @@ func schemaOptionalClaims() *schema.Schema {
 								"netbios_domain_and_sam_account_name",
 								"sam_account_name",
 								"use_guid",
+								"on_premise_security_identifier",
 							},
 							false,
 						),


### PR DESCRIPTION
Resolves #462 

Ran the following tests seems to all work fine.
![image](https://user-images.githubusercontent.com/29356754/122125041-03a39d00-ce28-11eb-8444-bedbcf95b828.png)

```
> $ TF_ACC=1 go test -v -timeout=2h ./internal/services/applications -run="TestAccApplication_complete"                                                     
=== RUN   TestAccApplication_complete
=== PAUSE TestAccApplication_complete
=== CONT  TestAccApplication_complete
--- PASS: TestAccApplication_complete (84.10s)
PASS
ok      github.com/hashicorp/terraform-provider-azuread/internal/services/applications  84.113s
```