### PR TITLE
Add state migration for azuread_application to handle group_membership_claims type change

### DIFF
--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -3,7 +3,6 @@ package applications
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/migrations"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
@@ -31,6 +31,15 @@ func applicationPasswordResource() *schema.Resource {
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migrations.ResourceApplicationPasswordInstanceResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: migrations.ResourceApplicationPasswordInstanceStateUpgradeV0,
+				Version: 0,
+			},
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -89,14 +98,6 @@ func applicationPasswordResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
-			},
-		},
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceApplicationPasswordInstanceResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: resourceApplicationPasswordInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 	}
@@ -222,76 +223,4 @@ func applicationPasswordResourceDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	return nil
-}
-
-func resourceApplicationPasswordInstanceResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"application_object_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validate.UUID,
-			},
-
-			"key_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validate.UUID,
-			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"value": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 863),
-			},
-
-			"start_date": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsRFC3339Time,
-			},
-
-			"end_date": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ExactlyOneOf: []string{"end_date_relative"},
-				ValidateFunc: validation.IsRFC3339Time,
-			},
-
-			"end_date_relative": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				ExactlyOneOf:     []string{"end_date"},
-				ValidateDiagFunc: validate.NoEmptyStrings,
-			},
-		},
-	}
-}
-
-func resourceApplicationPasswordInstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
-	newId, err := parse.OldPasswordID(rawState["id"].(string))
-	if err != nil {
-		return rawState, fmt.Errorf("generating new ID: %s", err)
-	}
-
-	rawState["id"] = newId.String()
-	return rawState, nil
 }

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/migrations"
+
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -45,6 +47,15 @@ func applicationResource() *schema.Resource {
 			}
 			return nil
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migrations.ResourceApplicationInstanceResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: migrations.ResourceApplicationInstanceStateUpgradeV0,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"display_name": {

--- a/internal/services/applications/migrations/application_password_resource.go
+++ b/internal/services/applications/migrations/application_password_resource.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+)
+
+func ResourceApplicationPasswordInstanceResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"application_object_id": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"key_id": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"value": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringLenBetween(1, 863),
+			},
+
+			"start_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+
+			"end_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"end_date_relative"},
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+
+			"end_date_relative": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ExactlyOneOf:     []string{"end_date"},
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+		},
+	}
+}
+
+func ResourceApplicationPasswordInstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+	newId, err := parse.OldPasswordID(rawState["id"].(string))
+	if err != nil {
+		return rawState, fmt.Errorf("generating new ID: %s", err)
+	}
+
+	rawState["id"] = newId.String()
+	return rawState, nil
+}

