### PR TITLE
Feature/issue 551 azuread_groups security_enabled flag

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -30,6 +30,15 @@ data "azuread_groups" "allGroups" {
 }
 ```
 
+*Look up all security groups*
+```terraform
+data "azuread_groups" "allGroups" {
+  return_all       = true
+  security_enabled = true
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -38,8 +47,11 @@ The following arguments are supported:
 * `object_ids` - (Optional) The object IDs of the groups.
 * `return_all` - (Optional) A flag to denote if all groups should be fetched and returned.
 * `security_enabled` - (Optional) A flag to denote if only `security_enabled=true` groups should be returned.
+* `mail_enabled` - (Optional) A flag to denote if only `mail_enabled=true` groups should be returned.
 
 ~> One of `display_names`, `object_ids` or `return_all` should be specified. Either of the first two _may_ be specified as an empty list, in which case no results will be returned.
+
+~> `security_enabled` and `mail_enabled` flags work with `return_all` and `display_names` but not `object_ids`
 
 ## Attributes Reference
 

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `display_names` - (Optional) The display names of the groups.
 * `object_ids` - (Optional) The object IDs of the groups.
 * `return_all` - (Optional) A flag to denote if all groups should be fetched and returned.
+* `security_enabled` - (Optional) A flag to denote if only `security_enabled=true` groups should be returned.
 
 ~> One of `display_names`, `object_ids` or `return_all` should be specified. Either of the first two _may_ be specified as an empty list, in which case no results will be returned.
 

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -30,7 +30,7 @@ data "azuread_groups" "allGroups" {
 }
 ```
 
-*Look up all security groups*
+*Look up all security-enabled groups*
 ```terraform
 data "azuread_groups" "allGroups" {
   return_all       = true

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 ~> One of `display_names`, `object_ids` or `return_all` should be specified. Either of the first two _may_ be specified as an empty list, in which case no results will be returned.
 
-~> `security_enabled` and `mail_enabled` flags work with `return_all` and `display_names` but not `object_ids`
+-> `security_enabled` and `mail_enabled` flags work with `return_all` and `display_names` but not `object_ids`
 
 ## Attributes Reference
 

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -44,10 +44,10 @@ data "azuread_groups" "allGroups" {
 The following arguments are supported:
 
 * `display_names` - (Optional) The display names of the groups.
+* `mail_enabled` - (Optional) A flag to denote if only `mail_enabled=true` groups should be returned.
 * `object_ids` - (Optional) The object IDs of the groups.
 * `return_all` - (Optional) A flag to denote if all groups should be fetched and returned.
 * `security_enabled` - (Optional) A flag to denote if only `security_enabled=true` groups should be returned.
-* `mail_enabled` - (Optional) A flag to denote if only `mail_enabled=true` groups should be returned.
 
 ~> One of `display_names`, `object_ids` or `return_all` should be specified. Either of the first two _may_ be specified as an empty list, in which case no results will be returned.
 

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -161,6 +161,10 @@ func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			newDisplayNames = append(newDisplayNames, *group.DisplayName)
 		}
 	}
+	// Check if securityEnabled has caused the number of returned groups to be 0
+	if len(newObjectIds) == 0 && securityEnabled{
+		return tf.ErrorDiagF(errors.New("No groups found with 'security_enabled = true'"), "Unexpected Number of groups returned")
+	}
 
 	h := sha1.New()
 	if _, err := h.Write([]byte(strings.Join(newDisplayNames, "-"))); err != nil {

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -112,10 +112,8 @@ func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 			if securityEnabled {
 				groups = append(groups, *result...)
-
 			} else if count > 1 {
 				return tf.ErrorDiagPathF(err, "display_names", "More than one group found with display name: %q", displayName)
-
 			} else if count == 0 {
 				return tf.ErrorDiagPathF(err, "display_names", "No group found with display name: %q", displayName)
 			}

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -162,7 +162,7 @@ func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 	// Check if securityEnabled has caused the number of returned groups to be 0
-	if len(newObjectIds) == 0 && securityEnabled{
+	if len(newObjectIds) == 0 && securityEnabled {
 		return tf.ErrorDiagF(errors.New("No groups found with 'security_enabled = true'"), "Unexpected Number of groups returned")
 	}
 

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -61,17 +61,19 @@ func groupsDataSource() *schema.Resource {
 			},
 
 			"security_enabled": {
-				Description: "Whether the groups are security_enabled",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
+				Description:   "Whether the groups are security_enabled",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_ids"},
 			},
 
 			"mail_enabled": {
-				Description: "Whether the groups are mail_enabled",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Computed:    true,
+				Description:   "Whether the groups are mail_enabled",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_ids"},
 			},
 		},
 	}
@@ -104,7 +106,6 @@ func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return tf.ErrorDiagPathF(err, "return_all", "No groups found")
 		}
 		groups = filterResults(securityEnabled, mailEnabled, result)
