### PR TITLE
azuread_conditional_access_policy: make platform and location optional, require one of included_applications or included_user_actions

### DIFF
--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -76,8 +76,9 @@ func conditionalAccessPolicyResource() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"included_applications": {
-										Type:     schema.TypeList,
-										Required: true,
+										Type:         schema.TypeList,
+										Optional:     true,
+										AtLeastOneOf: []string{"conditions.0.applications.0.included_applications", "conditions.0.applications.0.included_user_actions"},
 										Elem: &schema.Schema{
 											Type:             schema.TypeString,
 											ValidateDiagFunc: validate.NoEmptyStrings,
@@ -94,8 +95,9 @@ func conditionalAccessPolicyResource() *schema.Resource {
 									},
 
 									"included_user_actions": {
-										Type:     schema.TypeList,
-										Optional: true,
+										Type:         schema.TypeList,
+										Optional:     true,
+										AtLeastOneOf: []string{"conditions.0.applications.0.included_applications", "conditions.0.applications.0.included_user_actions"},
 										Elem: &schema.Schema{
 											Type:             schema.TypeString,
 											ValidateDiagFunc: validate.NoEmptyStrings,

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -222,7 +222,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 
 						"locations": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -249,7 +249,7 @@ func conditionalAccessPolicyResource() *schema.Resource {
 
 						"platforms": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -288,7 +288,7 @@ func expandConditionalAccessUsers(in []interface{}) *msgraph.ConditionalAccessUs
 func expandConditionalAccessPlatforms(in []interface{}) *msgraph.ConditionalAccessPlatforms {
 	result := msgraph.ConditionalAccessPlatforms{}
 	if len(in) == 0 || in[0] == nil {
-		return &result
+		return nil
 	}
 
 	config := in[0].(map[string]interface{})


### PR DESCRIPTION
This PR resolves two outstanding issues:
* The platform and location conditions should be optional rather than required - they aren't required by MSFT upstream.
* The application condition should require one of included_applications or included_user_actions, rather than requiring included_applications

With these two fixes, the azuread_conditional_access_policy resource can be used to recreate all eight of the [conditional access templates in the Identity category](https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/concept-conditional-access-policy-common).

Fixes #708 and #774 