### PR TITLE
User(s) Data Source: Lookup users by on-prem SAM account

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -28,9 +28,10 @@ The following arguments are supported:
 
 * `mail_nickname` - (Optional) The email alias of the user.
 * `object_id` - (Optional) The object ID of the user.
+* `onpremises_sam_account_name` - (Optional) The on-premise SAM account name of the user.
 * `user_principal_name` - (Optional) The user principal name (UPN) of the user.
 
-~> One of `user_principal_name`, `object_id` or `mail_nickname` must be specified.
+~> One of `user_principal_name`, `object_id`, `onpremises_sam_account_name` or `mail_nickname` must be specified.
 
 ## Attributes Reference
 

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -29,10 +29,11 @@ The following arguments are supported:
 * `ignore_missing` - (Optional) Ignore missing users and return users that were found. The data source will still fail if no users are found. Defaults to false.
 * `mail_nicknames` - (Optional) The email aliases of the users.
 * `object_ids` - (Optional) The object IDs of the users.
+* `onpremises_sam_account_names` - (Optional) The on-premise SAM account names of the users.
 * `return_all` - (Optional) When `true`, the data source will return all users. Cannot be used with `ignore_missing`. Defaults to false.
 * `user_principal_names` - (Optional) The user principal names (UPNs) of the users.
 
-~> Either `return_all`, or one of `user_principal_names`, `object_ids` or `mail_nicknames` must be specified. These _may_ be specified as an empty list, in which case no results will be returned.
+~> Either `return_all`, or one of `user_principal_names`, `object_ids`, `onpremises_sam_account_names` or `mail_nicknames` must be specified. These _may_ be specified as an empty list, in which case no results will be returned.
 
 ## Attributes Reference
 
@@ -40,6 +41,7 @@ The following attributes are exported:
 
 * `mail_nicknames` - The email aliases of the users.
 * `object_ids` - The object IDs of the users.
+* `onpremises_sam_account_names` - The on-premise SAM account names of the users.
 * `user_principal_names` - The user principal names (UPNs) of the users.
 * `users` - A list of users. Each `user` object provides the attributes documented below.
 

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -236,9 +236,10 @@ resource "azuread_user" "testB" {
 }
 
 resource "azuread_user" "testC" {
-  user_principal_name = "acctestUser.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "acctestUser-%[1]d-C"
-  password            = "%[2]s"
+  user_principal_name     = "acctestUser.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name            = "acctestUser-%[1]d-C"
+  onpremises_immutable_id = "%[1]d"
+  password                = "%[2]s"
 }
 `, data.RandomInteger, data.RandomPassword)
 }


### PR DESCRIPTION
This PR extends the features on User and Users Data Sources, by adding support to look up users by on-premise SAM account name.


- Add on-prem SAM account name as supported arguments In Data Sources: User and Users documentation.
- Creates Tests on User and Users Data Sources  for validating support of on-prem
  SAM account names as reference arguments.
  Data source should be able to search users by on-prem SAM account name, the same way it's possible than by UPN or
  mail nickname.
- Refactor of DS Read method for both data sources.
- Users data source also exports onpremises_sam_account_names.

Note: Haven't confirmed the status of the tests, please advice if correct and complete. The value for the on-prem SAM account name for the test users is unknown to me.
