### PR TITLE
data.azuread_group: ensure security/mail enabled groups are excluded when explicitly `false` in config

### DIFF
--- a/internal/services/groups/group_data_source.go
+++ b/internal/services/groups/group_data_source.go
@@ -244,10 +244,10 @@ func groupDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	var mailEnabled, securityEnabled *bool
-	if v, exists := d.GetOkExists("mail_enabled"); exists {
+	if v, exists := d.GetOkExists("mail_enabled"); exists { //nolint:staticcheck // needed to detect unset booleans
 		mailEnabled = utils.Bool(v.(bool))
 	}
-	if v, exists := d.GetOkExists("security_enabled"); exists {
+	if v, exists := d.GetOkExists("security_enabled"); exists { //nolint:staticcheck // needed to detect unset booleans
 		securityEnabled = utils.Bool(v.(bool))
 	}
 

--- a/internal/services/groups/group_data_source.go
+++ b/internal/services/groups/group_data_source.go
@@ -244,10 +244,10 @@ func groupDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	var mailEnabled, securityEnabled *bool
-	if v, exists := d.GetOk("mail_enabled"); exists {
+	if v, exists := d.GetOkExists("mail_enabled"); exists {
 		mailEnabled = utils.Bool(v.(bool))
 	}
-	if v, exists := d.GetOk("security_enabled"); exists {
+	if v, exists := d.GetOkExists("security_enabled"); exists {
 		securityEnabled = utils.Bool(v.(bool))
 	}
 

--- a/internal/services/groups/group_data_source_test.go
+++ b/internal/services/groups/group_data_source_test.go
@@ -37,6 +37,19 @@ func TestAccGroupDataSource_byDisplayNameWithSecurity(t *testing.T) {
 	})
 }
 
+func TestAccGroupDataSource_byDisplayNameWithSecurityNotMail(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.displayNameSecurityNotMail(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
+
 func TestAccGroupDataSource_byCaseInsensitiveDisplayName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
 
@@ -153,10 +166,22 @@ func (GroupDataSource) displayNameSecurity(data acceptance.TestData) string {
 
 data "azuread_group" "test" {
   display_name     = azuread_group.test.display_name
-  mail_enabled     = false
   security_enabled = true
 }
 `, GroupResource{}.basic(data))
+}
+
+func (GroupDataSource) displayNameSecurityNotMail(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+data "azuread_group" "test" {
+  display_name     = azuread_group.test.display_name
+  mail_enabled     = false
+  security_enabled = true
+}
+`, GroupResource{}.basic(data), GroupResource{}.basicUnified(data))
 }
 
 func (GroupDataSource) caseInsensitiveDisplayName(data acceptance.TestData) string {

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -35,7 +35,7 @@ func TestAccGroup_basic(t *testing.T) {
 }
 
 func TestAccGroup_basicUnified(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azuread_group", "test")
+	data := acceptance.BuildTestData(t, "azuread_group", "test_unified")
 	r := GroupResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
@@ -485,7 +485,7 @@ resource "azuread_group" "test" {
 
 func (GroupResource) basicUnified(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-resource "azuread_group" "test" {
+resource "azuread_group" "test_unified" {
   display_name     = "acctestGroup-%[1]d"
   types            = ["Unified"]
   mail_enabled     = true


### PR DESCRIPTION
Fixes: #832