### PR TITLE
Add warning that OIDC auth only works in GitHub Actions

### DIFF
--- a/docs/guides/service_principal_oidc.md
+++ b/docs/guides/service_principal_oidc.md
@@ -17,7 +17,7 @@ We recommend using either a Service Principal or Managed Identity when running T
 
 Once you have configured a Service Principal as described in this guide, you should follow the [Configuring a Service Principal for managing Azure Active Directory](service_principal_configuration.html) guide to grant the Service Principal necessary permissions to create and modify Azure Active Directory objects such as users and groups.
 
-~> **Note:** WARNING: the current implementation of OIDC authentication only works in GitHub actions. A generic implementation where a token can be provided is being tracked in [this issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/16901)
+~> **Note:** The current implementation of OIDC authentication currently only works in GitHub actions.
 
 ---
 

--- a/docs/guides/service_principal_oidc.md
+++ b/docs/guides/service_principal_oidc.md
@@ -17,6 +17,8 @@ We recommend using either a Service Principal or Managed Identity when running T
 
 Once you have configured a Service Principal as described in this guide, you should follow the [Configuring a Service Principal for managing Azure Active Directory](service_principal_configuration.html) guide to grant the Service Principal necessary permissions to create and modify Azure Active Directory objects such as users and groups.
 
+~> **Note:** WARNING: the current implementation of OIDC authentication only works in GitHub actions. A generic implementation where a token can be provided is being tracked in [this issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/16901)
+
 ---
 
 ## Setting up an Application and Service Principal


### PR DESCRIPTION
Add a warning that the OIDC implementation is specific to GitHub actions and cannot be used in a generic way

This warning could then be removed once the work in #869 is done