### PR TITLE
Fix: [azuread_application] The 'type' parameter in 'oauth2_permission_scope' block is marked as Required but behaves as Optional #888

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -221,7 +221,7 @@ The following arguments are supported:
 
 -> **Tip: Generating a UUID for the `id` field** To generate a value for the `id` field in cases where the actual UUID is not important, you can use the `random_uuid` resource. See the [application example](https://github.com/hashicorp/terraform-provider-azuread/tree/main/examples/application) in the provider repository.
 
-* `type` - (Required) Whether this delegated permission should be considered safe for non-admin users to consent to on behalf of themselves, or whether an administrator should be required for consent to the permissions. Defaults to `User`. Possible values are `User` or `Admin`.
+* `type` - (Optional) Whether this delegated permission should be considered safe for non-admin users to consent to on behalf of themselves, or whether an administrator should be required for consent to the permissions. Defaults to `User`. Possible values are `User` or `Admin`.
 * `user_consent_description` - (Optional) Delegated permission description that appears in the end user consent experience, intended to be read by a user consenting on their own behalf.
 * `user_consent_display_name` - (Optional) Display name for the delegated permission that appears in the end user consent experience.
 * `value` - (Optional) The value that is used for the `scp` claim in OAuth 2.0 access tokens.


### PR DESCRIPTION

Fix issue #888 