### PR TITLE
Bump provider version in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.0.0"
+      version = "~> 2.15.0"
     }
   }
 }


### PR DESCRIPTION
I found there were some resources that didn't work as the docs stated when I had my required provider version set to "~> 2.0.0"