### PR TITLE
Upgrade golangci to 1.43.0 - so that `make tools` works on arm64

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ tools:
 	go install github.com/bflad/tfproviderdocs@latest
 	go install github.com/katbyte/terrafmt@latest
 	go install mvdan.cc/gofumpt@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$(go env GOPATH || $$GOPATH)"/bin v1.32.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$(go env GOPATH || $$GOPATH)"/bin v1.43.0
 
 build: fmtcheck
 	go install


### PR DESCRIPTION
make tools was erroring on fresh clone:

```
$ make tools
==> installing required tooling...
...
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH || $GOPATH)"/bin v1.32.0
golangci/golangci-lint info checking GitHub for tag 'v1.32.0'
golangci/golangci-lint info found version: 1.32.0 for v1.32.0/darwin/arm64
make: *** [tools] Error 1
```

This PR upgrades the version of golangci-lint to 1.43.0 which seems to install fine.