### PR TITLE
Add Resources for Claims Mapping Policy Management

### DIFF
--- a/docs/resources/claims_mapping_policy.md
+++ b/docs/resources/claims_mapping_policy.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Policies"
+---
+
+# Resource: claims_mapping_policy
+
+Manages a Claims Mapping Policy within Azure Active Directory.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application roles: `Policy.ReadWrite.ApplicationConfiguration` 
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Application Administrator` or `Global Administrator`
+
+## Example Usage
+
+```terraform
+resource "azuread_claims_mapping_policy" "test" {
+  definition = [
+    jsonencode(
+      {
+        ClaimsMappingPolicy = {
+          ClaimsSchema = [
+            {
+              ID            = "employeeid"
+              JwtClaimType  = "name"
+              SamlClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+              Source        = "user"
+            },
+            {
+              ID            = "tenantcountry"
+              JwtClaimType  = "country"
+              SamlClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country"
+              Source        = "company"
+            }
+          ]
+          IncludeBasicClaimSet = "true"
+          Version              = 1
+        }
+      }
+    ),
+  ]
+  description  = "hcl-created-policy"
+  display_name = "hcl-create-policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `definition` - (Required) The claims mapping policy. This is a JSON formatted
+  string, for which the [`jsonencode()` function](https://www.terraform.io/language/functions/jsonencode)
+  can be used.
+* `description` - (Required) The description for this Claims Mapping Policy.
+* `display_name` - (Required) The friendly name for this Claims Mapping Policy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Claims Mapping Policy.
+
+## Import
+
+Claims Mapping Policy can be imported using the `id`, e.g.
+
+```shell
+terraform import azuread_claims_mapping_policy.id 00000000-0000-0000-0000-000000000000
+```

--- a/docs/resources/claims_mapping_policy_assignment.md
+++ b/docs/resources/claims_mapping_policy_assignment.md
@@ -1,0 +1,46 @@
+
+---
+subcategory: "Policies"
+---
+
+# Resource: claims_mapping_policy_assignment
+
+Manages a Claims Mapping Policy Assignment within Azure Active Directory.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application roles: `Policy.ReadWrite.ApplicationConfiguration` 
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Application Administrator` or `Global Administrator`
+
+## Example Usage
+
+```terraform
+resource "azuread_claims_mapping_policy_assignment" "app" {
+  claims_mapping_policy_id = azuread_claims_mapping_policy.my_policy.id
+  service_principal_id     = azuread_service_principal.my_principal.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `claims_mapping_policy_id` - (Required) The `id` of the claims mapping policy to assign.
+* `service_principal_id` - (Required) The `id` of the service principal for the policy assignment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Claims Mapping Policy Assignment.
+
+## Import
+
+Claims Mapping Policy can be imported using the `id`, in the form `service-principal-uuid/azuread_claims_mapping_policy/claims-mapping-policy-uuid`, e.g:
+
+```shell
+terraform import azuread_claims_mapping_policy_assignment.app 00000000-0000-0000-0000-000000000000/azuread_claims_mapping_policy/00000000-0000-0000-0000-000000000000
+```

--- a/internal/services/serviceprincipals/client/client.go
+++ b/internal/services/serviceprincipals/client/client.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Client struct {
+	ClaimsMappingPolicyClient       *msgraph.ClaimsMappingPolicyClient
 	DelegatedPermissionGrantsClient *msgraph.DelegatedPermissionGrantsClient
 	DirectoryObjectsClient          *msgraph.DirectoryObjectsClient
 	ServicePrincipalsClient         *msgraph.ServicePrincipalsClient
@@ -22,9 +23,13 @@ func NewClient(o *common.ClientOptions) *Client {
 	servicePrincipalsClient := msgraph.NewServicePrincipalsClient(o.TenantID)
 	o.ConfigureClient(&servicePrincipalsClient.BaseClient)
 
+	claimsMappingPolicyClient := msgraph.NewClaimsMappingPolicyClient(o.TenantID)
+	o.ConfigureClient(&claimsMappingPolicyClient.BaseClient)
+
 	return &Client{
 		DelegatedPermissionGrantsClient: delegatedPermissionGrantsClient,
 		DirectoryObjectsClient:          directoryObjectsClient,
 		ServicePrincipalsClient:         servicePrincipalsClient,
+		ClaimsMappingPolicyClient:       claimsMappingPolicyClient,
 	}
 }

--- a/internal/services/serviceprincipals/parse/claims_mapping_policy_assignment.go
+++ b/internal/services/serviceprincipals/parse/claims_mapping_policy_assignment.go
@@ -1,0 +1,30 @@
+package parse
+
+import "fmt"
+
+type ClaimsMappingPolicyAssignmentId struct {
+	ObjectSubResourceId
+	ServicePolicyId       string
+	ClaimsMappingPolicyId string
+}
+
+func NewClaimsMappingPolicyAssignmentID(ServicePolicyId, ClaimsMappingPolicyId string) ClaimsMappingPolicyAssignmentId {
+	return ClaimsMappingPolicyAssignmentId{
+		ObjectSubResourceId:   NewObjectSubResourceID(ServicePolicyId, "azuread_claims_mapping_policy", ClaimsMappingPolicyId),
+		ServicePolicyId:       ServicePolicyId,
+		ClaimsMappingPolicyId: ClaimsMappingPolicyId,
+	}
+}
+
+func ClaimsMappingPolicyAssignmentID(idString string) (*ClaimsMappingPolicyAssignmentId, error) {
+	id, err := ObjectSubResourceID(idString, "azuread_claims_mapping_policy")
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse azuread_claims_mapping_policy ID: %v", err)
+	}
+
+	return &ClaimsMappingPolicyAssignmentId{
+		ObjectSubResourceId:   *id,
+		ServicePolicyId:       id.objectId,
+		ClaimsMappingPolicyId: id.subId,
+	}, nil
+}

--- a/internal/services/serviceprincipals/registration.go
+++ b/internal/services/serviceprincipals/registration.go
@@ -30,6 +30,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
+		"azuread_claims_mapping_policy":                        servicePrincipalClaimsMappingPolicy(),
 		"azuread_service_principal":                            servicePrincipalResource(),
 		"azuread_service_principal_certificate":                servicePrincipalCertificateResource(),
 		"azuread_service_principal_delegated_permission_grant": servicePrincipalDelegatedPermissionGrantResource(),

--- a/internal/services/serviceprincipals/registration.go
+++ b/internal/services/serviceprincipals/registration.go
@@ -31,6 +31,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azuread_claims_mapping_policy":                        servicePrincipalClaimsMappingPolicy(),
+		"azuread_claims_mapping_policy_assignment":             servicePrincipalClaimsMappingPolicyAssignment(),
 		"azuread_service_principal":                            servicePrincipalResource(),
 		"azuread_service_principal_certificate":                servicePrincipalCertificateResource(),
 		"azuread_service_principal_delegated_permission_grant": servicePrincipalDelegatedPermissionGrantResource(),

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy.go
@@ -1,0 +1,162 @@
+package serviceprincipals
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func servicePrincipalClaimsMappingPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: servicePrincipalClaimsMappingPolicyResourceCreate,
+		ReadContext:   servicePrincipalClaimsMappingPolicyResourceRead,
+		UpdateContext: servicePrincipalClaimsMappingPolicyResourceUpdate,
+		DeleteContext: servicePrincipalClaimsMappingPolicyResourceDelete,
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			if _, err := uuid.ParseUUID(id); err != nil {
+				return fmt.Errorf("specified ID (%q) is not valid: %s", id, err)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "Unique identifier for this policy",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
+			"definition": {
+				Description: "A string collection containing a JSON string " +
+					"that defines the rules and settings for this policy.",
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"display_name": {
+				Description: "Display name for this policy",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			"description": {
+				Description: "Description for this policy",
+				Optional:    true,
+				Type:        schema.TypeString,
+				Required:    false,
+			},
+		},
+	}
+}
+
+func servicePrincipalClaimsMappingPolicyResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ClaimsMappingPolicyClient
+	var definitions []string
+	for _, v := range d.Get("definition").([]interface{}) {
+		definitions = append(definitions, v.(string))
+	}
+
+	displayName := d.Get("display_name").(string)
+
+	claimsMappingPolicy := msgraph.ClaimsMappingPolicy{
+		Definition:  &definitions,
+		DisplayName: &displayName,
+	}
+	policy, _, err := client.Create(ctx, claimsMappingPolicy)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Could not create ClaimsMappingPolicy %q", displayName)
+	}
+
+	if policy != nil {
+		d.SetId(*policy.ID)
+	}
+
+	return servicePrincipalClaimsMappingPolicyResourceRead(ctx, d, meta)
+}
+
+func servicePrincipalClaimsMappingPolicyResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ClaimsMappingPolicyClient
+	objectId := d.Id()
+
+	policy, status, err := client.Get(ctx, objectId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Claims Mapping Policy with Object ID %q was not found - removing from state!", objectId)
+			d.SetId("")
+			return nil
+		}
+
+		return tf.ErrorDiagF(err, "retrieving Claims Mapping Policy with object ID: %q", d.Id())
+	}
+
+	tf.Set(d, "id", policy.ID)
+	tf.Set(d, "definition", policy.Definition)
+	tf.Set(d, "display_name", policy.DisplayName)
+
+	return nil
+}
+
+func servicePrincipalClaimsMappingPolicyResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ClaimsMappingPolicyClient
+	objectId := d.Id()
+
+	var definitions []string
+	for _, v := range d.Get("definition").([]interface{}) {
+		definitions = append(definitions, v.(string))
+	}
+
+	displayName := d.Get("display_name").(string)
+
+	claimsMappingPolicy := msgraph.ClaimsMappingPolicy{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: &objectId,
+		},
+		Definition:  &definitions,
+		DisplayName: &displayName,
+	}
+	_, err := client.Update(ctx, claimsMappingPolicy)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Could not update ClaimsMappingPolicy %q", displayName)
+	}
+
+	return servicePrincipalClaimsMappingPolicyResourceRead(ctx, d, meta)
+}
+
+func servicePrincipalClaimsMappingPolicyResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ClaimsMappingPolicyClient
+	objectId := d.Id()
+
+	_, status, err := client.Get(ctx, objectId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return tf.ErrorDiagPathF(
+				fmt.Errorf(
+					"Claims Mapping Policy was not found"),
+				"id", "Retrieving Claims Mapping Policy with object ID %q",
+				objectId,
+			)
+		}
+
+		return tf.ErrorDiagPathF(err, "id", "Retrieving Claims Mapping Policy with object ID %q", objectId)
+	}
+
+	status, err = client.Delete(ctx, objectId)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Deleting Claims Mapping Policy with object ID %q, received status %d", objectId, status)
+	}
+
+	return nil
+}

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment.go
@@ -1,0 +1,155 @@
+package serviceprincipals
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func servicePrincipalClaimsMappingPolicyAssignment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: servicePrincipalClaimsMappingPolicyAssignmentResourceCreate,
+		ReadContext:   servicePrincipalClaimsMappingPolicyAssignmentResourceRead,
+		DeleteContext: servicePrincipalClaimsMappingPolicyAssignmentResourceDelete,
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ObjectSubResourceID(id, "azuread_claims_mapping_policy")
+			return err
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"claims_mapping_policy_id": {
+				Description: "ID of the claims mapping policy to assign",
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			"service_principal_id": {
+				Description: "ID of the service principal to assign the policy to",
+				ForceNew:    true,
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func servicePrincipalClaimsMappingPolicyAssignmentResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	spClient := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
+	policyClient := meta.(*clients.Client).ServicePrincipals.ClaimsMappingPolicyClient
+
+	policyID := d.Get("claims_mapping_policy_id").(string)
+	policy, _, err := policyClient.Get(ctx, policyID, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(
+			err,
+			"Could not find ClaimsMappingPolicy, claims_mapping_policy_id: %q",
+			policyID,
+		)
+	}
+
+	properties := msgraph.ServicePrincipal{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: utils.String(d.Get("service_principal_id").(string)),
+		},
+		ClaimsMappingPolicies: &[]msgraph.ClaimsMappingPolicy{
+			*policy,
+		},
+	}
+	_, err = spClient.AssignClaimsMappingPolicy(ctx, &properties)
+	if err != nil {
+		return tf.ErrorDiagF(
+			err,
+			"Could not create ClaimsMappingPolicyAssignment, service_principal_id: %q, claims_mapping_policy_id: %q",
+			*properties.DirectoryObject.ID,
+			*(*properties.ClaimsMappingPolicies)[0].DirectoryObject.ID,
+		)
+	}
+
+	resourceID := parse.NewClaimsMappingPolicyAssignmentID(
+		*properties.DirectoryObject.ID,
+		*(*properties.ClaimsMappingPolicies)[0].DirectoryObject.ID,
+	)
+
+	d.SetId(resourceID.String())
+
+	return servicePrincipalClaimsMappingPolicyAssignmentResourceRead(ctx, d, meta)
+}
+
+func servicePrincipalClaimsMappingPolicyAssignmentResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
+
+	id, err := parse.ClaimsMappingPolicyAssignmentID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing Claims Mapping Policy Assignment ID %q", d.Id())
+	}
+
+	spID := id.ServicePolicyId
+
+	policyList, status, err := client.ListClaimsMappingPolicy(ctx, spID)
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Service Principal with Object ID %q was not found - removing claims mapping policy assignment from state!", spID)
+			d.SetId("")
+			return nil
+		}
+
+		return tf.ErrorDiagF(err, "listing Claims Mapping Policy Assignments for Service Principal with object ID: %q", d.Id())
+	}
+
+	policyID := id.ClaimsMappingPolicyId
+	var foundPolicy *msgraph.ClaimsMappingPolicy
+
+	// Check the assignment is found in the currently assigned policies
+	for _, policy := range *policyList {
+		if *policy.ID == policyID {
+			foundPolicy = &policy
+			break
+		}
+	}
+	if foundPolicy == nil {
+		d.SetId("")
+		log.Printf("[DEBUG] Claims Mapping Policy with Object ID %q was not found - removing assignment from state!", policyID)
+		return nil
+	}
+
+	tf.Set(d, "service_principal_id", spID)
+	tf.Set(d, "claims_mapping_policy_id", policyID)
+
+	return nil
+}
+
+func servicePrincipalClaimsMappingPolicyAssignmentResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
+
+	id, err := parse.ClaimsMappingPolicyAssignmentID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing Claims Mapping Policy Assignment ID %q", d.Id())
+	}
+
+	claimIDs := []string{id.ClaimsMappingPolicyId}
+
+	spID := id.ServicePolicyId
+
+	sp := msgraph.ServicePrincipal{
+		DirectoryObject: msgraph.DirectoryObject{
+			ID: &spID,
+		},
+	}
+	_, err = client.RemoveClaimsMappingPolicy(ctx, &sp, &claimIDs)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Could not Remove ClaimsMappingPolicyAssignment, service_principal_id: %q, claims_mapping_policy_ids: %q", spID, claimIDs)
+	}
+
+	return servicePrincipalClaimsMappingPolicyAssignmentResourceRead(ctx, d, meta)
+}

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_test.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_test.go
@@ -1,0 +1,114 @@
+package serviceprincipals_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+)
+
+type ServicePrincipalClaimsMappingPolicyAssignment struct{}
+
+func TestClaimsMappingPolicyAssignment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_claims_mapping_policy_assignment", "test")
+	mappingPolicy := acceptance.TestData{
+		ResourceName: "azuread_claims_mapping_policy.test2",
+	}
+	r := ServicePrincipalClaimsMappingPolicyAssignment{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicClaimsMappingPolicyAssignment(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateClaimsMappingPolicyAssignment(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key(
+					"claims_mapping_policy_id",
+				).MatchesOtherKey(
+					check.That(mappingPolicy.ResourceName).Key(
+						"id",
+					),
+				),
+			),
+		},
+	})
+}
+
+func (ServicePrincipalClaimsMappingPolicyAssignment) basicClaimsMappingPolicyAssignment(data acceptance.TestData) string {
+	c := ServicePrincipalClaimsMappingPolicy{}
+	return c.basicClaimsMappingPolicy(data) + `
+	data "azuread_application_published_app_ids" "well_known" {}
+	
+	resource "azuread_service_principal" "msgraph" {
+	  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+	  use_existing   = true
+	}
+	resource "azuread_claims_mapping_policy_assignment" "test" {
+	  service_principal_id     = azuread_service_principal.msgraph.id
+	  claims_mapping_policy_id = azuread_claims_mapping_policy.test.id
+	}
+	`
+}
+
+func (ServicePrincipalClaimsMappingPolicyAssignment) updateClaimsMappingPolicyAssignment(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+	provider "azuread" {}
+
+	data "azuread_application_published_app_ids" "well_known" {}
+
+	resource "azuread_service_principal" "msgraph" {
+	  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+	  use_existing   = true
+	}
+
+	resource "azuread_claims_mapping_policy" "test2" {
+	  definition = [
+		  "{\"ClaimsMappingPolicy\":{\"Version\":1,\"IncludeBasicClaimSet\":\"false\",\"ClaimsSchema\": [{\"Source\":\"user\",\"ID\":\"employeeid\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"JwtClaimType\":\"name\"},{\"Source\":\"company\",\"ID\":\"tenantcountry\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country\",\"JwtClaimType\":\"country\"}]}}"
+	  ]
+	  description = "%[1]s"
+	  display_name = "integration-%[1]s"
+	}
+
+	resource "azuread_claims_mapping_policy_assignment" "test" {
+	  service_principal_id     = azuread_service_principal.msgraph.id
+	  claims_mapping_policy_id = azuread_claims_mapping_policy.test2.id
+	}
+`, data.RandomString)
+}
+
+func (r ServicePrincipalClaimsMappingPolicyAssignment) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.ServicePrincipals.ServicePrincipalsClient
+	client.BaseClient.DisableRetries = true
+
+	spID := state.Attributes["service_principal_id"]
+	policyList, status, err := client.ListClaimsMappingPolicy(ctx, spID)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return utils.Bool(false), fmt.Errorf("Service Policy with object ID %q does not exist", spID)
+		}
+		return utils.Bool(false), fmt.Errorf("failed to retrieve claims mapping policy assignments with service policy ID %q: %+v", spID, err)
+	}
+
+	policyID := state.Attributes["claims_mapping_policy_id"]
+
+	// Check the assignment is found in the currently assigned policies
+	for _, policy := range *policyList {
+		if *policy.ID == policyID {
+			return utils.Bool(true), nil
+		}
+	}
+	return utils.Bool(false), nil
+}

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy_test.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy_test.go
@@ -1,0 +1,85 @@
+package serviceprincipals_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/manicminer/hamilton/odata"
+)
+
+type ServicePrincipalClaimsMappingPolicy struct{}
+
+func TestClaimsMappingPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_claims_mapping_policy", "test")
+	r := ServicePrincipalClaimsMappingPolicy{}
+	updatedRegex, _ := regexp.Compile(`updated`)
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicClaimsMappingPolicy(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.updateClaimsMappingPolicy(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").MatchesRegex(updatedRegex),
+			),
+		},
+	})
+}
+
+func (ServicePrincipalClaimsMappingPolicy) basicClaimsMappingPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_claims_mapping_policy" "test" {
+  definition = [
+	  "{\"ClaimsMappingPolicy\":{\"Version\":1,\"IncludeBasicClaimSet\":\"false\",\"ClaimsSchema\": [{\"Source\":\"user\",\"ID\":\"employeeid\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"JwtClaimType\":\"name\"},{\"Source\":\"company\",\"ID\":\"tenantcountry\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country\",\"JwtClaimType\":\"country\"}]}}"
+  ]
+  description = "%[1]s"
+  display_name = "integration-%[1]s"
+}
+`, data.RandomString)
+}
+
+func (ServicePrincipalClaimsMappingPolicy) updateClaimsMappingPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_claims_mapping_policy" "test" {
+  definition = [
+	  "{\"ClaimsMappingPolicy\":{\"Version\":1,\"IncludeBasicClaimSet\":\"true\",\"ClaimsSchema\": [{\"Source\":\"user\",\"ID\":\"employeeid\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name\",\"JwtClaimType\":\"name\"},{\"Source\":\"company\",\"ID\":\"tenantcountry\",\"SamlClaimType\":\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country\",\"JwtClaimType\":\"country\"}]}}"
+  ]
+  description = "%[1]s updated"
+  display_name = "integration-%[1]s-updated"
+}
+`, data.RandomString)
+}
+
+func (r ServicePrincipalClaimsMappingPolicy) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.ServicePrincipals.ClaimsMappingPolicyClient
+	client.BaseClient.DisableRetries = true
+
+	exists := false
+	_, status, err := client.Get(ctx, state.ID, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return nil, fmt.Errorf("Claims mapping policy with object ID %q does not exist", state.ID)
+		}
+		return &exists, fmt.Errorf("failed to retrieve claims mapping policy with object ID %q: %+v", state.ID, err)
+	}
+
+	exists = true
+	return &exists, nil
+}


### PR DESCRIPTION
Adds support for the claims mapping policy and claims mapping policy assignment resources so these can be
managed with Terraform. This depends on the hamilton sdk support being merged first and then this branch can be updated with the correct vendor dependencies.

Related to:
- https://github.com/manicminer/hamilton/pull/147
- https://github.com/hashicorp/terraform-provider-azuread/issues/644
- https://docs.microsoft.com/en-us/graph/api/resources/claimsmappingpolicy?view=graph-rest-1.0
- https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-claimsmappingpolicies?view=graph-rest-1.0&tabs=http