### PR TITLE
Update azuread provider version to 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.0.0"
+      version = "~> 2.7.0"
     }
   }
 }


### PR DESCRIPTION
Version 2.0.0 fails to create azure group, with this error:

```azuread_group.aks_cluster_admins: Creating...
╷
│ Error: Could not retrieve owner principal object "a0630******"
│ 
│   with azuread_group.aks_cluster_admins,
│   on azuread.tf line 12, in resource "azuread_group" "aks_cluster_admins":
│   12: resource "azuread_group" "aks_cluster_admins" {
│ 
│ ODataId was nil
```
Upgrade to 2.7.0 fixed it.