### PR TITLE
azuread_conditional_access_policy: fix docs to reflect that `All` isn't accepted for role/group conditions

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -129,8 +129,8 @@ The following arguments are supported:
 * `excluded_groups` - (Optional) A list of group IDs excluded from scope of policy.
 * `excluded_roles` - (Optional) A list of role IDs excluded from scope of policy.
 * `excluded_users` - (Optional) A list of user IDs excluded from scope of policy and/or `GuestsOrExternalUsers`.
-* `included_groups` - (Optional) A list of group IDs in scope of policy unless explicitly excluded, or `All`.
-* `included_roles` - (Optional) A list of role IDs in scope of policy unless explicitly excluded, or `All`.
+* `included_groups` - (Optional) A list of group IDs in scope of policy unless explicitly excluded.
+* `included_roles` - (Optional) A list of role IDs in scope of policy unless explicitly excluded.
 * `included_users` - (Optional) A list of user IDs in scope of policy unless explicitly excluded, or `None` or `All` or `GuestsOrExternalUsers`.
 
 -> At least one of `included_groups`, `included_roles` or `included_users` must be specified.


### PR DESCRIPTION
Closes: #686