### PR TITLE
Bugfix CA Policies

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -22,25 +22,29 @@ resource "azuread_conditional_access_policy" "example" {
   state        = "disabled"
 
   conditions {
+    client_app_types    = ["all"]
+    sign_in_risk_levels = ["medium"]
+    user_risk_levels    = ["medium"]
+
     applications {
       included_applications = ["All"]
       excluded_applications = ["00000004-0000-0ff1-ce00-000000000000"]
     }
-    users {
-      included_users = ["All"]
-      excluded_users = ["GuestsOrExternalUsers"]
-    }
-    client_app_types = ["all"]
+
     locations {
       included_locations = ["All"]
       excluded_locations = ["AllTrusted"]
     }
+
     platforms {
       included_platforms = ["android"]
       excluded_platforms = ["iOS"]
     }
-    sign_in_risk_levels = ["medium"]
-    user_risk_levels    = ["medium"]
+
+    users {
+      included_users = ["All"]
+      excluded_users = ["GuestsOrExternalUsers"]
+    }
   }
 
   grant_controls {
@@ -52,10 +56,12 @@ resource "azuread_conditional_access_policy" "example" {
     application_enforced_restrictions {
       enabled = true
     }
+
     cloud_app_security {
       enabled                 = true
       cloud_app_security_type = "monitorOnly"
     }
+
     sign_in_frequency {
       enabled = true
       type    = "hours"
@@ -79,13 +85,13 @@ The following arguments are supported:
 
 `conditions` block supports the following:
 
-* `applications` - (Optional) An `applications` block as documented below, which specifies applications and user actions included in and excluded from the policy.
-* `client_app_types` - (Optional) A list of client application types included in the policy. Possible values are: `all`, `browser`, `mobileAppsAndDesktopClients`, `exchangeActiveSync`, `easSupported` and `other`.
-* `locations` - (Optional) A `locations` block as documented below, which specifies locations included in and excluded from the policy.
-* `platforms` - (Optional) A `platforms` block as documented below, which specifies platforms included in and excluded from the policy.
+* `applications` - (Required) An `applications` block as documented below, which specifies applications and user actions included in and excluded from the policy.
+* `client_app_types` - (Required) A list of client application types included in the policy. Possible values are: `all`, `browser`, `mobileAppsAndDesktopClients`, `exchangeActiveSync`, `easSupported` and `other`.
+* `locations` - (Required) A `locations` block as documented below, which specifies locations included in and excluded from the policy.
+* `platforms` - (Required) A `platforms` block as documented below, which specifies platforms included in and excluded from the policy.
 * `sign_in_risk_levels` - (Optional) A list of sign-in risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
 * `user_risk_levels` - (Optional) A list of user risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
-* `users` - (Optional) A `users` block as documented below, which specifies users, groups, and roles included in and excluded from the policy.
+* `users` - (Required) A `users` block as documented below, which specifies users, groups, and roles included in and excluded from the policy.
 
 ---
 
@@ -119,14 +125,14 @@ The following arguments are supported:
 
 `platforms` block supports the following:
 
-* `excluded_platforms` - (Optional) A list of platforms explicitly excluded from the policy. Possible values are: `android`, `iOS`, `windows`, `windowsPhone`, `macOS`, `all`, `unknownFutureValue`.
-* `included_platforms` - (Required) A list of platforms the policy applies to, unless explicitly excluded. Possible values are: `android`, `iOS`, `windows`, `windowsPhone`, `macOS`, `all`, `unknownFutureValue`.
+* `excluded_platforms` - (Optional) A list of platforms explicitly excluded from the policy. Possible values are: `all`, `android`, `iOS`, `macOS`, `windows`, `windowsPhone` or `unknownFutureValue`.
+* `included_platforms` - (Required) A list of platforms the policy applies to, unless explicitly excluded. Possible values are: `all`, `android`, `iOS`, `macOS`, `windows`, `windowsPhone` or `unknownFutureValue`.
 
 ---
 
 `grant_controls` block supports the following:
 
-* `built_in_controls` - (Required) List of built-in controls required by the policy. Possible values are: `block`, `mfa`, `compliantDevice`, `domainJoinedDevice`, `approvedApplication`, `compliantApplication`, `passwordChange`, `unknownFutureValue`.
+* `built_in_controls` - (Required) List of built-in controls required by the policy. Possible values are: `block`, `mfa`, `approvedApplication`, `compliantApplication`, `compliantDevice`, `domainJoinedDevice`, `passwordChange` or `unknownFutureValue`.
 * `custom_authentication_factors` - (Optional) List of custom controls IDs required by the policy.
 * `operator` - (Required) Defines the relationship of the grant controls. Possible values are: `AND`, `OR`.
 * `terms_of_use` - (Optional) List of terms of use IDs required by the policy.
@@ -139,7 +145,7 @@ The following arguments are supported:
 
 -> Only Office 365, Exchange Online and Sharepoint Online support application enforced restrictions.
 
-* `cloud_app_security_policy` - (Optional) Enables cloud app security and specifies the cloud app security policy to use. Possible values are: `mcasConfigured`, `monitorOnly`, `blockDownloads` or `unknownFutureValue`.
+* `cloud_app_security_policy` - (Optional) Enables cloud app security and specifies the cloud app security policy to use. Possible values are: `blockDownloads`, `mcasConfigured`, `monitorOnly` or `unknownFutureValue`.
 * `sign_in_frequency` - (Optional) Number of days or hours to enforce sign-in frequency. Required when `sign_in_frequency_period` is specified.
 * `sign_in_frequency_period` - (Optional) The time period to enforce sign-in frequency. Possible values are: `hours` or `days`. Required when `sign_in_frequency_period` is specified.
 

--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -146,8 +146,8 @@ The following arguments are supported:
 -> Only Office 365, Exchange Online and Sharepoint Online support application enforced restrictions.
 
 * `cloud_app_security_policy` - (Optional) Enables cloud app security and specifies the cloud app security policy to use. Possible values are: `blockDownloads`, `mcasConfigured`, `monitorOnly` or `unknownFutureValue`.
-* `sign_in_frequency` - (Optional) Number of days or hours to enforce sign-in frequency. Required when `sign_in_frequency_period` is specified.
-* `sign_in_frequency_period` - (Optional) The time period to enforce sign-in frequency. Possible values are: `hours` or `days`. Required when `sign_in_frequency_period` is specified.
+* `sign_in_frequency` - (Optional) Number of days or hours to enforce sign-in frequency. Required when `sign_in_frequency_period` is specified. Due to an API issue, removing this property forces a new resource to be created.
+* `sign_in_frequency_period` - (Optional) The time period to enforce sign-in frequency. Possible values are: `hours` or `days`. Required when `sign_in_frequency_period` is specified. Due to an API issue, removing this property forces a new resource to be created.
 
 ---
 

--- a/internal/services/conditionalaccess/client/client.go
+++ b/internal/services/conditionalaccess/client/client.go
@@ -17,6 +17,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	policiesClient := msgraph.NewConditionalAccessPolicyClient(o.TenantID)
 	o.ConfigureClient(&policiesClient.BaseClient)
+	policiesClient.BaseClient.ApiVersion = msgraph.Version10
 
 	return &Client{
 		NamedLocationsClient: namedLocationsClient,

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -568,14 +568,22 @@ func flattenConditionalAccessSessionControls(in *msgraph.ConditionalAccessSessio
 		return []interface{}{}
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"application_enforced_restrictions_enabled": in.ApplicationEnforcedRestrictions.IsEnabled,
-			"cloud_app_security_policy":                 in.CloudAppSecurity.CloudAppSecurityType,
-			"sign_in_frequency":                         in.SignInFrequency.Value,
-			"sign_in_frequency_period":                  in.SignInFrequency.Type,
-		},
+	result := make(map[string]interface{})
+
+	if in.ApplicationEnforcedRestrictions != nil {
+		result["application_enforced_restrictions_enabled"] = in.ApplicationEnforcedRestrictions.IsEnabled
 	}
+
+	if in.CloudAppSecurity != nil {
+		result["cloud_app_security_policy"] = in.CloudAppSecurity.CloudAppSecurityType
+	}
+
+	if in.SignInFrequency != nil {
+		result["sign_in_frequency"] = in.SignInFrequency.Value
+		result["sign_in_frequency_period"] = in.SignInFrequency.Type
+	}
+
+	return []interface{}{result}
 }
 
 func expandConditionalAccessConditionSet(in []interface{}) *msgraph.ConditionalAccessConditionSet {
@@ -715,19 +723,27 @@ func expandConditionalAccessSessionControls(in []interface{}) *msgraph.Condition
 	cloudAppSecurity := config["cloud_app_security_policy"].(string)
 	signInFrequency := config["sign_in_frequency"].(int)
 
-	result := msgraph.ConditionalAccessSessionControls{
-		ApplicationEnforcedRestrictions: &msgraph.ApplicationEnforcedRestrictionsSessionControl{
+	var result msgraph.ConditionalAccessSessionControls
+
+	if applicationEnforcedRestrictions {
+		result.ApplicationEnforcedRestrictions = &msgraph.ApplicationEnforcedRestrictionsSessionControl{
 			IsEnabled: utils.Bool(applicationEnforcedRestrictions),
-		},
-		CloudAppSecurity: &msgraph.CloudAppSecurityControl{
-			IsEnabled:            utils.Bool(cloudAppSecurity != ""),
+		}
+	}
+
+	if cloudAppSecurity != "" {
+		result.CloudAppSecurity = &msgraph.CloudAppSecurityControl{
+			IsEnabled:            utils.Bool(true),
 			CloudAppSecurityType: utils.String(cloudAppSecurity),
-		},
-		SignInFrequency: &msgraph.SignInFrequencySessionControl{
-			IsEnabled: utils.Bool(signInFrequency > 0),
+		}
+	}
+
+	if signInFrequency > 0 {
+		result.SignInFrequency = &msgraph.SignInFrequencySessionControl{
+			IsEnabled: utils.Bool(true),
 			Type:      utils.String(config["sign_in_frequency_period"].(string)),
 			Value:     utils.Int32(int32(signInFrequency)),
-		},
+		}
 	}
 
 	return &result

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -32,7 +32,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
@@ -68,7 +68,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"applications": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -80,6 +80,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"excluded_applications": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -88,6 +89,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"included_user_actions": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -99,9 +101,10 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								},
 							},
 						},
+
 						"users": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -114,6 +117,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"excluded_users": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -122,6 +126,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"included_groups": {
 										Type:         schema.TypeList,
 										Optional:     true,
@@ -131,6 +136,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"excluded_groups": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -139,6 +145,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"included_roles": {
 										Type:         schema.TypeList,
 										Optional:     true,
@@ -148,6 +155,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"excluded_roles": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -159,9 +167,10 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								},
 							},
 						},
+
 						"client_app_types": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{
@@ -174,9 +183,10 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								}, false),
 							},
 						},
