### PR TITLE
New resource: `azuread_directory_role_assignment`

### DIFF
--- a/docs/resources/directory_role_assignment.md
+++ b/docs/resources/directory_role_assignment.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Directory Roles"
+---
+
+# Resource: azuread_directory_role_assignment
+
+Manages a single directory role assignment within Azure Active Directory.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires one of the following application roles: `RoleManagement.ReadWrite.Directory` or `Directory.ReadWrite.All`
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Privileged Role Administrator` or `Global Administrator`
+
+## Example Usage
+
+*Assignment for a built-in role*
+
+```terraform
+data "azuread_user" "example" {
+  user_principal_name = "jdoe@hashicorp.com"
+}
+
+resource "azuread_directory_role" "example" {
+  display_name = "Security administrator"
+}
+
+resource "azuread_directory_role_assignment" "example" {
+  role_id             = azuread_directory_role.example.template_id
+  principal_object_id = data.azuread_user.example.object_id
+}
+```
+
+~> Note the use of the `template_id` attribute when referencing built-in roles.
+
+*Assignment for a custom role*
+
+```terraform
+data "azuread_user" "example" {
+  user_principal_name = "jdoe@hashicorp.com"
+}
+
+resource "azuread_custom_directory_role" "example" {
+  display_name = "My Custom Role"
+  enabled      = true
+  version      = "1.0"
+
+  permissions {
+    allowed_resource_actions = [
+      "microsoft.directory/applications/basic/update",
+      "microsoft.directory/applications/standard/read",
+    ]
+  }
+}
+
+resource "azuread_directory_role_assignment" "example" {
+  role_id             = azuread_custom_directory_role.example.object_id
+  principal_object_id = data.azuread_user.example.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app_scope_object_id` - (Optional) Identifier of the app-specific scope when the assignment scope is app-specific. Cannot be used with `directory_scope_object_id`. Changing this forces a new resource to be created.
+* `directory_scope_object_id` - (Optional) The object ID of a directory object representing the scope of the assignment. Cannot be used with `app_scope_object_id`. Changing this forces a new resource to be created.
+* `principal_object_id` - (Required) The object ID of the principal for you want to create a role assignment. Supported object types are Users, Groups or Service Principals. Changing this forces a new resource to be created.
+* `role_id` - (Required) The template ID (in the case of built-in roles) or object ID (in the case of custom roles) of the directory role you want to assign. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+*No additional attributes are exported*
+
+## Import
+
+Directory role assignments can be imported using the ID of the assignment, e.g.
+
+```shell
+terraform import azuread_directory_role_assignment.test ePROZI_iKE653D_d6aoLHyr-lKgHI8ZGiIdz8CLVcng-1
+```

--- a/docs/resources/directory_role_member.md
+++ b/docs/resources/directory_role_member.md
@@ -6,6 +6,8 @@ subcategory: "Directory Roles"
 
 Manages a single directory role membership (assignment) within Azure Active Directory.
 
+-> **Deprecation Warning:** This resource has been superseded by the [azuread_directory_role_assignment](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role_assignment) resource and will be removed in version 3.0 of the AzureAD provider
+
 ## API Permissions
 
 The following API permissions are required in order to use this resource.

--- a/internal/services/directoryroles/client/client.go
+++ b/internal/services/directoryroles/client/client.go
@@ -1,15 +1,15 @@
 package client
 
 import (
-	"github.com/manicminer/hamilton/msgraph"
-
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+	"github.com/manicminer/hamilton/msgraph"
 )
 
 type Client struct {
 	DirectoryObjectsClient       *msgraph.DirectoryObjectsClient
 	DirectoryRolesClient         *msgraph.DirectoryRolesClient
 	DirectoryRoleTemplatesClient *msgraph.DirectoryRoleTemplatesClient
+	RoleAssignmentsClient        *msgraph.RoleAssignmentsClient
 	RoleDefinitionsClient        *msgraph.RoleDefinitionsClient
 }
 
@@ -23,6 +23,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	directoryRoleTemplatesClient := msgraph.NewDirectoryRoleTemplatesClient(o.TenantID)
 	o.ConfigureClient(&directoryRoleTemplatesClient.BaseClient)
 
+	roleAssignmentsClient := msgraph.NewRoleAssignmentsClient(o.TenantID)
+	o.ConfigureClient(&roleAssignmentsClient.BaseClient)
+
 	roleDefinitionsClient := msgraph.NewRoleDefinitionsClient(o.TenantID)
 	o.ConfigureClient(&roleDefinitionsClient.BaseClient)
 
@@ -30,6 +33,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		DirectoryObjectsClient:       directoryObjectsClient,
 		DirectoryRolesClient:         directoryRolesClient,
 		DirectoryRoleTemplatesClient: directoryRoleTemplatesClient,
+		RoleAssignmentsClient:        roleAssignmentsClient,
 		RoleDefinitionsClient:        roleDefinitionsClient,
 	}
 }

--- a/internal/services/directoryroles/directory_role_assignment_resource.go
+++ b/internal/services/directoryroles/directory_role_assignment_resource.go
@@ -1,0 +1,181 @@
+package directoryroles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func directoryRoleAssignmentResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: directoryRoleAssignmentResourceCreate,
+		ReadContext:   directoryRoleAssignmentResourceRead,
+		DeleteContext: directoryRoleAssignmentResourceDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			if id == "" {
+				return errors.New("id was empty")
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"role_id": {
+				Description:      "The object ID of the directory role for this assignment",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"principal_object_id": {
+				Description:      "The object ID of the member principal",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"directory_scope_object_id": {
+				Description:      "The object ID of a directory object representing the scope of the assignment",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"app_scope_object_id"},
+				ValidateDiagFunc: validate.UUID,
+			},
+
+			"app_scope_object_id": {
+				Description:      "Identifier of the app-specific scope when the assignment scope is app-specific",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"directory_scope_object_id"},
+				ValidateDiagFunc: validate.UUID,
+			},
+		},
+	}
+}
+
+func directoryRoleAssignmentResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).DirectoryRoles.RoleAssignmentsClient
+
+	roleId := d.Get("role_id").(string)
+	memberId := d.Get("principal_object_id").(string)
+
+	directoryScopeId := d.Get("directory_scope_object_id").(string)
+	if directoryScopeId == "" {
+		directoryScopeId = "/"
+	}
+
+	properties := msgraph.UnifiedRoleAssignment{
+		DirectoryScopeId: &directoryScopeId,
+		PrincipalId:      &memberId,
+		RoleDefinitionId: &roleId,
+	}
+
+	appScopeId := d.Get("app_scope_object_id").(string)
+	if appScopeId != "" {
+		properties.AppScopeId = &appScopeId
+	}
+
+	assignment, status, err := client.Create(ctx, properties)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Adding role member %q to directory role %q, received %d with error: %+v", memberId, roleId, status, err)
+	}
+	if assignment == nil || assignment.ID == nil {
+		return tf.ErrorDiagF(errors.New("returned role assignment ID was nil"), "API Error")
+	}
+
+	d.SetId(*assignment.ID)
+
+	// Wait for role membership to reflect
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return tf.ErrorDiagF(errors.New("context has no deadline"), "Waiting for role member %q to reflect for directory role %q", memberId, roleId)
+	}
+	timeout := time.Until(deadline)
+	_, err = (&resource.StateChangeConf{
+		Pending:                   []string{"Waiting"},
+		Target:                    []string{"Done"},
+		Timeout:                   timeout,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Refresh: func() (interface{}, string, error) {
+			_, status, err := client.Get(ctx, *assignment.ID, odata.Query{})
+			if err != nil {
+				if status == http.StatusNotFound {
+					return "stub", "Waiting", nil
+				}
+				return nil, "Error", fmt.Errorf("retrieving role assignment")
+			}
+			return "stub", "Done", nil
+		},
+	}).WaitForStateContext(ctx)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Waiting for role assignment for %q to reflect in directory role %q", memberId, roleId)
+	}
+
+	return directoryRoleAssignmentResourceRead(ctx, d, meta)
+}
+
+func directoryRoleAssignmentResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).DirectoryRoles.RoleAssignmentsClient
+
+	id := d.Id()
+	assignment, status, err := client.Get(ctx, id, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Assignment with ID %q was not found - removing from state", id)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving role assignment %q", id)
+	}
+
+	directoryScopeId := assignment.DirectoryScopeId
+	if directoryScopeId == nil || *directoryScopeId == "/" {
+		directoryScopeId = utils.String("")
+	}
+
+	appScopeId := assignment.DirectoryScopeId
+	if appScopeId == nil || *appScopeId == "/" {
+		appScopeId = utils.String("")
+	}
+
+	tf.Set(d, "app_scope_object_id", appScopeId)
+	tf.Set(d, "directory_scope_object_id", directoryScopeId)
+	tf.Set(d, "principal_object_id", assignment.PrincipalId)
+	tf.Set(d, "role_id", assignment.RoleDefinitionId)
+
+	return nil
+}
+
+func directoryRoleAssignmentResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).DirectoryRoles.RoleAssignmentsClient
+
+	if _, err := client.Delete(ctx, d.Id()); err != nil {
+		return tf.ErrorDiagF(err, "Deleting role assignment %q: %+v", d.Id(), err)
+	}
+	return nil
+}

--- a/internal/services/directoryroles/directory_role_assignment_resource_test.go
+++ b/internal/services/directoryroles/directory_role_assignment_resource_test.go
@@ -1,0 +1,246 @@
+package directoryroles_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/odata"
+)
+
+type DirectoryRoleAssignmentResource struct{}
+
+func TestAccDirectoryRoleAssignment_servicePrincipal(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "test")
+	r := DirectoryRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.servicePrincipal(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_id").IsUuid(),
+				check.That(data.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDirectoryRoleAssignment_servicePrincipalWithCustomRole(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "test")
+	r := DirectoryRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.servicePrincipalCustomRole(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_id").IsUuid(),
+				check.That(data.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDirectoryRoleAssignment_user(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "testA")
+	r := DirectoryRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneUser(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_id").IsUuid(),
+				check.That(data.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDirectoryRoleAssignment_userWithCustomRole(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "testA")
+	r := DirectoryRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneUserCustomRole(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_id").IsUuid(),
+				check.That(data.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDirectoryRoleAssignment_multipleUser(t *testing.T) {
+	dataA := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "testA")
+	dataB := acceptance.BuildTestData(t, "azuread_directory_role_assignment", "testB")
+	r := DirectoryRoleAssignmentResource{}
+
+	dataA.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneUser(dataA),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(dataA.ResourceName).ExistsInAzure(r),
+				check.That(dataA.ResourceName).Key("role_id").IsUuid(),
+				check.That(dataA.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		dataA.ImportStep(),
+		{
+			Config: r.twoUsers(dataA),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(dataA.ResourceName).ExistsInAzure(r),
+				check.That(dataA.ResourceName).Key("role_id").IsUuid(),
+				check.That(dataA.ResourceName).Key("principal_object_id").IsUuid(),
+				check.That(dataB.ResourceName).ExistsInAzure(r),
+				check.That(dataB.ResourceName).Key("role_id").IsUuid(),
+				check.That(dataB.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		dataA.ImportStep(),
+		dataB.ImportStep(),
+		{
+			Config: r.oneUser(dataA),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(dataA.ResourceName).ExistsInAzure(r),
+				check.That(dataA.ResourceName).Key("role_id").IsUuid(),
+				check.That(dataA.ResourceName).Key("principal_object_id").IsUuid(),
+			),
+		},
+		dataA.ImportStep(),
+	})
+}
+
+func (r DirectoryRoleAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.DirectoryRoles.RoleAssignmentsClient
+	client.BaseClient.DisableRetries = true
+
+	if _, status, err := client.Get(ctx, state.ID, odata.Query{}); err != nil {
+		if status == http.StatusNotFound {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("failed to retrieve directory role assignment %q: %+v", state.ID, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (DirectoryRoleAssignmentResource) templateThreeUsers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "testA" {
+  user_principal_name = "acctestUser.%[1]d.A@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-A"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testB" {
+  user_principal_name = "acctestUser.%[1]d.B@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-B"
+  mail_nickname       = "acctestUser-%[1]d-B"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testC" {
+  user_principal_name = "acctestUser.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-C"
+  password            = "%[2]s"
+}
+`, data.RandomInteger, data.RandomPassword)
+}
+
+func (r DirectoryRoleAssignmentResource) servicePrincipal(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_application" "test" {
+  display_name = "acctestServicePrincipal-%[2]d"
+}
+
+resource "azuread_service_principal" "test" {
+  application_id = azuread_application.test.application_id
+}
+
+resource "azuread_directory_role_assignment" "test" {
+  role_id             = azuread_directory_role.test.template_id
+  principal_object_id = azuread_service_principal.test.object_id
+}
+`, DirectoryRoleResource{}.byTemplateId(data), data.RandomInteger)
+}
+
+func (r DirectoryRoleAssignmentResource) servicePrincipalCustomRole(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_application" "test" {
+  display_name = "acctestServicePrincipal-%[2]d"
+}
+
+resource "azuread_service_principal" "test" {
+  application_id = azuread_application.test.application_id
+}
+
+resource "azuread_directory_role_assignment" "test" {
+  role_id             = azuread_custom_directory_role.test.object_id
+  principal_object_id = azuread_service_principal.test.object_id
+}
+`, CustomDirectoryRoleResource{}.basic(data), data.RandomInteger)
+}
+
+func (r DirectoryRoleAssignmentResource) oneUser(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "azuread_directory_role_assignment" "testA" {
+  role_id             = azuread_directory_role.test.template_id
+  principal_object_id = azuread_user.testA.object_id
+}
+`, DirectoryRoleResource{}.byTemplateId(data), r.templateThreeUsers(data))
+}
+
+func (r DirectoryRoleAssignmentResource) oneUserCustomRole(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "azuread_directory_role_assignment" "testA" {
+  role_id             = azuread_custom_directory_role.test.object_id
+  principal_object_id = azuread_user.testA.object_id
+}
+`, CustomDirectoryRoleResource{}.basic(data), r.templateThreeUsers(data))
+}
+
+func (r DirectoryRoleAssignmentResource) twoUsers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "azuread_directory_role_assignment" "testA" {
+  role_id             = azuread_directory_role.test.template_id
+  principal_object_id = azuread_user.testA.object_id
+}
+
+resource "azuread_directory_role_assignment" "testB" {
+  role_id             = azuread_directory_role.test.template_id
+  principal_object_id = azuread_user.testB.object_id
+}
+`, DirectoryRoleResource{}.byTemplateId(data), r.templateThreeUsers(data))
+}

--- a/internal/services/directoryroles/directory_role_member_resource.go
+++ b/internal/services/directoryroles/directory_role_member_resource.go
@@ -42,6 +42,8 @@ func directoryRoleMemberResource() *schema.Resource {
 			return err
 		}),
 
+		DeprecationMessage: "This resource is deprecated and will be removed in version 3.0 of the AzureAD provider. Please use the `azuread_directory_role_assignment` resource instead.",
+
 		Schema: map[string]*schema.Schema{
 			"role_object_id": {
 				Description:      "The object ID of the directory role",

--- a/internal/services/directoryroles/registration.go
+++ b/internal/services/directoryroles/registration.go
@@ -26,8 +26,9 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azuread_custom_directory_role": customDirectoryRoleResource(),
-		"azuread_directory_role":        directoryRoleResource(),
-		"azuread_directory_role_member": directoryRoleMemberResource(),
+		"azuread_custom_directory_role":     customDirectoryRoleResource(),
+		"azuread_directory_role":            directoryRoleResource(),
+		"azuread_directory_role_assignment": directoryRoleAssignmentResource(),
+		"azuread_directory_role_member":     directoryRoleMemberResource(),
 	}
 }


### PR DESCRIPTION
This uses the newer "unified role assignment" endpoints to manage
directory role assignments for built-in roles and custom roles. Also
supports scoping via directory object IDs or apps.

Closes: #742