### PR TITLE
When reading, use decoded CustomKeyIdentifier as display_name if DisplayName is nil

### DIFF
--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"errors"
 	"log"
 	"net/http"
@@ -201,7 +202,17 @@ func applicationPasswordResourceRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	tf.Set(d, "application_object_id", id.ObjectId)
-	tf.Set(d, "display_name", credential.DisplayName)
+
+	if credential.DisplayName != nil {
+		tf.Set(d, "display_name", credential.DisplayName)
+	} else {
+		displayName, err := b64.StdEncoding.DecodeString(*credential.CustomKeyIdentifier)
+		if err != nil {
+			return tf.ErrorDiagPathF(err, "display_name", "Parsing CustomKeyIdentifier")
+		}
+		tf.Set(d, "display_name", string(displayName))
+	}
+
 	tf.Set(d, "key_id", id.KeyId)
 
 	startDate := ""

--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -205,7 +205,7 @@ func applicationPasswordResourceRead(ctx context.Context, d *schema.ResourceData
 
 	if credential.DisplayName != nil {
 		tf.Set(d, "display_name", credential.DisplayName)
-	} else {
+	} else if credential.CustomKeyIdentifier != nil {
 		displayName, err := b64.StdEncoding.DecodeString(*credential.CustomKeyIdentifier)
 		if err != nil {
 			return tf.ErrorDiagPathF(err, "display_name", "Parsing CustomKeyIdentifier")


### PR DESCRIPTION

Fix for #498 

- Decode CustomKeyIdentifier used by prior provider versions and use it as display_name if DisplayName is nil