+
 						"locations": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -188,6 +198,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											ValidateDiagFunc: validate.NoEmptyStrings,
 										},
 									},
+
 									"excluded_locations": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -199,9 +210,10 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								},
 							},
 						},
+
 						"platforms": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -221,6 +233,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 											}, false),
 										},
 									},
+
 									"excluded_platforms": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -240,6 +253,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								},
 							},
 						},
+
 						"sign_in_risk_levels": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -255,6 +269,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								}, false),
 							},
 						},
+
 						"user_risk_levels": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -302,6 +317,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								}, false),
 							},
 						},
+
 						"custom_authentication_factors": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -310,6 +326,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								ValidateDiagFunc: validate.NoEmptyStrings,
 							},
 						},
+
 						"terms_of_use": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -331,6 +348,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+
 						"cloud_app_security_policy": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -341,12 +359,14 @@ func conditionalAccessPolicyResource() *schema.Resource {
 								"unknownFutureValue",
 							}, false),
 						},
+
 						"sign_in_frequency": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							RequiredWith: []string{"session_controls.0.sign_in_frequency_period"},
 							ValidateFunc: validation.IntAtLeast(0),
 						},
+
 						"sign_in_frequency_period": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -368,7 +388,7 @@ func conditionalAccessPolicyResourceCreate(ctx context.Context, d *schema.Resour
 		State:           utils.String(d.Get("state").(string)),
 		Conditions:      expandConditionalAccessConditionSet(d.Get("conditions").([]interface{})),
 		GrantControls:   expandConditionalAccessGrantControls(d.Get("grant_controls").([]interface{})),
-		SessionControls: expandConditionalAccessSessionControls(d.Get("session_controls").([]interface{})),
+		SessionControls: expandConditionalAccessSessionControls(d.Get("session_controls").([]interface{}), true),
 	}
 
 	policy, _, err := client.Create(ctx, properties)
