### PR TITLE
Ensure `prevent_duplicate_names` checks don't falsely fail for unknown display names

### DIFF
--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -576,7 +576,7 @@ func applicationResourceCustomizeDiff(ctx context.Context, diff *schema.Resource
 	client := meta.(*clients.Client).Applications.ApplicationsClient
 	oldDisplayName, newDisplayName := diff.GetChange("display_name")
 
-	if diff.Get("prevent_duplicate_names").(bool) &&
+	if diff.Get("prevent_duplicate_names").(bool) && tf.ValueIsNotEmptyOrUnknown(newDisplayName) &&
 		(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
 		result, err := applicationFindByName(ctx, client, newDisplayName.(string))
 		if err != nil {

--- a/internal/services/applications/applications.go
+++ b/internal/services/applications/applications.go
@@ -317,10 +317,10 @@ func applicationValidateRolesScopes(appRoles, oauth2Permissions []interface{}) e
 			continue
 		}
 		role := roleRaw.(map[string]interface{})
-		if id := role["id"].(string); id != "" && id != tf.PluginSdkUnknownValue {
+		if id := role["id"].(string); tf.ValueIsNotEmptyOrUnknown(id) {
 			ids = append(ids, id)
 		}
-		if val := role["value"].(string); val != "" && val != tf.PluginSdkUnknownValue {
+		if val := role["value"].(string); tf.ValueIsNotEmptyOrUnknown(val) {
 			values = append(values, val)
 		}
 	}
@@ -330,10 +330,10 @@ func applicationValidateRolesScopes(appRoles, oauth2Permissions []interface{}) e
 			continue
 		}
 		scope := scopeRaw.(map[string]interface{})
-		if id := scope["id"].(string); id != "" && id != tf.PluginSdkUnknownValue {
+		if id := scope["id"].(string); tf.ValueIsNotEmptyOrUnknown(id) {
 			ids = append(ids, id)
 		}
-		if val := scope["value"].(string); val != "" && val != tf.PluginSdkUnknownValue {
+		if val := scope["value"].(string); tf.ValueIsNotEmptyOrUnknown(val) {
 			values = append(values, val)
 		}
 	}

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -259,11 +259,11 @@ func groupResourceCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, 
 
 	// Check for duplicate names
 	oldDisplayName, newDisplayName := diff.GetChange("display_name")
-	if diff.Get("prevent_duplicate_names").(bool) &&
+	if diff.Get("prevent_duplicate_names").(bool) && tf.ValueIsNotEmptyOrUnknown(newDisplayName) &&
 		(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
 		result, err := groupFindByName(ctx, client, newDisplayName.(string))
 		if err != nil {
-			return fmt.Errorf("could not check for existing application(s): %+v", err)
+			return fmt.Errorf("could not check for existing group(s): %+v", err)
 		}
 		if result != nil && len(*result) > 0 {
 			for _, existingGroup := range *result {
@@ -283,6 +283,7 @@ func groupResourceCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, 
 	for _, v := range diff.Get("types").(*schema.Set).List() {
 		groupTypes = append(groupTypes, v.(string))
 	}
+
 	hasGroupType := func(value msgraph.GroupType) bool {
 		for _, v := range groupTypes {
 			if value == v {

--- a/internal/tf/pluginsdk.go
+++ b/internal/tf/pluginsdk.go
@@ -4,3 +4,16 @@ package tf
 // e.g. during a CustomizeDiff function
 // See https://github.com/hashicorp/terraform-plugin-sdk/blob/main/internal/configs/hcl2shim/values.go#L16
 const PluginSdkUnknownValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+// ValueIsNotEmptyOrUnknown returns false if provided a blank string or a string that looks "unknown". Intended for use
+// in CustomizeDiff functions to avoid validating a field that can't be validated.
+func ValueIsNotEmptyOrUnknown(in interface{}) bool {
+	switch val := in.(type) {
+	case string:
+		// consider strings potentially unknown if empty or set to the SDK dummy value
+		return val != "" && val != PluginSdkUnknownValue
+	default:
+		// for all other types, treat them as known
+		return true
+	}
+}


### PR DESCRIPTION
- Helper func for unknown plan-time strings
- Ensure `prevent_duplicate_names` checks don't falsely fail for unknown display names

Closes: #592