-
 	} else if len(displayNames) > 0 {
 		expectedCount = len(displayNames)
 		for _, v := range displayNames {
@@ -199,9 +200,7 @@ func filterResults(securityEnabled, mailEnabled bool, results *[]msgraph.Group) 
 			}
 		}
 	} else {
-		for _, r := range *results {
-			groups = append(groups, r)
-		}
+		groups = append(groups, *results...)
 	}
 	return groups
 }

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -61,7 +61,7 @@ func groupsDataSource() *schema.Resource {
 			},
 
 			"security_enabled": {
-				Description: "Retrieve only groups that are security_enabled groups",
+				Description: "Whether the groups are security-enabled",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed: true,

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -64,6 +64,7 @@ func groupsDataSource() *schema.Resource {
 				Description: "Retrieve only groups that are security_enabled groups",
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed: true,
 			},
 		},
 	}

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -64,7 +64,7 @@ func groupsDataSource() *schema.Resource {
 				Description: "Whether the groups are security-enabled",
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed: true,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -98,6 +98,20 @@ func TestAccGroupsDataSource_mailEnabled(t *testing.T) {
 	})
 }
 
+func TestAccGroupsDataSource_bothMailSecurityEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_groups", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupsDataSource{}.bothMailSecurityEnabled(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("object_ids.#").Exists(),
+			),
+		},
+	})
+}
+
 func (GroupsDataSource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azuread_group" "testA" {
@@ -164,6 +178,16 @@ func (GroupsDataSource) mailEnabled() string {
 data "azuread_groups" "test" {
   return_all   = true
   mail_enabled = true
+}
+`
+}
+
+func (GroupsDataSource) bothMailSecurityEnabled() string {
+	return `
+data "azuread_groups" "test" {
+  return_all   = true
+  mail_enabled = true
+  security_enabled = true
 }
 `
 }

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -79,7 +79,7 @@ func TestAccGroupsDataSource_securityEnabled(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
-				),
+			),
 		},
 	})
 }
@@ -139,7 +139,7 @@ data "azuread_groups" "test" {
 func (GroupsDataSource) securityEnabled() string {
 	return `
 data "azuread_groups" "test" {
-  return_all = true
+  return_all       = true
   security_enabled = true
 }
 `

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -162,7 +162,7 @@ data "azuread_groups" "test" {
 func (GroupsDataSource) mailEnabled() string {
 	return `
 data "azuread_groups" "test" {
-  return_all       = true
+  return_all   = true
   main_enabled = true
 }
 `

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -70,6 +70,20 @@ func TestAccGroupsDataSource_returnAll(t *testing.T) {
 	})
 }
 
+func TestAccGroupsDataSource_securityEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_groups", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupsDataSource{}.securityEnabled(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("object_ids.#").Exists(),
+				),
+		},
+	})
+}
+
 func (GroupsDataSource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azuread_group" "testA" {
@@ -118,6 +132,15 @@ func (GroupsDataSource) returnAll() string {
 	return `
 data "azuread_groups" "test" {
   return_all = true
+}
+`
+}
+
+func (GroupsDataSource) securityEnabled() string {
+	return `
+data "azuread_groups" "test" {
+  return_all = true
+  security_enabled = true
 }
 `
 }

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -84,6 +84,20 @@ func TestAccGroupsDataSource_securityEnabled(t *testing.T) {
 	})
 }
 
+func TestAccGroupsDataSource_mailEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_groups", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupsDataSource{}.mailEnabled(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("object_ids.#").Exists(),
+			),
+		},
+	})
+}
+
 func (GroupsDataSource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azuread_group" "testA" {
@@ -141,6 +155,15 @@ func (GroupsDataSource) securityEnabled() string {
 data "azuread_groups" "test" {
   return_all       = true
   security_enabled = true
+}
+`
+}
+
+func (GroupsDataSource) mailEnabled() string {
+	return `
+data "azuread_groups" "test" {
+  return_all       = true
+  main_enabled = true
 }
 `
 }

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -163,7 +163,7 @@ func (GroupsDataSource) mailEnabled() string {
 	return `
 data "azuread_groups" "test" {
   return_all   = true
-  main_enabled = true
+  mail_enabled = true
 }
 `
 }


### PR DESCRIPTION
Fixes [#551](https://github.com/hashicorp/terraform-provider-azuread/issues/551)

Added a `security_enabled=true` flag to `azuread_groups` datasource. It currently does not implement any logic when `security_enabled=false` which some people might want in the future.

This checks to ensure that atleast 1 result is returned - If one non security_enabled group is found but then dropped then an error suggesting the flag will be returned.

The test functionality for this and the return_all flag needs to be revisited by someone that understands this testing framwork more than me. There are single cases