### PR TITLE
Deprecation notices for application_oauth2_permission{,_scope} and azuread_application_app_role resources

### DIFF
--- a/docs/guides/microsoft-graph.md
+++ b/docs/guides/microsoft-graph.md
@@ -166,13 +166,13 @@ The legacy `type` field is deprecated and will be removed.
 
 ### Resource: `azuread_application_app_role`
 
-The deprecated field `is_enabled` has been replaced by the `enabled` field and will be removed.
+This resource will be removed in version 2.0 of the provider. Limitations of the `azuread_application` resource, that currently necessitate use of this resource, will be resolved in version 2.0. See [this pull request](https://github.com/hashicorp/terraform-provider-azuread/pull/465) for more information about this change.
 
-### Resource: `azuread_application_oauth2_permission`
+### Resources: `azuread_application_oauth2_permission` and `azuread_application_oauth2_permission_scope`
 
-This resource has been renamed to `azuread_application_oauth2_permission_scope`.
+In version 1.5.0 of the provider, the `azuread_application_oauth2_permission` resource was deprecated and replaced by the `azuread_application_oauth2_permission_scope` resource.
 
-The deprecated field `is_enabled` has been replaced by the `enabled` field and will be removed.
+However, in version 2.0 of the provider, both of these resources will be removed. Limitations of the `azuread_application` resource, that currently necessitate use of these resources, will be resolved in version 2.0. See [this pull request](https://github.com/hashicorp/terraform-provider-azuread/pull/465) for more information about this change.
 
 ### Resource: `azuread_application_password`
 

--- a/internal/services/applications/application_app_role_resource.go
+++ b/internal/services/applications/application_app_role_resource.go
@@ -21,6 +21,8 @@ func applicationAppRoleResource() *schema.Resource {
 		ReadContext:   applicationAppRoleResourceRead,
 		DeleteContext: applicationAppRoleResourceDelete,
 
+		DeprecationMessage: "[NOTE] The `azuread_application_app_role` resource is deprecated and will be removed in version 2.0 of the provider",
+
 		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
 			_, err := parse.AppRoleID(id)
 			return err

--- a/internal/services/applications/application_oauth2_permission_resource.go
+++ b/internal/services/applications/application_oauth2_permission_resource.go
@@ -18,7 +18,7 @@ func applicationOAuth2PermissionResource() *schema.Resource {
 		ReadContext:   applicationOAuth2PermissionScopeResourceRead,
 		DeleteContext: applicationOAuth2PermissionScopeResourceDelete,
 
-		DeprecationMessage: "[NOTE] The `azuread_application_oauth2_permission` resource has been renamed to `azuread_application_oauth2_permission` and will be removed in version 2.0 of the provider",
+		DeprecationMessage: "[NOTE] The `azuread_application_oauth2_permission` resource is deprecated and will be removed in version 2.0 of the provider",
 
 		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
 			_, err := parse.OAuth2PermissionScopeID(id)

--- a/internal/services/applications/application_oauth2_permission_scope_resource.go
+++ b/internal/services/applications/application_oauth2_permission_scope_resource.go
@@ -21,6 +21,8 @@ func applicationOAuth2PermissionScopeResource() *schema.Resource {
 		ReadContext:   applicationOAuth2PermissionScopeResourceRead,
 		DeleteContext: applicationOAuth2PermissionScopeResourceDelete,
 
+		DeprecationMessage: "[NOTE] The `azuread_application_oauth2_permission_scope` resource is deprecated and will be removed in version 2.0 of the provider",
+
 		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
 			_, err := parse.OAuth2PermissionScopeID(id)
 			return err


### PR DESCRIPTION
Both the `azuread_application_app_role` and `azuread_application_oauth2_permission`
resources were added to the provider as a workaround for several bugs in our
implementations of the corresponding properties in the `azuread_application` resource.

- Both these properties (blocks) are TypeSet, and currently Optional + Computed,
  which stems from API inconsistencies and (in the case of oauth2 permissions)
  default values applied by the AAD Graph API.
- The `id` field in each of these blocks is Computed (read-only),
  however there are use cases where it's necessary to be able to specify
  this field. We couldn't make this field Optional + Computed inside a TypeSet
  that is also Optional + Computed, due to an upstream limitation / bug.

We therefore introduced these virtual resources to enable users to specify an
`id` for a role/scope.

In version 2.0 both these blocks in the azuread_application resource
will lose their Computed field, to eliminate these problems for users:

- Although we use `ConfigMode: schema.SchemaConfigModeAttr`, it's not
  always possible to clear the values of these properties because the
  actual value in configuration is not exposed to the provider (via
  either schema.ResourceData or schema.ResourceDiff).
- Changes to these properties are not always detected by Terraform when
  there are no other changes to that same resource, and then the
  UpdateFunc is never actually invoked.
- When updating these fields, the API requires them to be orchestrated
  so that each role/scope is first disabled before updating or removing
  it. With `id` being Computed, we have no way to identify which
  role/scope was updated by the user and so we have no choice but to
  disable all of them, before making our changes and quickly re-enabling
  them. This causes momentary outages for users and has sometimes left
  roles/scopes disabled after the fact due to an API bug ignoring our
  re-enable request (breaking customers' applications).

All of these issues will be fixed in v2.0, by way of removing the Computed
field from these properties. This means we can no longer support these
virtual resources, but also that they are no longer needed, so in v2.0
they will be removed.