### PR TITLE
Bugfix: UPN single quote escaping

### DIFF
--- a/internal/services/users/user_data_source.go
+++ b/internal/services/users/user_data_source.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
@@ -316,7 +317,7 @@ func userDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if upn, ok := d.Get("user_principal_name").(string); ok && upn != "" {
 		query := odata.Query{
-			Filter: fmt.Sprintf("userPrincipalName eq '%s'", upn),
+			Filter: fmt.Sprintf("userPrincipalName eq '%s'", utils.EscapeSingleQuote(upn)),
 		}
 		users, _, err := client.List(ctx, query)
 		if err != nil {
@@ -346,7 +347,7 @@ func userDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interf
 		user = *u
 	} else if mailNickname, ok := d.Get("mail_nickname").(string); ok && mailNickname != "" {
 		query := odata.Query{
-			Filter: fmt.Sprintf("mailNickname eq '%s'", mailNickname),
+			Filter: fmt.Sprintf("mailNickname eq '%s'", utils.EscapeSingleQuote(mailNickname)),
 		}
 		users, _, err := client.List(ctx, query)
 		if err != nil {

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -149,7 +149,7 @@ data "azuread_domains" "test" {
 }
 
 resource "azuread_user" "test" {
-  user_principal_name = "acctestUser.%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  user_principal_name = "acctestUser'%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
   display_name        = "acctestUser-%[1]d"
   password            = "%[2]s"
 }
@@ -171,7 +171,7 @@ resource "azuread_user" "manager" {
 }
 
 resource "azuread_user" "test" {
-  user_principal_name = "acctestUser.%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  user_principal_name = "acctestUser'%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
   mail                = "acctestUser.%[1]d@hashicorp.biz"
   mail_nickname       = "acctestUser-%[1]d-MailNickname"
   other_mails         = ["acctestUser.%[1]d@hashicorp.net", "acctestUser.%[1]d@hashicorp.org"]
@@ -223,7 +223,7 @@ data "azuread_domains" "test" {
 }
 
 resource "azuread_user" "testA" {
-  user_principal_name = "acctestUser.%[1]d.A@${data.azuread_domains.test.domains.0.domain_name}"
+  user_principal_name = "acctestUser'%[1]d.A@${data.azuread_domains.test.domains.0.domain_name}"
   display_name        = "acctestUser-%[1]d-A"
   password            = "%[2]s"
 }

--- a/internal/services/users/users_data_source.go
+++ b/internal/services/users/users_data_source.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
 )
 
@@ -179,7 +180,7 @@ func usersDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		expectedCount = len(upns)
 		for _, v := range upns {
 			query := odata.Query{
-				Filter: fmt.Sprintf("userPrincipalName eq '%s'", v),
+				Filter: fmt.Sprintf("userPrincipalName eq '%s'", utils.EscapeSingleQuote(v.(string))),
 			}
 			result, _, err := client.List(ctx, query)
 			if err != nil {
@@ -222,7 +223,7 @@ func usersDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inter
 			expectedCount = len(mailNicknames)
 			for _, v := range mailNicknames {
 				query := odata.Query{
-					Filter: fmt.Sprintf("mailNickname eq '%s'", v),
+					Filter: fmt.Sprintf("mailNickname eq '%s'", utils.EscapeSingleQuote(v.(string))),
 				}
 				result, _, err := client.List(ctx, query)
 				if err != nil {

--- a/internal/utils/odata_query_string.go
+++ b/internal/utils/odata_query_string.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strings"
+
+// EscapeSingleQuote replaces all occurrences of single quote, with 2 single quotes.
+// For requests that use single quotes, if any parameter values also contain single quotes,
+// those must be double escaped; otherwise, the request will fail due to invalid syntax.
+// https://docs.microsoft.com/en-us/graph/query-parameters#escaping-single-quotes
+func EscapeSingleQuote(qparam string) string {
+	return strings.ReplaceAll(qparam, `'`, `''`)
+}


### PR DESCRIPTION
This PR addresses https://github.com/hashicorp/terraform-provider-azuread/issues/639.

We need to escape User Principal Names before querying Microsoft Graph.

I'm unable to run acceptance tests at the moment, but I have included a test.