### PR TITLE
[docs] Fix typo in Service Principal/Client Secret doc

### DIFF
--- a/docs/guides/service_principal_client_secret.md
+++ b/docs/guides/service_principal_client_secret.md
@@ -48,7 +48,7 @@ Click the "New client secret" button, then enter a short description, choose an 
 
 ---
 
-## Configuring Terraform to use the Client Certificate
+## Configuring Terraform to use the Client Secret
 
 Now we have obtained the necessary credentials, it's possible to configure Terraform in a few different ways.
 


### PR DESCRIPTION
The page references using a "Client Certificate" but it should read "Client Secret"