--- a/internal/services/applications/migrations/application_resource.go
+++ b/internal/services/applications/migrations/application_resource.go
@@ -1,0 +1,554 @@
+package migrations
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/manicminer/hamilton/msgraph"
+
+	applicationsValidate "github.com/hashicorp/terraform-provider-azuread/internal/services/applications/validate"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+)
+
+func ResourceApplicationInstanceResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ExactlyOneOf:     []string{"display_name", "name"},
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+
+			"name": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				Deprecated:       "This property has been renamed to `display_name` and will be removed in version 2.0 of the AzureAD provider",
+				ExactlyOneOf:     []string{"display_name", "name"},
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+
+			"api": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"oauth2_permission_scope": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"admin_consent_description": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: validate.NoEmptyStrings,
+									},
+
+									"admin_consent_display_name": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: validate.NoEmptyStrings,
+									},
+
+									"enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  string(msgraph.PermissionScopeTypeUser),
+										ValidateFunc: validation.StringInSlice([]string{
+											string(msgraph.PermissionScopeTypeAdmin),
+											string(msgraph.PermissionScopeTypeUser),
+										}, false),
+									},
+
+									"user_consent_description": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: validate.NoEmptyStrings,
+									},
+
+									"user_consent_display_name": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: validate.NoEmptyStrings,
+									},
+
+									"value": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										ValidateDiagFunc: applicationsValidate.RoleScopeClaimValue,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"app_role": {
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"allowed_member_types": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice(
+									[]string{
+										string(msgraph.AppRoleAllowedMemberTypeApplication),
+										string(msgraph.AppRoleAllowedMemberTypeUser),
+									}, false,
+								),
+							},
+						},
+
+						"description": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validate.NoEmptyStrings,
+						},
+
+						"display_name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validate.NoEmptyStrings,
+						},
+
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+
+						"is_enabled": {
+							Type:       schema.TypeBool,
+							Optional:   true,
+							Default:    true,
+							Deprecated: "[NOTE] This attribute has been renamed to `enabled` and will be removed in version 2.0 of the AzureAD provider",
+						},
+
+						"value": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: applicationsValidate.RoleScopeClaimValue,
+						},
+					},
+				},
+			},
+
+			"available_to_other_tenants": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"sign_in_audience"},
+				Deprecated:    "[NOTE] This attribute will be replaced by a new property `sign_in_audience` in version 2.0 of the AzureAD provider",
+			},
+
+			"fallback_public_client_enabled": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"public_client"},
+			},
+
+			"group_membership_claims": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "[NOTE] This attribute will become a list in version 2.0 of the AzureAD provider",
+				ValidateFunc: validation.StringInSlice([]string{
+					string(msgraph.GroupMembershipClaimAll),
+					string(msgraph.GroupMembershipClaimNone),
+					string(msgraph.GroupMembershipClaimApplicationGroup),
+					string(msgraph.GroupMembershipClaimDirectoryRole),
+					string(msgraph.GroupMembershipClaimSecurityGroup),
+				}, false),
+			},
+
+			"homepage": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
+				ConflictsWith:    []string{"web.0.homepage_url"},
+				Deprecated:       "[NOTE] This attribute will be replaced by a new attribute `homepage_url` in the `web` block in version 2.0 of the AzureAD provider",
+			},
+
+			"identifier_uris": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validate.IsAppURI,
+				},
+			},
+
+			"logout_url": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
+				Computed:         true,
+				ConflictsWith:    []string{"web.0.logout_url"},
+				Deprecated:       "[NOTE] This attribute will be moved into the `web` block in version 2.0 of the AzureAD provider",
+			},
+
+			"oauth2_allow_implicit_flow": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"web.0.implicit_grant.0.access_token_issuance_enabled"},
+				Deprecated:    "[NOTE] This attribute will be moved to the `implicit_grant` block and renamed to `access_token_issuance_enabled` in version 2.0 of the AzureAD provider",
+			},
+
+			"oauth2_permissions": {
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Deprecated: "[NOTE] The `oauth2_permissions` block has been renamed to `oauth2_permission_scope` and moved to the `api` block. `oauth2_permissions` will be removed in version 2.0 of the AzureAD provider.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"admin_consent_description": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validate.NoEmptyStrings,
+						},
+
+						"admin_consent_display_name": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validate.NoEmptyStrings,
+						},
+
+						"is_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"Admin", "User"}, false),
+						},
+
+						"user_consent_description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"user_consent_display_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"value": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validate.NoEmptyStrings,
+						},
+					},
+				},
+			},
+
+			"optional_claims": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_token": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"source": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice(
+											[]string{"user"},
+											false,
+										),
+									},
+									"essential": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"additional_properties": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.StringInSlice(
+												[]string{
+													"dns_domain_and_sam_account_name",
+													"emit_as_roles",
+													"include_externally_authenticated_upn",
+													"include_externally_authenticated_upn_without_hash",
+													"netbios_domain_and_sam_account_name",
+													"sam_account_name",
+													"use_guid",
+												},
+												false,
+											),
+										},
+									},
+								},
+							},
+						},
+
+						"id_token": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+
+									"source": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice(
+											[]string{"user"},
+											false,
+										),
+									},
+									"essential": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"additional_properties": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.StringInSlice(
+												[]string{
+													"dns_domain_and_sam_account_name",
+													"emit_as_roles",
+													"include_externally_authenticated_upn",
+													"include_externally_authenticated_upn_without_hash",
+													"netbios_domain_and_sam_account_name",
+													"sam_account_name",
+													"use_guid",
+												},
+												false,
+											),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"owners": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validate.NoEmptyStrings,
+				},
+			},
+
+			"public_client": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"fallback_public_client_enabled"},
+				Deprecated:    "[NOTE] This legacy attribute will be renamed to `fallback_public_client_enabled` in version 2.0 of the AzureAD provider",
+			},
+
+			"reply_urls": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"web.0.redirect_uris"},
+				Deprecated:    "[NOTE] This attribute will be replaced by a new attribute `redirect_uris` in the `web` block in version 2.0 of the AzureAD provider",
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validate.NoEmptyStrings,
+				},
+			},
+
+			"required_resource_access": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_app_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"resource_access": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: validate.UUID,
+									},
+
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice(
+											[]string{
+												string(msgraph.ResourceAccessTypeRole),
+												string(msgraph.ResourceAccessTypeScope),
+											},
+											false, // force case sensitivity
+										),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"sign_in_audience": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"available_to_other_tenants"},
+				ValidateFunc: validation.StringInSlice([]string{
+					string(msgraph.SignInAudienceAzureADMyOrg),
+					string(msgraph.SignInAudienceAzureADMultipleOrgs),
+					//string(msgraph.SignInAudienceAzureADandPersonalMicrosoftAccount),
+				}, false),
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Deprecated:   "[NOTE] This legacy property is deprecated and will be removed in version 2.0 of the AzureAD provider",
+				ValidateFunc: validation.StringInSlice([]string{"webapp/api", "native"}, false),
+				Default:      "webapp/api",
+			},
+
+			"web": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"homepage_url": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ConflictsWith:    []string{"homepage"},
+							ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
+						},
+
+						"logout_url": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ConflictsWith:    []string{"logout_url"},
+							ValidateDiagFunc: validate.IsHTTPOrHTTPSURL,
+						},
+
+						"redirect_uris": {
+							Type:          schema.TypeSet,
+							Optional:      true,
+							ConflictsWith: []string{"reply_urls"},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validate.NoEmptyStrings,
+							},
+						},
+
+						"implicit_grant": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"access_token_issuance_enabled": {
+										Type:          schema.TypeBool,
+										Optional:      true,
+										ConflictsWith: []string{"oauth2_allow_implicit_flow"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"application_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"object_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"prevent_duplicate_names": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func ResourceApplicationInstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+	groupMembershipClaimsOld := rawState["group_membership_claims"].(string)
+	rawState["group_membership_claims"] = []string{groupMembershipClaimsOld}
+	return rawState, nil
+}

--- a/internal/services/applications/migrations/application_resource.go
+++ b/internal/services/applications/migrations/application_resource.go
@@ -547,7 +547,7 @@ func ResourceApplicationInstanceResourceV0() *schema.Resource {
 }
 
 func ResourceApplicationInstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+	log.Println("[DEBUG] Migrating `group_membership_claims` from v0 to v1 format")
 	groupMembershipClaimsOld := rawState["group_membership_claims"].(string)
 	rawState["group_membership_claims"] = []string{groupMembershipClaimsOld}
 	return rawState, nil

--- a/internal/services/serviceprincipals/migrations/service_principal_password_resource.go
+++ b/internal/services/serviceprincipals/migrations/service_principal_password_resource.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+)
+
+func ResourceServicePrincipalPasswordInstanceResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"service_principal_id": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"key_id": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"value": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringLenBetween(1, 863),
+			},
+
+			"start_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+
+			"end_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"end_date_relative"},
+				ValidateFunc: validation.IsRFC3339Time,
+			},
+
+			"end_date_relative": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ExactlyOneOf:     []string{"end_date"},
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+		},
+	}
+}
+
+func ResourceServicePrincipalPasswordInstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+	newId, err := parse.OldPasswordID(rawState["id"].(string))
+	if err != nil {
+		return rawState, fmt.Errorf("generating new ID: %s", err)
+	}
+
+	rawState["id"] = newId.String()
+	return rawState, nil
+}


### PR DESCRIPTION
- Migrate `group_membership_claims` in `azuread_application` from a TypeString to a TypeSet
- Organize other state migrations into `migrations/` directory for each service

Fixes: #484