### PR TITLE
Fixed overly restrictive validation for federated cred audience vals

### DIFF
--- a/internal/services/applications/application_federated_identity_credential_resource.go
+++ b/internal/services/applications/application_federated_identity_credential_resource.go
@@ -57,7 +57,7 @@ func applicationFederatedIdentityCredentialResource() *schema.Resource {
 				Required:    true,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
-					ValidateDiagFunc: validate.IsAppUri,
+					ValidateDiagFunc: validate.ValidateDiag(validation.StringIsNotEmpty),
 				},
 			},
 


### PR DESCRIPTION
Current audicence field parsing validates that the values are URIs. This is not a requirement for audience fields though. JWT spec allows these to be URIs or strings (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)