### PR TITLE
azuread_service_principal_password: fix for unintentional forcenew

### DIFF
--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -2,7 +2,7 @@ package applications
 
 import (
 	"context"
-	b64 "encoding/base64"
+	"encoding/base64"
 	"errors"
 	"log"
 	"net/http"
@@ -206,7 +206,7 @@ func applicationPasswordResourceRead(ctx context.Context, d *schema.ResourceData
 	if credential.DisplayName != nil {
 		tf.Set(d, "display_name", credential.DisplayName)
 	} else if credential.CustomKeyIdentifier != nil {
-		displayName, err := b64.StdEncoding.DecodeString(*credential.CustomKeyIdentifier)
+		displayName, err := base64.StdEncoding.DecodeString(*credential.CustomKeyIdentifier)
 		if err != nil {
 			return tf.ErrorDiagPathF(err, "display_name", "Parsing CustomKeyIdentifier")
 		}


### PR DESCRIPTION
Source display_name from `CustomKeyIdentifier` field as per legacy API to prevent unintentional ForceNew after upgrade

(Same fix as implemented in #499 for `azuread_application_password`)