### PR TITLE
Add migration for public_client attribute

### DIFF
--- a/internal/services/applications/migrations/application_resource.go
+++ b/internal/services/applications/migrations/application_resource.go
@@ -549,5 +549,10 @@ func ResourceApplicationInstanceStateUpgradeV0(_ context.Context, rawState map[s
 	log.Println("[DEBUG] Migrating `group_membership_claims` from v0 to v1 format")
 	groupMembershipClaimsOld := rawState["group_membership_claims"].(string)
 	rawState["group_membership_claims"] = []string{groupMembershipClaimsOld}
+
+	log.Println("[DEBUG] Migrating `public_client` from v0 to v1 format (new attribute name)")
+	rawState["fallback_public_client_enabled"] = rawState["public_client"]
+	delete(rawState, "public_client")
+
 	return rawState, nil
 }

--- a/internal/services/applications/migrations/application_resource.go
+++ b/internal/services/applications/migrations/application_resource.go
@@ -551,7 +551,9 @@ func ResourceApplicationInstanceStateUpgradeV0(_ context.Context, rawState map[s
 	rawState["group_membership_claims"] = []string{groupMembershipClaimsOld}
 
 	log.Println("[DEBUG] Migrating `public_client` from v0 to v1 format (new attribute name)")
-	rawState["fallback_public_client_enabled"] = rawState["public_client"]
+	if v, ok := rawState["fallback_public_client_enabled"]; !ok || v == nil {
+		rawState["fallback_public_client_enabled"] = rawState["public_client"]
+	}
 	delete(rawState, "public_client")
 
 	return rawState, nil


### PR DESCRIPTION
- Add a migration for the `public_client` attribute to rename it to `fallback_public_client_enabled`