@@ -394,11 +414,45 @@ func conditionalAccessPolicyResourceUpdate(ctx context.Context, d *schema.Resour
 		State:           utils.String(d.Get("state").(string)),
 		Conditions:      expandConditionalAccessConditionSet(d.Get("conditions").([]interface{})),
 		GrantControls:   expandConditionalAccessGrantControls(d.Get("grant_controls").([]interface{})),
-		SessionControls: expandConditionalAccessSessionControls(d.Get("session_controls").([]interface{})),
+		SessionControls: expandConditionalAccessSessionControls(d.Get("session_controls").([]interface{}), false),
 	}
 
 	if _, err := client.Update(ctx, properties); err != nil {
 		return tf.ErrorDiagF(err, "Could not update conditional access policy with ID: %q", d.Id())
+	}
+
+	// Poll for 5 retrievals of the updated policy. We don't check every property as this is prone to getting stuck
+	// in a timeout loop, instead we're hoping that this allows enough time/activity for the update to be reflected.
+	log.Printf("[DEBUG] Waiting for conditional access policy %q to be updated", d.Id())
+	timeout, _ := ctx.Deadline()
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{"Pending"},
+		Target:                    []string{"Done"},
+		Timeout:                   time.Until(timeout),
+		MinTimeout:                5 * time.Second,
+		ContinuousTargetOccurence: 5,
+		Refresh: func() (interface{}, string, error) {
+			client.BaseClient.DisableRetries = true
+			policy, _, err := client.Get(ctx, d.Id(), odata.Query{})
+			if err != nil {
+				return nil, "Error", err
+			}
+
+			if policy == nil {
+				return "stub", "Pending", nil
+			}
+			if policy.DisplayName == nil || *policy.DisplayName != d.Get("display_name").(string) {
+				return "stub", "Pending", nil
+			}
+			if policy.State == nil || *policy.State != d.Get("state").(string) {
+				return "stub", "Pending", nil
+			}
+
+			return "stub", "Done", nil
+		},
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return tf.ErrorDiagF(err, "waiting for update of conditional access policy with ID %q", d.Id())
 	}
 
 	return nil
