### PR TITLE
Mitigate some replication delays after creating some resources

### DIFF
--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1032,6 +1032,16 @@ func applicationResourceCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(*app.ID)
 
+	// Wait until the application is updatable (the SDK handles retries for us)
+	_, err = client.Update(ctx, msgraph.Application{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: app.ID,
+		},
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Timed out whilst waiting for new application to be replicated in Azure AD")
+	}
+
 	if len(ownersExtra) > 0 {
 		// Add any remaining owners after the application is created
 		app.Owners = &ownersExtra

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -498,6 +498,16 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(*group.ID)
 
+	// Wait until the group is updatable (the SDK handles retries for us)
+	_, err = client.Update(ctx, msgraph.Group{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: group.ID,
+		},
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Timed out whilst waiting for new group to be replicated in Azure AD")
+	}
+
 	// Add any remaining owners after the group is created
 	if len(ownersExtra) > 0 {
 		group.Owners = &ownersExtra

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -471,6 +471,16 @@ func servicePrincipalResourceCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.SetId(*servicePrincipal.ID)
 
+	// Wait until the service principal is updatable (the SDK handles retries for us)
+	_, err = client.Update(ctx, msgraph.ServicePrincipal{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: servicePrincipal.ID,
+		},
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Timed out whilst waiting for new service principal to be replicated in Azure AD")
+	}
+
 	// Add any remaining owners after the service principal is created
 	if len(ownersExtra) > 0 {
 		servicePrincipal.Owners = &ownersExtra


### PR DESCRIPTION
- For applications, service principals, groups and users
- After creating, make a PATCH request with no changes
- Oftentimes if replication is very delayed, the PATCH request will fail
- The SDK handles retries of the PATCH request until it succeeds or times out

Closes: #652