### PR TITLE
`data.azuread_groups` - support the `ignore_missing` property

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -60,9 +60,10 @@ The following arguments are supported:
 
 * `display_names` - (Optional) The display names of the groups.
 * `display_name_prefix` - (Optional) A common display name prefix to match when returning groups.
+* `ignore_missing` - (Optional) Ignore missing groups and return groups that were found. The data source will still fail if no groups are found. Cannot be specified with `return_all`. Defaults to `false`.
 * `mail_enabled` - (Optional) Whether the returned groups should be mail-enabled. By itself this does not exclude security-enabled groups. Setting this to `true` ensures all groups are mail-enabled, and setting to `false` ensures that all groups are _not_ mail-enabled. To ignore this filter, omit the property or set it to null. Cannot be specified together with `object_ids`.
 * `object_ids` - (Optional) The object IDs of the groups.
-* `return_all` - (Optional) A flag to denote if all groups should be fetched and returned.
+* `return_all` - (Optional) A flag to denote if all groups should be fetched and returned. Cannot be specified wth `ignore_missing`. Defaults to `false`.
 * `security_enabled` - (Optional) Whether the returned groups should be security-enabled. By itself this does not exclude mail-enabled groups. Setting this to `true` ensures all groups are security-enabled, and setting to `false` ensures that all groups are _not_ security-enabled. To ignore this filter, omit the property or set it to null. Cannot be specified together with `object_ids`.
 
 ~> One of `display_names`, `display_name_prefix`, `object_ids` or `return_all` should be specified. Either `display_name` or `object_ids` _may_ be specified as an empty list, in which case no results will be returned.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -26,10 +26,10 @@ data "azuread_users" "users" {
 
 The following arguments are supported:
 
-* `ignore_missing` - (Optional) Ignore missing users and return users that were found. The data source will still fail if no users are found. Defaults to false.
+* `ignore_missing` - (Optional) Ignore missing users and return users that were found. The data source will still fail if no users are found. Cannot be specified with `return_all`. Defaults to `false`.
 * `mail_nicknames` - (Optional) The email aliases of the users.
 * `object_ids` - (Optional) The object IDs of the users.
-* `return_all` - (Optional) When `true`, the data source will return all users. Cannot be used with `ignore_missing`. Defaults to false.
+* `return_all` - (Optional) When `true`, the data source will return all users. Cannot be used with `ignore_missing`. Defaults to `false`.
 * `user_principal_names` - (Optional) The user principal names (UPNs) of the users.
 
 ~> Either `return_all`, or one of `user_principal_names`, `object_ids` or `mail_nicknames` must be specified. These _may_ be specified as an empty list, in which case no results will be returned.

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -34,6 +34,22 @@ func TestAccGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccGroup_basicUnified(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group", "test")
+	r := GroupResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicUnified(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccGroup_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_group", "test")
 	r := GroupResource{}
@@ -463,6 +479,18 @@ func (GroupResource) basic(data acceptance.TestData) string {
 resource "azuread_group" "test" {
   display_name     = "acctestGroup-%[1]d"
   security_enabled = true
+}
+`, data.RandomInteger)
+}
+
+func (GroupResource) basicUnified(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctestGroup-%[1]d"
+  security_enabled = false
 }
 `, data.RandomInteger)
 }


### PR DESCRIPTION
Also adds a workaround for an API bug involving group descriptions.

Fixes: #776
Fixes: #782