@@ -667,11 +721,11 @@ func expandConditionalAccessUsers(in []interface{}) *msgraph.ConditionalAccessUs
 }
 
 func expandConditionalAccessPlatforms(in []interface{}) *msgraph.ConditionalAccessPlatforms {
+	result := msgraph.ConditionalAccessPlatforms{}
 	if len(in) == 0 || in[0] == nil {
-		return nil
+		return &result
 	}
 
-	result := msgraph.ConditionalAccessPlatforms{}
 	config := in[0].(map[string]interface{})
 
 	includePlatforms := config["included_platforms"].([]interface{})
@@ -721,38 +775,48 @@ func expandConditionalAccessGrantControls(in []interface{}) *msgraph.Conditional
 	return &result
 }
 
-func expandConditionalAccessSessionControls(in []interface{}) *msgraph.ConditionalAccessSessionControls {
-	if len(in) == 0 || in[0] == nil {
+func expandConditionalAccessSessionControls(in []interface{}, create bool) *msgraph.ConditionalAccessSessionControls {
+	// For POST requests, the API doesn't accept empty objects for nested fields here
+	if create && (len(in) == 0 || in[0] == nil) {
 		return nil
+	}
+
+	result := msgraph.ConditionalAccessSessionControls{
+		ApplicationEnforcedRestrictions: &msgraph.ApplicationEnforcedRestrictionsSessionControl{
+			IsEnabled: utils.Bool(false),
+		},
+		CloudAppSecurity: &msgraph.CloudAppSecurityControl{
+			IsEnabled: utils.Bool(false),
+		},
+		SignInFrequency: &msgraph.SignInFrequencySessionControl{
+			IsEnabled: utils.Bool(false),
+		},
+	}
+
+	// API doesn't accept boolean false values for POST requests, we must instead omit the entire object
+	if !create {
+		result.ApplicationEnforcedRestrictions.IsEnabled = utils.Bool(false)
+		result.CloudAppSecurity.IsEnabled = utils.Bool(false)
+		result.SignInFrequency.IsEnabled = utils.Bool(false)
+	}
+
+	if len(in) == 0 || in[0] == nil {
+		return &result
 	}
 
 	config := in[0].(map[string]interface{})
 
-	applicationEnforcedRestrictions := config["application_enforced_restrictions_enabled"].(bool)
-	cloudAppSecurity := config["cloud_app_security_policy"].(string)
-	signInFrequency := config["sign_in_frequency"].(int)
+	result.ApplicationEnforcedRestrictions.IsEnabled = utils.Bool(config["application_enforced_restrictions_enabled"].(bool))
 
-	var result msgraph.ConditionalAccessSessionControls
-	// The API doesn't accept boolean false values, we must instead omit them
-	if applicationEnforcedRestrictions {
-		result.ApplicationEnforcedRestrictions = &msgraph.ApplicationEnforcedRestrictionsSessionControl{
-			IsEnabled: utils.Bool(applicationEnforcedRestrictions),
-		}
+	if cloudAppSecurity := config["cloud_app_security_policy"].(string); cloudAppSecurity != "" {
+		result.CloudAppSecurity.IsEnabled = utils.Bool(true)
+		result.CloudAppSecurity.CloudAppSecurityType = utils.String(cloudAppSecurity)
 	}
-	// The API doesn't accept boolean false values, we must instead omit related fields
-	if cloudAppSecurity != "" {
-		result.CloudAppSecurity = &msgraph.CloudAppSecurityControl{
-			IsEnabled:            utils.Bool(true),
-			CloudAppSecurityType: utils.String(cloudAppSecurity),
-		}
-	}
-	// The API doesn't accept boolean false values, we must instead omit related fields
-	if signInFrequency > 0 {
-		result.SignInFrequency = &msgraph.SignInFrequencySessionControl{
-			IsEnabled: utils.Bool(true),
-			Type:      utils.String(config["sign_in_frequency_period"].(string)),
-			Value:     utils.Int32(int32(signInFrequency)),
-		}
+
+	if signInFrequency := config["sign_in_frequency"].(int); signInFrequency > 0 {
+		result.SignInFrequency.IsEnabled = utils.Bool(true)
+		result.SignInFrequency.Type = utils.String(config["sign_in_frequency_period"].(string))
+		result.SignInFrequency.Value = utils.Int32(int32(signInFrequency))
 	}
 
 	return &result

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -83,6 +83,96 @@ func TestAccConditionalAccessPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccConditionalAccessPolicy_sessionControls(t *testing.T) {
+	// This should continue to pass when https://github.com/microsoftgraph/msgraph-metadata/issues/93
+	// is resolved and the conditional ForceNew workaround has been removed
+
+	data := acceptance.BuildTestData(t, "azuread_conditional_access_policy", "test")
+	r := ConditionalAccessPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.sessionControls(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.sessionControls(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.sessionControls(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccConditionalAccessPolicy_sessionControlsDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_conditional_access_policy", "test")
+	r := ConditionalAccessPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.sessionControlsDisabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.sessionControlsDisabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r ConditionalAccessPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	var id *string
 
@@ -175,6 +265,84 @@ resource "azuread_conditional_access_policy" "test" {
     cloud_app_security_policy                 = "monitorOnly"
     sign_in_frequency                         = 10
     sign_in_frequency_period                  = "hours"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (ConditionalAccessPolicyResource) sessionControls(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_conditional_access_policy" "test" {
+  display_name = "acctest-CONPOLICY-%[1]d"
+  state        = "disabled"
+
+  conditions {
+    client_app_types = ["browser"]
+
+    applications {
+      included_applications = ["All"]
+    }
+
+    locations {
+      included_locations = ["All"]
+    }
+
+    platforms {
+      included_platforms = ["all"]
+    }
+
+    users {
+      included_users = ["All"]
+      excluded_users = ["GuestsOrExternalUsers"]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+  session_controls {
+    cloud_app_security_policy = "monitorOnly"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (ConditionalAccessPolicyResource) sessionControlsDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_conditional_access_policy" "test" {
+  display_name = "acctest-CONPOLICY-%[1]d"
+  state        = "disabled"
+
+  conditions {
+    client_app_types = ["browser"]
+
+    applications {
+      included_applications = ["All"]
+    }
+
+    locations {
+      included_locations = ["All"]
+    }
+
+    platforms {
+      included_platforms = ["all"]
+    }
+
+    users {
+      included_users = ["All"]
+      excluded_users = ["GuestsOrExternalUsers"]
+    }
+  }
+
+  grant_controls {
+    operator          = "OR"
+    built_in_controls = ["block"]
+  }
+
+  session_controls {
+    application_enforced_restrictions_enabled = false
   }
 }
 `, data.RandomInteger)

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -73,6 +73,13 @@ func TestAccConditionalAccessPolicy_update(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -98,16 +105,23 @@ resource "azuread_conditional_access_policy" "test" {
   state        = "disabled"
 
   conditions {
+    client_app_types = ["browser"]
+
     applications {
       included_applications = ["All"]
     }
+
+    locations {
+      included_locations = ["All"]
+    }
+
+    platforms {
+      included_platforms = ["all"]
+    }
+
     users {
       included_users = ["All"]
       excluded_users = ["GuestsOrExternalUsers"]
-    }
-    client_app_types = ["browser"]
-    locations {
-      included_locations = ["All"]
     }
   }
 
@@ -126,25 +140,29 @@ resource "azuread_conditional_access_policy" "test" {
   state        = "disabled"
 
   conditions {
+    client_app_types    = ["all"]
+    sign_in_risk_levels = ["medium"]
+    user_risk_levels    = ["medium"]
+
     applications {
       included_applications = ["All"]
       excluded_applications = ["00000004-0000-0ff1-ce00-000000000000"]
     }
-    users {
-      included_users = ["All"]
-      excluded_users = ["GuestsOrExternalUsers"]
-    }
-    client_app_types = ["all"]
+
     locations {
       included_locations = ["All"]
       excluded_locations = ["AllTrusted"]
     }
+
     platforms {
       included_platforms = ["android"]
       excluded_platforms = ["iOS"]
     }
-    sign_in_risk_levels = ["medium"]
-    user_risk_levels    = ["medium"]
+
+    users {
+      included_users = ["All"]
+      excluded_users = ["GuestsOrExternalUsers"]
+    }
   }
 
   grant_controls {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azuread/issues/568

Whilst testing this I initially started by commenting out the setting of `ApplicationEnforcedRestrictions` and `CloudAppSecurity` in `expandConditionalAccessSessionControls` which bizarrely started causing panics in `flattenConditionalAccessSessionControls`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xed80d0]

goroutine 691 [running]:
github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess.flattenConditionalAccessSessionControls(...)
        /home/alexwilcox/go/src/github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess/conditional_access_policy_resource.go:573
github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess.conditionalAccessPolicyResourceRead(0x13afeb8, 0xc000d0acc0, 0xc0009aa400, 0x10322a0, 0xc00089a1c0, 0xc000992d70, 0xc00075dae0, 0x0)
        /home/alexwilcox/go/src/github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess/conditional_access_policy_resource.go:425 +0x6d0
github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess.conditionalAccessPolicyResourceCreate(0x13afeb8, 0xc000d0acc0, 0xc0009aa400, 0x10322a0, 0xc00089a1c0, 0xc000992d60, 0x9059ea, 0xc00075cb60)
```

I believe I've solved this by adding some nil checks in that function

I found that not setting `ApplicationEnforcedRestrictions` and `CloudAppSecurity` at all in `expandConditionalAccessSessionControls` even if they weren't set in the terraform configuration got it working so I've now rearranged the logic in that function so that if the attributes aren't set in the terraform we don't instantiate those structs

I've tried updating the `session_controls` block in the complete test to the following and all are now passing

```
  session_controls {
    application_enforced_restrictions_enabled = true
    cloud_app_security_policy                 = "monitorOnly"
    sign_in_frequency                         = 10
    sign_in_frequency_period                  = "hours"
  }
```
```
  session_controls {
    cloud_app_security_policy                 = "monitorOnly"
    sign_in_frequency                         = 10
    sign_in_frequency_period                  = "hours"
  }
```
```
  session_controls {
    sign_in_frequency                         = 10
    sign_in_frequency_period                  = "hours"
  }
```
```
  session_controls {
    application_enforced_restrictions_enabled = true
    cloud_app_security_policy                 = "monitorOnly"
  }
```

Also when running all these tests I did hit the update issue that named locations were getting (and were solved by the refresh func) but I wasn't sure how best to go about adding this as I see in named locations you just compare each value in turn and there's a lot of values to check in this resource! If that is the way I'm happy to crack on, just wanted to check first

```
=== CONT  TestAccConditionalAccessPolicy_update
    testcase.go:60: Step 3/4 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # azuread_conditional_access_policy.test will be updated in-place
          ~ resource "azuread_conditional_access_policy" "test" {
                id           = "84812c78-43fe-4338-b738-9c037623f6d3"
                # (2 unchanged attributes hidden)
        
              ~ conditions {
                  ~ client_app_types    = [
                      - "browser",
                      + "all",
                    ]
                  ~ sign_in_risk_levels = [
                      + "medium",
                    ]
                  ~ user_risk_levels    = [
                      + "medium",
                    ]
        
                  ~ applications {
                      ~ excluded_applications = [
                          + "00000004-0000-0ff1-ce00-000000000000",
                        ]
                        # (2 unchanged attributes hidden)
                    }
        
                  ~ locations {
                      ~ excluded_locations = [
                          + "AllTrusted",
                        ]
                        # (1 unchanged attribute hidden)
                    }
        
                  + platforms {
                      + excluded_platforms = [
                          + "iOS",
                        ]
                      + included_platforms = [
                          + "android",
                        ]
                    }
        
                    # (1 unchanged block hidden)
                }
        
              ~ grant_controls {
                  ~ built_in_controls             = [
                      - "block",
                      + "mfa",
                    ]
                    # (3 unchanged attributes hidden)
                }
        
              + session_controls {
                  + application_enforced_restrictions_enabled = true
                  + cloud_app_security_policy                 = "monitorOnly"
                  + sign_in_frequency                         = 10
                  + sign_in_frequency_period                  = "hours"
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccConditionalAccessPolicy_complete (45.17s)
--- PASS: TestAccConditionalAccessPolicy_basic (46.88s)
--- FAIL: TestAccConditionalAccessPolicy_update (48.58s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess     48.591s
```