### PR TITLE
Group ownership workarounds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,6 @@ linters:
 
 linters-settings:
   errcheck:
-    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close
+    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set|Clear,fmt:.*,io:Close
   goimports:
     local-prefixes: github.com/hashicorp/terraform-provider-azuread/azuread

--- a/docs/guides/microsoft-graph.md
+++ b/docs/guides/microsoft-graph.md
@@ -60,11 +60,17 @@ However, you may need to assign new API permissions depending on your configurat
 
 For users connecting to national clouds (e.g. germany, china and usgovernment), these are all supported using the existing provider configuration property `environment`, or the environment variable `ARM_ENVIRONMENT`. The "usgovernment" environment has been split into two environments "usgovernmentl4" and "usgovernmentl5" - see [this post](https://developer.microsoft.com/en-us/office/blogs/new-microsoft-graph-endpoints-in-us-government-cloud/) for more information. Specifying the "usgovernment" environment will use the "usgovernmentl4" cloud.
 
+### Additional option for Client Certificate authentication
+
+If you are using Client Certificate authentication, it's now possible to specify the certificate bundle data as an inline variable, in addition to the pre-existing method of specifying the filesystem path for a `.pfx` file. This may be useful when running Terraform in a non-interactive context, such as CI/CD pipelines.
+
+For more information, consult the [Client Certificate Authentication Guide](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/service_principal_client_certificate).
+
 ## New API permissions
 
 Microsoft Graph is a different web service to Azure Active Directory Graph, and as such if you are authenticating using a service principal, you may need to assign new permissions to [your authenticated principal](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/service_principal_configuration).
 
--> If you have assigned API permissions specific to the Azure Directory Graph API, you can safely unassign these permissions after upgrading to version 2.0.
+-> If you have assigned API permissions specific to the Azure Directory Graph API, you can safely un-assign these permissions after upgrading to version 2.0.
 
 ### Assigning directory roles
 

--- a/docs/guides/microsoft-graph.md
+++ b/docs/guides/microsoft-graph.md
@@ -96,6 +96,14 @@ Depending on the configuration of your AAD tenant, you may also need to grant th
 
 After assigning permissions, you will need to grant consent for the service principal to utilise them. The easiest way to do this is by clicking the Grant Admin Consent button in the same API Permissions pane, which will create the necessary app role assignments for the Service Principal.
 
+## New API Constraints
+
+Due to differences between the Azure Active Directory Graph API and the Microsoft Graph API, you may encounter some constraints after upgrading. These are due to implementation changes within Azure, and are outside the control of the provider, but where known these are detailed here for your convenience.
+
+### New requirements for groups
+
+Microsoft 365 groups are required to have at least one owner that is a user principal, i.e. not a service principal. When creating or managing Microsoft 365 groups, you should explicitly assign at least one user to be an owner of the group in your Terraform configuration. Note that whilst this requirement officially pertains to Microsoft 365 groups, you may encounter this constraint with newly created "traditional" security groups, such as the type supported by the AzureAD provider prior to version 2.0.
+
 ## New required fields
 
 ### Resource: `azuread_group`

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -61,6 +61,9 @@ The following arguments are supported:
 * `mail_nickname` - (Optional) The mail alias for the group, unique in the organisation. Required for mail-enabled groups. Changing this forces a new resource to be created.
 * `members` - (Optional) A set of members who should be present in this group. Supported object types are Users, Groups or Service Principals.
 * `owners` - (Optional) A set of owners who own this group. Supported object types are Users or Service Principals.
+
+-> **Group Ownership** Terraform always adds its own principal as a group owner to ensure that groups can continue to be managed. Microsoft 365 groups are required to have at least one owner which _must be a user_ (i.e. not a service principal). If you are running Terraform with an Azure AD user principal, you do not need to specify any owners for a group. However, we recommend always specifying at least one user as an owner in your configuration to avoid potential API errors during future apply operations.
+
 * `prevent_duplicate_names` - (Optional) If `true`, will return an error if an existing group is found with the same name. Defaults to `false`.
 * `provisioning_options` - (Optional) A set of provisioning options for a Microsoft 365 group. The only supported value is `Team`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for details. Changing this forces a new resource to be created.
 * `security_enabled` - (Optional) Whether the group is a security group for controlling access to in-app resources. At least one of `security_enabled` or `mail_enabled` must be specified. A group can be security enabled _and_ mail enabled.

--- a/internal/utils/slices.go
+++ b/internal/utils/slices.go
@@ -1,5 +1,7 @@
 package utils
 
+import "strings"
+
 // Difference returns the elements in `a` that aren't in `b`.
 func Difference(a, b []string) []string {
 	mb := make(map[string]struct{}, len(b))
@@ -13,4 +15,14 @@ func Difference(a, b []string) []string {
 		}
 	}
 	return diff
+}
+
+// EnsureStringInSlice ensures the given string is contained in a slice
+func EnsureStringInSlice(sl []string, in string) []string {
+	for _, s := range sl {
+		if strings.EqualFold(s, in) {
+			return sl
+		}
+	}
+	return append(sl, in)
 }


### PR DESCRIPTION
- Always ensure the calling principal is an owner
- Helps ensure that Terraform is able to continue to manage the group, whether the user specifies said principal as an explicit owner or not
- Add notes to documentation to help practitioners moving to MS Graph who might encounter group ownership related API errors

Closes: #464 
