### PR TITLE
Add support to manage access packages in identitygovernance

### DIFF
--- a/docs/data-sources/access_package.md
+++ b/docs/data-sources/access_package.md
@@ -3,12 +3,12 @@ subcategory: "Identity Governance"
 ---
 
 # Data Source: azuread_access_package
-Use this resource to retrieve information of existing access package.
+Use this resource to retrieve information of an existing access package.
 
 ## API Permissions
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this data source requires `Entitlement.Read.All` role.
+When authenticated with a service principal, this data source requires `EntitlementManagement.Read.All` role.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader`, `Access package manager` or `Global Administrator`.
 

--- a/docs/data-sources/access_package.md
+++ b/docs/data-sources/access_package.md
@@ -3,47 +3,51 @@ subcategory: "Identity Governance"
 ---
 
 # Data Source: azuread_access_package
-Use this resource to retrieve information of an existing access package.
+
+Use this data source to retrieve information for an existing access package within Identity Governance in Azure Active Directory.
 
 ## API Permissions
-The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this data source requires `EntitlementManagement.Read.All` role.
+The following API permissions are required in order to use this data source.
 
-When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader`, `Access package manager` or `Global Administrator`.
+When authenticated with a service principal, this data source requires one of the following application roles: `EntitlementManagement.Read.All`, or `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this data source requires one of the following directory roles: `Catalog owner`, `Catalog reader`, `Access package manager`, `Global Reader`, or `Global Administrator`.
 
 ## Example Usage
-By ID
 
-```
+*Look up by ID*
+
+```terraform
 data "azuread_access_package" "example" {
-  object_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  object_id = "00000000-0000-0000-0000-000000000000"
 }
 ```
 
-By DisplayName
+*Look up by DisplayName*
 
-```
+```terraform
 data "azuread_access_package" "example" {
+  catalog_id   = "00000000-0000-0000-0000-000000000000"
   display_name = "My access package Catalog"
-  catalog_id   = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 }
 ```
 
 ## Argument Reference
+
 The following arguments are supported:
 
-One of the `object_id` or combination of `display_name` and `catalog_id` must be specified
-
-* `object_id` - (Optional) The ID of this access package.
-* `display_name` - (Optional) The display name of the access package.
 * `catalog_id` - (Optional) The ID of the Catalog this access package is in.
+* `display_name` - (Optional) The display name of the access package.
+* `object_id` - (Optional) The ID of this access package.
+
+~> Either `object_id`, or both `catalog_id` and `display_name`, must be specified.
 
 
 ## Attributes Reference
+
 In addition to the above arguments, the following attributes are exported:
 
 * `id` - The ID of this resource.
 * `description` - The description of the access package.
-* `is_hidden` - Whether the access package is hidden from the requestor.
-
+* `hidden` - Whether the access package is hidden from the requestor.

--- a/docs/data-sources/access_package.md
+++ b/docs/data-sources/access_package.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Data Source: azuread_access_package
+Use this resource to retrieve information of existing access package.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this data source requires `Entitlement.Read.All` role.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader`, `Access package manager` or `Global Administrator`.
+
+## Example Usage
+By ID
+
+```
+data "azuread_access_package" "example" {
+  object_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+}
+```
+
+By DisplayName
+
+```
+data "azuread_access_package" "example" {
+  display_name = "My access package Catalog"
+  catalog_id   = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+One of the `object_id` or combination of `display_name` and `catalog_id` must be specified
+
+* `object_id` - (Optional) The ID of this access package.
+* `display_name` - (Optional) The display name of the access package.
+* `catalog_id` - (Optional) The ID of the Catalog this access package is in.
+
+
+## Attributes Reference
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The ID of this resource.
+* `description` - The description of the access package.
+* `is_hidden` - Whether the access package is hidden from the requestor.
+

--- a/docs/data-sources/access_package_catalog.md
+++ b/docs/data-sources/access_package_catalog.md
@@ -40,7 +40,7 @@ One of the `object_id` or `display_name` must be specified.
 
 
 ## Attributes Reference
-In additional to the arugments, the following attributes are exported:
+In additional to the arguments, the following attributes are exported:
 
 * `id` - The ID of this resource.
 * `description` - The description of the access package catalog.

--- a/docs/data-sources/access_package_catalog.md
+++ b/docs/data-sources/access_package_catalog.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Data Source: azuread_access_package_catalog
+Use this resource to retrieve information of existing access package catalog.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this data source requires `Entitlement.Read.All` role.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader` or `Global Administrator`.
+
+## Example Usage
+By ID
+
+```
+data "azuread_access_package_catalog" "example" {
+  object_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+}
+```
+
+By DisplayName
+
+```
+data "azuread_access_package_catalog" "example" {
+  display_name = "My access package Catalog"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+One of the `object_id` or `display_name` must be specified.
+
+* `object_id` - (Optional) The ID of this access package catalog.
+* `display_name` - (Optional) The display name of the access package catalog.
+
+
+## Attributes Reference
+In additional to the arugments, the following attributes are exported:
+
+* `id` - The ID of this resource.
+* `description` - The description of the access package catalog.
+* `is_externally_visible` - Whether the access packages in this catalog can be requested by users outside of the tenant.
+* `state` - Has the value published if the access packages are available for management. The possible values are: unpublished and published.
+

--- a/docs/data-sources/access_package_catalog.md
+++ b/docs/data-sources/access_package_catalog.md
@@ -3,12 +3,12 @@ subcategory: "Identity Governance"
 ---
 
 # Data Source: azuread_access_package_catalog
-Use this resource to retrieve information of existing access package catalog.
+Use this resource to retrieve information of an existing access package catalog.
 
 ## API Permissions
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this data source requires `Entitlement.Read.All` role.
+When authenticated with a service principal, this data source requires `EntitlementManagement.Read.All` role.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader` or `Global Administrator`.
 
@@ -33,7 +33,7 @@ data "azuread_access_package_catalog" "example" {
 
 The following arguments are supported:
 
-One of the `object_id` or `display_name` must be specified.
+One of the arguments `object_id` or `display_name` must be specified.
 
 * `object_id` - (Optional) The ID of this access package catalog.
 * `display_name` - (Optional) The display name of the access package catalog.
@@ -45,5 +45,5 @@ In additional to the arguments, the following attributes are exported:
 * `id` - The ID of this resource.
 * `description` - The description of the access package catalog.
 * `is_externally_visible` - Whether the access packages in this catalog can be requested by users outside of the tenant.
-* `state` - Has the value published if the access packages are available for management. The possible values are: unpublished and published.
+* `state` - Has the value published if the access package is available for management. The possible values are: unpublished and published.
 

--- a/docs/data-sources/access_package_catalog.md
+++ b/docs/data-sources/access_package_catalog.md
@@ -3,27 +3,30 @@ subcategory: "Identity Governance"
 ---
 
 # Data Source: azuread_access_package_catalog
-Use this resource to retrieve information of an existing access package catalog.
+i
+Use this resource to retrieve information for an existing access package catalog within Identity Governance in Azure Active Directory.
 
 ## API Permissions
-The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this data source requires `EntitlementManagement.Read.All` role.
+The following API permissions are required in order to use this data source.
 
-When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog reader` or `Global Administrator`.
+When authenticated with a service principal, this data source requires one of the following application roles: `EntitlementManagement.Read.All`, or `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this data source requires one of the following directory roles: `Catalog owner`, `Catalog reader`, `Global Reader`, or `Global Administrator`.
 
 ## Example Usage
-By ID
 
-```
+*Look up by ID*
+
+```terraform
 data "azuread_access_package_catalog" "example" {
-  object_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  object_id = "00000000-0000-0000-0000-000000000000"
 }
 ```
 
-By DisplayName
+*Look up by DisplayName*
 
-```
+```terraform
 data "azuread_access_package_catalog" "example" {
   display_name = "My access package Catalog"
 }
@@ -33,17 +36,17 @@ data "azuread_access_package_catalog" "example" {
 
 The following arguments are supported:
 
-One of the arguments `object_id` or `display_name` must be specified.
-
-* `object_id` - (Optional) The ID of this access package catalog.
 * `display_name` - (Optional) The display name of the access package catalog.
+* `object_id` - (Optional) The ID of this access package catalog.
 
+~> One of `display_name` or `object_id` must be specified.
 
 ## Attributes Reference
+
 In additional to the arguments, the following attributes are exported:
 
 * `id` - The ID of this resource.
 * `description` - The description of the access package catalog.
-* `is_externally_visible` - Whether the access packages in this catalog can be requested by users outside of the tenant.
-* `state` - Has the value published if the access package is available for management. The possible values are: unpublished and published.
+* `externally_visible` - Whether the access packages in this catalog can be requested by users outside the tenant.
+* `published` - Whether the access packages in this catalog are available for management.
 

--- a/docs/resources/access_package.md
+++ b/docs/resources/access_package.md
@@ -3,9 +3,11 @@ subcategory: "Identity Governance"
 ---
 
 # Resource: azuread_access_package
-Manages Access Packages within Identity Governance in Azure Active Directory.
+
+Manages an Access Package within Identity Governance in Azure Active Directory.
 
 ## API Permissions
+
 The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
@@ -14,18 +16,17 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
-```terraform
-provider "azuread" {}
 
+```terraform
 resource "azuread_access_package_catalog" "example" {
   display_name = "example-catalog"
   description  = "Example catalog"
 }
 
 resource "azuread_access_package" "example" {
+  catalog_id   = azuread_access_package_catalog.example.id
   display_name = "access-package"
   description  = "Access Package"
-  catalog_id   = azuread_access_package_catalog.example.id
 }
 ```
 
@@ -34,7 +35,7 @@ resource "azuread_access_package" "example" {
 * `catalog_id` - (Required) The ID of the Catalog this access package will be created in.
 * `description` - (Required) The description of the access package.
 * `display_name` - (Required) The display name of the access package.
-* `is_hidden` - (Optional) Whether the access package is hidden from the requestor.
+* `hidden` - (Optional) Whether the access package is hidden from the requestor.
 
 ## Attributes Reference
 
@@ -44,7 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Access Pakcage can be imported using the `id`, e.g.
+Access Packages can be imported using the `id`, e.g.
 
 ```
 terraform import azuread_access_package.example_package 00000000-0000-0000-0000-000000000000

--- a/docs/resources/access_package.md
+++ b/docs/resources/access_package.md
@@ -14,7 +14,7 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
-```
+```terraform
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "example" {
@@ -37,6 +37,8 @@ resource "azuread_access_package" "example" {
 * `is_hidden` - (Optional) Whether the access package is hidden from the requestor.
 
 ## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of this resource.
 

--- a/docs/resources/access_package.md
+++ b/docs/resources/access_package.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_access_package
+Manages Access Packages within Identity Governance in Azure Active Directory.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Access package manager` or `Global Administrator`
+
+
+## Example Usage
+```
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-catalog"
+  description  = "Example catalog"
+}
+
+resource "azuread_access_package" "example" {
+  display_name = "access-package"
+  description  = "Access Package"
+  catalog_id   = azuread_access_package_catalog.example.id
+}
+```
+
+## Argument Reference
+
+* `catalog_id` - (Required) The ID of the Catalog this access package will be created in.
+* `description` - (Required) The description of the access package.
+* `display_name` - (Required) The display name of the access package.
+* `is_hidden` - (Optional) Whether the access package is hidden from the requestor.
+
+## Attributes Reference
+
+* `id` - The ID of this resource.
+
+## Import
+
+Access Pakcage can be imported using the `id`, e.g.
+
+```
+terraform import azuread_access_package.example_package 00000000-0000-0000-0000-000000000000
+```
+
+

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -3,9 +3,11 @@ subcategory: "Identity Governance"
 ---
 
 # Resource: azuread_access_package_assignment_policy
-This resources manages the policies within an access package.
+
+Manages an assignment policy for an access package within Identity Governance in Azure Active Directory.
 
 ## API Permissions
+
 The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
@@ -15,49 +17,53 @@ When authenticated with a user principal, this resource requires `Global Adminis
 ## Example Usage
 
 ```terraform
-provider "azuread" {}
-
-resource "azuread_group" "test" {
-  display_name     = "test-group-%[1]d"
+resource "azuread_group" "example" {
+  display_name     = "group-name"
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-asscess-assignment-%[1]d"
-  description  = "TestAcc Catalog %[1]d for access assignment policy"
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-catalog"
+  description  = "Example catalog"
 }
 
-resource "azuread_access_package" "test" {
-  display_name = "testacc-asscess-assignment-%[1]d"
-  description  = "TestAcc Access Package %[1]d for access assignment policy"
-  catalog_id   = azuread_access_package_catalog.test_catalog.id
+resource "azuread_access_package" "example" {
+  catalog_id   = azuread_access_package_catalog.example.id
+  display_name = "access-package"
+  description  = "Access Package"
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "testacc-asscess-assignment-%[1]d"
-  description       = "TestAcc Access Package Assignnment Policy %[1]d"
-  duration_in_days  = 90
   access_package_id = azuread_access_package.test.id
+  display_name      = "assignment-policy"
+  description       = "My assignment policy"
+  duration_in_days  = 90
+
   requestor_settings {
     scope_type = "AllExistingDirectoryMemberUsers"
   }
+
   approval_settings {
-    is_approval_required = true
+    approval_required = true
+
     approval_stage {
       approval_timeout_in_days = 14
+
       primary_approver {
         object_id    = azuread_group.test.object_id
         subject_type = "groupMembers"
       }
     }
   }
+
   assignment_review_settings {
-    is_enabled                     = true
+    enabled                        = true
     review_frequency               = "weekly"
     duration_in_days               = 3
     review_type                    = "Self"
     access_review_timeout_behavior = "keepAccess"
   }
+
   question {
     text {
       default_text = "hello, how are you?"
@@ -72,135 +78,121 @@ resource "azuread_access_package_assignment_policy" "test" {
 - `access_package_id` (Required) The ID of the access package that will contain the policy.
 - `description` (Required) The description of the policy.
 - `display_name` (Required) The display name of the policy.
-- `approval_settings` (Optional) Settings of whether approvals are required and how they are obtained. (see [below for block details](#nestedblock--approval_settings))
-- `assignment_review_settings` (Optional) The settings of whether assignment review is needed and how it's conducted. (see [below for block details](#nestedblock--assignment_review_settings))
+- `approval_settings` (Optional) An `approval_settings` block to specify whether approvals are required and how they are obtained, as documented below.
+- `assignment_review_settings` (Optional) An `assignment_review_settings` block, to specify whether assignment review is needed and how it is conducted, as documented below.
 - `can_extend` (Optional) When enabled, users will be able to request extension of their access to this package before their access expires.
 - `duration_in_days` (Optional) How many days this assignment is valid for.
 - `expiration_date` (Optional) The date that this assignment expires, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z).
-- `question` (Optional) One ore more questions to the requestor. (see [below for block details](#nestedblock--question))
-- `requestor_settings` (Optional) This block configures the users who can request access. (see [below for block details](#nestedblock--requestor_settings))
+- `question` (Optional) One or more `question` blocks for the requestor, as documented below.
+- `requestor_settings` (Optional) A `requestor_settings` block to configure the users who can request access, as documented below.
 
 ---
 
-<a id="nestedblock--approval_settings"></a>
 `approval_settings` block supports the following:
 
-- `approval_stage` (Optional) The process to obtain an approval (see [below for block details](#nestedblock--approval_settings--approval_stage))
-- `is_approval_required` (Optional) Whether an approval is required.
-- `is_approval_required_for_extension` (Optional) Whether an approval is required to grant extension. Same approval settings used to approve initial access will apply.
-- `is_requestor_justification_required` (Optional) Whether a requestor is required to provide a justification to request an access package. Justification is visible to approvers and the requestor.
+- `approval_stage` (Optional) An `approval_stage` block specifying the process to obtain an approval, as documented below.
+- `approval_required` (Optional) Whether an approval is required.
+- `approval_required_for_extension` (Optional) Whether an approval is required to grant extension. Same approval settings used to approve initial access will apply.
+- `requestor_justification_required` (Optional) Whether a requestor is required to provide a justification to request an access package. Justification is visible to approvers and the requestor.
 
 ---
 
-<a id="nestedblock--approval_settings--approval_stage"></a>
 `approval_settings.approval_stage` block supports the following
 
-- `approval_timeout_in_days` (Required) Decision must be made in how many days? If a request is not approved within this time period after it is made, it will be automatically rejected.
-- `alternative_approver` (Optional) If escalation is enabled and the primary approvers do not respond before the escalation time, the escalationApprovers are the users who will be asked to approve requests. This can be a collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, if there are no escalation approvers, or escalation approvers are not required for the stage, the value of this property should be an empty collection. (see [below for block details](#nestedblock--approval_settings--approval_stage--approvers))
-- `enable_alternative_approval_in_days` (Optional) Forward to alternate approver(s) after how many days?
-- `is_alternative_approval_enabled` (Optional) If no action taken, forward to alternate approvers?
-- `is_approver_justification_required` (Optional) Whether an approver must provide a justification for their decision. Justification is visible to other approvers and the requestor.
-- `primary_approver` (Optional) The users who will be asked to approve requests. A collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, include at least one userSet in this collection. (see [below for block details](#nestedblock--approval_settings--approval_stage--approvers))
+- `approval_timeout_in_days` (Required) Maximum number of days within which a request must be approved. If a request is not approved within this time period after it is made, it will be automatically rejected.
+- `alternative_approver` (Optional) A block specifying alternative approvers when escalation is enabled and the primary approvers do not respond before the escalation time, as documented below.
+- `enable_alternative_approval_in_days` (Optional) Number of days before the request is forwarded to alternative approvers.
+- `alternative_approval_enabled` (Optional) Whether alternative approvers are enabled.
+- `approver_justification_required` (Optional) Whether an approver must provide a justification for their decision. Justification is visible to other approvers and the requestor.
+- `primary_approver` (Optional) A block specifying the users who will be asked to approve requests, as documented below.
 
 ---
 
-<a id="nestedblock--approval_settings--approval_stage--approvers"></a>
-`approval_settings.approval_stage.alternative_approver` and `approval_settings.approval_stage.alternative_approver` blocks support the following:
+`approval_settings.approval_stage.primary_approver` and `approval_settings.approval_stage.alternative_approver` blocks support the following:
 
-- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
-- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `subject_type` (Required) Specifies the type of users. Valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, or `externalSponsors`.
+- `backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
 - `object_id` (Optional) The ID of the subject.
 
 ---
 
-<a id="nestedblock--assignment_review_settings"></a>
 `assignment_review_settings` block supports the following:
 
-- `access_review_timeout_behavior` (Optional) What actions the system takes if reviewers don't respond in time, valid values are `keepAccess`, `removeAcces`, `acceptAccessRecommendation`.
+- `access_review_timeout_behavior` (Optional) Specifies the actions the system takes if reviewers don't respond in time. Vlid values are `keepAccess`, `removeAccess`, or `acceptAccessRecommendation`.
 - `duration_in_days` (Number) How many days each occurrence of the access review series will run.
-- `is_access_recommendation_enabled` (Optional) Whether to show the reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days.
-- `is_approver_justification_required` (Optional) Whether a reviewer needs to provide a justification for their decision. Justification is visible to other reviewers and the requestor.
-- `is_enabled` (Optional) Whether to enable assignment review.
-- `review_frequency` (Optional) This will determine how often the access review campaign runs, valid values are `weekly`,`monthly`,`quarterly`,`halfyearly`,`annual`.
-- `review_type` (Optional) Self reivew or specific reviewers, valid values are `Self`, `Reviewers`.
-- `reviewer` (Optional) If the `review_type` is Reviewers, this collection specifies the users who will be reviewers, either by ID or as members of a group, using a collection of singleUser and groupMembers. (see [below for block details](#nestedblock--assignment_review_settings--reviewer))
+- `access_recommendation_enabled` (Optional) Whether to show the reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days.
+- `approver_justification_required` (Optional) Whether a reviewer needs to provide a justification for their decision. Justification is visible to other reviewers and the requestor.
+- `enabled` (Optional) Whether to enable assignment review.
+- `review_frequency` (Optional) This will determine how often the access review campaign runs, valid values are `weekly`, `monthly`, `quarterly`, `halfyearly`, or `annual`.
+- `review_type` (Optional) Self review or specific reviewers, valid values are `Self`, `Reviewers`.
+- `reviewer` (Optional) One or more `reviewer` blocks to specify the users who will be reviewers (when `review_type` is `Reviewers`), as documented below.
 - `starting_on` (Optional) This is the date the access review campaign will start on, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z), default is now. Once an access review has been created, you cannot update its start date
 
 ---
 
-<a id="nestedblock--assignment_review_settings--reviewer"></a>
 `assignment_review_settings.reviewer` block supports the following:
 
-- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
-- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
+- `subject_type` (Required) Specifies the type of users. Valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, or `externalSponsors`.
+- `backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
 - `object_id` (Optional) The ID of the subject.
 
 ---
 
-<a id="nestedblock--question"></a>
 `question` block supports the following:
 
-- `text` (Required) The content of this question. (see [below for block details](#nestedblock--question--text))
-- `choice` (Optional) Configuration of a choice to the question. (see [below for block details](#nestedblock--question--choice))
-- `is_required` (Optional) Whether this question is required.
+- `text` (Required) A block describing the content of this question, as documented below.
+- `choice` (Optional) One or more blocks configuring a choice to the question, as documented below.
+- `required` (Optional) Whether this question is required.
 - `sequence` (Optional) The sequence number of this question.
 
 ---
 
-<a id="nestedblock--question--text"></a>
 `question.text` block supports the following:
 
-- `default_text` (Required) The default text of this question
-- `localized_text` (Optional) The localized text of the this question (see [below for block details](#nestedblock--question--text--localized_text))
+- `default_text` (Required) The default text of this question.
+- `localized_text` (Optional) One or more blocks describing localized text of this question, as documented below.
 
 ---
 
-<a id="nestedblock--question--text--localized_text"></a>
 `question.text.localized_text` block supports the following:
 
-- `content` (Required) The localized content of this questions
-- `language_code` (Required) The language code of this question content
+- `content` (Required) The localized content of this question.
+- `language_code` (Required) The ISO 639 language code for this question content.
 
 ---
 
-<a id="nestedblock--question--choice"></a>
 `question.choice` block supports the following:
 
-- `actual_value` (Required) The actual value of this choice
-- `display_value` (Required) The display text of this choice (see [below for block details](#nestedblock--question--choice--display_value))
+- `actual_value` (Required) The actual value of this choice.
+- `display_value` (Required) A block describing the display text of this choice, as documented below.
 
 ---
 
-<a id="nestedblock--question--choice--display_value"></a>
 `question.choice.display_value` block supports the following:
 
-- `default_text` (Required) The default text of this question
-- `localized_text` (Optional) The localized text of the this question (see [below for block details](#nestedblock--question--choice--display_value--localized_text))
+- `default_text` (Required) The default text of this question choice.
+- `localized_text` (Optional) One or more blocks describing localized text of this question choice, as documented below.
 
 ---
 
-<a id="nestedblock--question--choice--display_value--localized_text"></a>
 `question.choice.display_value.localized_text` block supports the following:
 
-- `content` (Required) The localized content of this questions
-- `language_code` (Required) The language code of this question content
+- `content` (Required) The localized content of this question choice.
+- `language_code` (Required) The ISO 639 language code for this question choice content.
 
 ---
 
-<a id="nestedblock--requestor_settings"></a>
 `requestor_settings` block supports the following:
 
-- `accept_requests` (Optional) Whether to accept requests now, when disabled, no new requests can be made using this policy.
-- `requestor` (Optional) The users who are allowed to request on this policy, which can be singleUser, groupMembers, and connectedOrganizationMembers. (see [below for block details](#nestedblock--requestor_settings--requestor))
-- `scope_type` (Optional) Specify the scopes of the requestors. Valid values are `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects`, `AllExternalSubjects`, `NoSubjects`, `SpecificConnectedOrganizationSubjects`,`SpecificDirectorySubjects`.
+- `requests_accepted` (Optional) Whether to accept requests using this policy. When `false`, no new requests can be made using this policy.
+- `requestor` (Optional) A block specifying the users who are allowed to request on this policy, as documented below.
+- `scope_type` (Optional) Specifies the scopes of the requestors. Valid values are `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects`, `AllExternalSubjects`, `NoSubjects`, `SpecificConnectedOrganizationSubjects`, or `SpecificDirectorySubjects`.
 
 ---
 
-<a id="nestedblock--requestor_settings--requestor"></a>
 `requestor_settings.requestor` block supports the following:
 
-- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
-- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
+- `subject_type` (Required) Specifies the type of users. Valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, or `externalSponsors`.
 - `object_id` (Optional) The ID of the subject.
 
 ## Attributes Reference
@@ -211,8 +203,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The policy can be imported using their object ID, e.g.
+An access package assignment policy can be imported using the ID, e.g.
 
 ```shell
-terraform import azuread_access_package_assignment_policy.test_policy 00000000-0000-0000-0000-000000000000
+terraform import azuread_access_package_assignment_policy.example 00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -1,0 +1,216 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_access_package_assignment_policy
+This resources manages the policies within an access package.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this resource requires `Global Administrator` directory role, or one of the `Catalog Owner` and `Access Package Manager` role in Idneity Governance.
+
+## Example Usage
+
+```
+provider "azuread" {}
+
+resource "azuread_group" "test" {
+  display_name     = "test-group-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "testacc-asscess-assignment-%[1]d"
+  description  = "TestAcc Catalog %[1]d for access assignment policy"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "testacc-asscess-assignment-%[1]d"
+  description  = "TestAcc Access Package %[1]d for access assignment policy"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_assignment_policy" "test" {
+  display_name      = "testacc-asscess-assignment-%[1]d"
+  description       = "TestAcc Access Package Assignnment Policy %[1]d"
+  duration_in_days  = 90
+  access_package_id = azuread_access_package.test.id
+  requestor_settings {
+    scope_type = "AllExistingDirectoryMemberUsers"
+  }
+  approval_settings {
+    is_approval_required = true
+    approval_stage {
+      approval_timeout_in_days = 14
+      primary_approver {
+        object_id    = azuread_group.test.object_id
+        subject_type = "groupMembers"
+      }
+    }
+  }
+  assignment_review_settings {
+    is_enabled                     = true
+    review_frequency               = "weekly"
+    duration_in_days               = 3
+    review_type                    = "Self"
+    access_review_timeout_behavior = "keepAccess"
+  }
+  question {
+    text {
+      default_text = "hello, how are you?"
+    }
+  }
+}
+```
+
+
+## Argument Reference
+
+- `access_package_id` (Required) The ID of the access package that will contain the policy.
+- `description` (Required) The description of the policy.
+- `display_name` (Required) The display name of the policy.
+- `approval_settings` (Optional) Settings of whether apporvals are required and how they are obtained. (see [below for block details](#nestedblock--approval_settings))
+- `assignment_review_settings` (Optional) The settings of whether assignment review is needed and how it's conducted. (see [below for block details](#nestedblock--assignment_review_settings))
+- `can_extend` (Optional) When enabled, users will be able to request extension of their access to this package before their access expires.
+- `duration_in_days` (Optional) How many days this assignment is valid for.
+- `expiration_date` (Optional) The date that this assignment expires, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z).
+- `question` (Optional) One ore more questions to the requestor. (see [below for block details](#nestedblock--question))
+- `requestor_settings` (Optional) This block configures the users who can request access. (see [below for block details](#nestedblock--requestor_settings))
+
+---
+
+<a id="nestedblock--approval_settings"></a>
+`approval_settings` block supports the follwoing:
+
+- `approval_stage` (Optional) The process to obtain an approval (see [below for block details](#nestedblock--approval_settings--approval_stage))
+- `is_approval_required` (Optional) Whether an approval is required.
+- `is_approval_required_for_extension` (Optional) Whether an approval is required to grant extension. Same approval settings used to approve initial access will apply.
+- `is_requestor_justification_required` (Optional) Whether requestor are required to provide a justification to request an access package. Justification is visible to other approvers and the requestor.
+
+---
+
+<a id="nestedblock--approval_settings--approval_stage"></a>
+`approval_settings.approval_stage` block supports the following
+
+- `approval_timeout_in_days` (Required) Decision must be made in how many days? If a request is not approved within this time period after it is made, it will be automatically rejected.
+- `alternative_approver` (Optional) If escalation is enabled and the primary approvers do not respond before the escalation time, the escalationApprovers are the users who will be asked to approve requests. This can be a collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, if there are no escalation approvers, or escalation approvers are not required for the stage, the value of this property should be an empty collection. (see [below for block details](#nestedblock--approval_settings--approval_stage--approvers))
+- `enable_alternative_approval_in_days` (Optional) Forward to alternate approver(s) after how many days?
+- `is_alternative_approval_enabled` (Optional) If no action taken, forward to alternate approvers?
+- `is_approver_justification_required` (Optional) Whether an approver must provide a justification for their decision. Justification is visible to other approvers and the requestor.
+- `primary_approver` (Optional) The users who will be asked to approve requests. A collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, include at least one userSet in this collection. (see [below for block details](#nestedblock--approval_settings--approval_stage--approvers))
+
+---
+
+<a id="nestedblock--approval_settings--approval_stage--approvers"></a>
+`approval_settings.approval_stage.alternative_approver` and `approval_settings.approval_stage.alternative_approver` blocks support the following:
+
+- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
+- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `object_id` (Optional) The ID of the subject.
+
+---
+
+<a id="nestedblock--assignment_review_settings"></a>
+`assignment_review_settings` block supports the following:
+
+- `access_review_timeout_behavior` (Optional) What actions the system takes if reviewers don't respond in time, valid values are `keepAccess`, `removeAcces`, `acceptAccessRecommendation`.
+- `duration_in_days` (Number) How many days each occurrence of the access review series will run.
+- `is_access_recommendation_enabled` (Optional) Whether to show Show reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days
+- `is_approver_justification_required` (Optional) Whether a reviewer need provide a justification for their decision. Justification is visible to other reviewers and the requestor.
+- `is_enabled` (Optional) Whether to enable assignment reivew.
+- `review_frequency` (Optional) This will determine how often the access review campaign runs, valid values are `weekly`,`monthly`,`quarterly`,`halfyearly`,`annual`.
+- `review_type` (Optional) Self reivew or specific reviewers, valid values are `Self`, `Reviewers`.
+- `reviewer` (Optional) If the reviewerType is Reviewers, this collection specifies the users who will be reviewers, either by ID or as members of a group, using a collection of singleUser and groupMembers. (see [below for block details](#nestedblock--assignment_review_settings--reviewer))
+- `starting_on` (Optional) This is the date the access review campaign will start on, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z), default is now. Once an access review has been created, you cannot update its start date
+
+---
+
+<a id="nestedblock--assignment_review_settings--reviewer"></a>
+`assignment_review_settings.reviewer` block supports the following:
+
+- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
+- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `object_id` (Optional) The ID of the subject.
+
+---
+
+<a id="nestedblock--question"></a>
+`question` block supports the following:
+
+- `text` (Required) The content of this question. (see [below for block details](#nestedblock--question--text))
+- `choice` (Optional) Configuration of a choice to the question. (see [below for block details](#nestedblock--question--choice))
+- `is_required` (Optional) Whether this question is required.
+- `sequence` (Optional) The sequence number of this question.
+
+---
+
+<a id="nestedblock--question--text"></a>
+`question.text` block supports the following:
+
+- `default_text` (Required) The default text of this question
+- `localized_text` (Optional) The localized text of the this question (see [below for block details](#nestedblock--question--text--localized_text))
+
+---
+
+<a id="nestedblock--question--text--localized_text"></a>
+`question.text.localized_text` block supports the following:
+
+- `content` (Required) The localized content of this questions
+- `language_code` (Required) The language code of this question content
+
+---
+
+<a id="nestedblock--question--choice"></a>
+`question.choice` block supports the following:
+
+- `actual_value` (Required) The actual value of this choice
+- `display_value` (Required) The display text of this choice (see [below for block details](#nestedblock--question--choice--display_value))
+
+---
+
+<a id="nestedblock--question--choice--display_value"></a>
+`question.choice.display_value` block supports the following:
+
+- `default_text` (Required) The default text of this question
+- `localized_text` (Optional) The localized text of the this question (see [below for block details](#nestedblock--question--choice--display_value--localized_text))
+
+---
+
+<a id="nestedblock--question--choice--display_value--localized_text"></a>
+`question.choice.display_value.localized_text` block supports the following:
+
+- `content` (Required) The localized content of this questions
+- `language_code` (Required) The language code of this question content
+
+---
+
+<a id="nestedblock--requestor_settings"></a>
+`requestor_settings` block supports the following:
+
+- `accept_requests` (Optional) Whether to accept requets now, when disabled, no new requests can be made using this policy.
+- `requestor` (Optional) The users who are allowed to request on this policy, which can be singleUser, groupMembers, and connectedOrganizationMembers. (see [below for block details](#nestedblock--requestor_settings--requestor))
+- `scope_type` (Optional) Specify the scopes of the requestors. Valid values are `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects`, `AllExternalSubjects`, `NoSubjects`, `SpecificConnectedOrganizationSubjects`,`SpecificDirectorySubjects`.
+
+---
+
+<a id="nestedblock--requestor_settings--requestor"></a>
+`requestor_settings.requestor` block supports the following:
+
+- `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
+- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `object_id` (Optional) The ID of the subject.
+
+## Attribute Reference
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+The policy can be imported using their object ID, e.g.
+
+```shell
+terraform import azuread_access_package_assignment_policy.test_policy 00000000-0000-0000-0000-000000000000
+```

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -72,7 +72,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 - `access_package_id` (Required) The ID of the access package that will contain the policy.
 - `description` (Required) The description of the policy.
 - `display_name` (Required) The display name of the policy.
-- `approval_settings` (Optional) Settings of whether apporvals are required and how they are obtained. (see [below for block details](#nestedblock--approval_settings))
+- `approval_settings` (Optional) Settings of whether approvals are required and how they are obtained. (see [below for block details](#nestedblock--approval_settings))
 - `assignment_review_settings` (Optional) The settings of whether assignment review is needed and how it's conducted. (see [below for block details](#nestedblock--assignment_review_settings))
 - `can_extend` (Optional) When enabled, users will be able to request extension of their access to this package before their access expires.
 - `duration_in_days` (Optional) How many days this assignment is valid for.
@@ -88,7 +88,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 - `approval_stage` (Optional) The process to obtain an approval (see [below for block details](#nestedblock--approval_settings--approval_stage))
 - `is_approval_required` (Optional) Whether an approval is required.
 - `is_approval_required_for_extension` (Optional) Whether an approval is required to grant extension. Same approval settings used to approve initial access will apply.
-- `is_requestor_justification_required` (Optional) Whether requestor are required to provide a justification to request an access package. Justification is visible to other approvers and the requestor.
+- `is_requestor_justification_required` (Optional) Whether a requestor is required to provide a justification to request an access package. Justification is visible to approvers and the requestor.
 
 ---
 
@@ -118,12 +118,12 @@ resource "azuread_access_package_assignment_policy" "test" {
 
 - `access_review_timeout_behavior` (Optional) What actions the system takes if reviewers don't respond in time, valid values are `keepAccess`, `removeAcces`, `acceptAccessRecommendation`.
 - `duration_in_days` (Number) How many days each occurrence of the access review series will run.
-- `is_access_recommendation_enabled` (Optional) Whether to show Show reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days
-- `is_approver_justification_required` (Optional) Whether a reviewer need provide a justification for their decision. Justification is visible to other reviewers and the requestor.
-- `is_enabled` (Optional) Whether to enable assignment reivew.
+- `is_access_recommendation_enabled` (Optional) Whether to show the reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days.
+- `is_approver_justification_required` (Optional) Whether a reviewer needs to provide a justification for their decision. Justification is visible to other reviewers and the requestor.
+- `is_enabled` (Optional) Whether to enable assignment review.
 - `review_frequency` (Optional) This will determine how often the access review campaign runs, valid values are `weekly`,`monthly`,`quarterly`,`halfyearly`,`annual`.
 - `review_type` (Optional) Self reivew or specific reviewers, valid values are `Self`, `Reviewers`.
-- `reviewer` (Optional) If the reviewerType is Reviewers, this collection specifies the users who will be reviewers, either by ID or as members of a group, using a collection of singleUser and groupMembers. (see [below for block details](#nestedblock--assignment_review_settings--reviewer))
+- `reviewer` (Optional) If the `review_type` is Reviewers, this collection specifies the users who will be reviewers, either by ID or as members of a group, using a collection of singleUser and groupMembers. (see [below for block details](#nestedblock--assignment_review_settings--reviewer))
 - `starting_on` (Optional) This is the date the access review campaign will start on, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z), default is now. Once an access review has been created, you cannot update its start date
 
 ---
@@ -132,7 +132,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 `assignment_review_settings.reviewer` block supports the following:
 
 - `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
-- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
 - `object_id` (Optional) The ID of the subject.
 
 ---
@@ -190,7 +190,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 <a id="nestedblock--requestor_settings"></a>
 `requestor_settings` block supports the following:
 
-- `accept_requests` (Optional) Whether to accept requets now, when disabled, no new requests can be made using this policy.
+- `accept_requests` (Optional) Whether to accept requests now, when disabled, no new requests can be made using this policy.
 - `requestor` (Optional) The users who are allowed to request on this policy, which can be singleUser, groupMembers, and connectedOrganizationMembers. (see [below for block details](#nestedblock--requestor_settings--requestor))
 - `scope_type` (Optional) Specify the scopes of the requestors. Valid values are `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects`, `AllExternalSubjects`, `NoSubjects`, `SpecificConnectedOrganizationSubjects`,`SpecificDirectorySubjects`.
 
@@ -200,7 +200,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 `requestor_settings.requestor` block supports the following:
 
 - `subject_type` (Required) Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.
-- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
+- `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
 - `object_id` (Optional) The ID of the subject.
 
 ## Attributes Reference

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -14,7 +14,7 @@ When authenticated with a user principal, this resource requires `Global Adminis
 
 ## Example Usage
 
-```
+```terraform
 provider "azuread" {}
 
 resource "azuread_group" "test" {
@@ -203,7 +203,9 @@ resource "azuread_access_package_assignment_policy" "test" {
 - `is_backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup fallback approver.
 - `object_id` (Optional) The ID of the subject.
 
-## Attribute Reference
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
 
 - `id` (String) The ID of this resource.
 

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -83,7 +83,7 @@ resource "azuread_access_package_assignment_policy" "test" {
 ---
 
 <a id="nestedblock--approval_settings"></a>
-`approval_settings` block supports the follwoing:
+`approval_settings` block supports the following:
 
 - `approval_stage` (Optional) The process to obtain an approval (see [below for block details](#nestedblock--approval_settings--approval_stage))
 - `is_approval_required` (Optional) Whether an approval is required.

--- a/docs/resources/access_package_catalog.md
+++ b/docs/resources/access_package_catalog.md
@@ -3,9 +3,11 @@ subcategory: "Identity Governance"
 ---
 
 # Resource: azuread_access_package_catalog
-Manages Access Catalogs within Identity Governance in Azure Active Directory.
+
+Manages an access package catalog within Identity Governance in Azure Active Directory.
 
 ## API Permissions
+
 The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
@@ -14,18 +16,20 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
+
 ```terraform
 resource "azuread_access_package_catalog" "example" {
   display_name = "example-access-package-catalog"
   description  = "Example access package catalog"
 }
 ```
+
 ## Argument Reference
 
 * `description` - (Required) The description of the access package catalog.
 * `display_name` - (Required) The display name of the access package catalog.
-* `is_externally_visible` - (Optional) Whether the access packages in this catalog can be requested by users outside of the tenant.
-* `state` - (Optional) Has the value published if the access packages are available for management. The possible values are: unpublished and published.
+* `externally_visible` - (Optional) Whether the access packages in this catalog can be requested by users outside the tenant.
+* `published` - (Optional) Whether the access packages in this catalog are available for management.
 
 ## Attributes Reference
 
@@ -35,10 +39,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Access Pakcage Catalog can be imported using the `id`, e.g.
+An Access Package Catalog can be imported using the `id`, e.g.
 
 ```
-terraform import azuread_access_package_catalog.example_catalog 00000000-0000-0000-0000-000000000000
+terraform import azuread_access_package_catalog.example 00000000-0000-0000-0000-000000000000
 ```
 
 

--- a/docs/resources/access_package_catalog.md
+++ b/docs/resources/access_package_catalog.md
@@ -14,7 +14,7 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
-```
+```terraform
 resource "azuread_access_package_catalog" "example" {
   display_name = "example-access-package-catalog"
   description  = "Example access package catalog"
@@ -28,6 +28,9 @@ resource "azuread_access_package_catalog" "example" {
 * `state` - (Optional) Has the value published if the access packages are available for management. The possible values are: unpublished and published.
 
 ## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
 * `id` - The ID of this resource.
 
 ## Import

--- a/docs/resources/access_package_catalog.md
+++ b/docs/resources/access_package_catalog.md
@@ -1,0 +1,41 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_access_package_catalog
+Manages Access Catalogs within Identity Governance in Azure Active Directory.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Catalog creator` or `Global Administrator`
+
+
+## Example Usage
+```
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-access-package-catalog"
+  description  = "Example access package catalog"
+}
+```
+## Argument Reference
+
+* `description` - (Required) The description of the access package catalog.
+* `display_name` - (Required) The display name of the access package catalog.
+* `is_externally_visible` - (Optional) Whether the access packages in this catalog can be requested by users outside of the tenant.
+* `state` - (Optional) Has the value published if the access packages are available for management. The possible values are: unpublished and published.
+
+## Attributes Reference
+* `id` - The ID of this resource.
+
+## Import
+
+Access Pakcage Catalog can be imported using the `id`, e.g.
+
+```
+terraform import azuread_access_package_catalog.example_catalog 00000000-0000-0000-0000-000000000000
+```
+
+

--- a/docs/resources/access_package_resource_catalog_association.md
+++ b/docs/resources/access_package_resource_catalog_association.md
@@ -14,14 +14,14 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
-```
+```terraform
 resource "azuread_group" "example_group" {
   display_name     = "example_group"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "example_catalog" {
-  display_name = "example-catalog"	
+  display_name = "example-catalog"
   description  = "Example catalog"
 }
 
@@ -39,6 +39,8 @@ resource "azuread_access_package_resource_catalog_association" "example" {
 * `resource_origin_system` - (Required) The type of the resource in the origin system, such as SharePointOnline, AadApplication or AadGroup.
 
 ## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of this resource, the ID is the concatenation of `catalog_id` and `resource_origin_id` with colon in between.
 

--- a/docs/resources/access_package_resource_catalog_association.md
+++ b/docs/resources/access_package_resource_catalog_association.md
@@ -3,9 +3,11 @@ subcategory: "Identity Governance"
 ---
 
 # Resource: azuread_access_package_resource_catalog_association
-This resource manages the resources added to access package catalogs.
+
+Manages the resources added to access package catalogs within Identity Governance in Azure Active Directory.
 
 ## API Permissions
+
 The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
@@ -14,13 +16,14 @@ When authenticated with a user principal, this resource requires one of the foll
 
 
 ## Example Usage
+
 ```terraform
-resource "azuread_group" "example_group" {
-  display_name     = "example_group"
+resource "azuread_group" "example" {
+  display_name     = "example-group"
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "example_catalog" {
+resource "azuread_access_package_catalog" "example" {
   display_name = "example-catalog"
   description  = "Example catalog"
 }
@@ -34,9 +37,9 @@ resource "azuread_access_package_resource_catalog_association" "example" {
 
 ## Argument Reference
 
-* `catalog_id` - (Required) The unique ID of the access package catalog.
-* `resource_origin_id` - (Required) The unique identifier of the resource in the origin system. In the case of an Azure AD group, this is the identifier of the group.
-* `resource_origin_system` - (Required) The type of the resource in the origin system, such as SharePointOnline, AadApplication or AadGroup.
+* `catalog_id` - (Required) The unique ID of the access package catalog. Changing this forces a new resource to be created.
+* `resource_origin_id` - (Required) The unique identifier of the resource in the origin system. In the case of an Azure AD group, this is the identifier of the group. Changing this forces a new resource to be created.
+* `resource_origin_system` - (Required) The type of the resource in the origin system, such as `SharePointOnline`, `AadApplication` or `AadGroup`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
@@ -46,9 +49,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The resource and catalog association can be imported using the `id` which is the concatenation of `catalog_id` and `resource_origin_id` with colon in between, e.g.
+The resource and catalog association can be imported using the catalog ID and the resource origin ID, e.g.
 
 ```
-terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111
+terraform import azuread_access_package_resource_catalog_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111
 ```
 
+-> This ID format is unique to Terraform and is composed of the Catalog ID and the Resource Origin ID in the format `{CatalogID}/{ResourceOriginID}`.

--- a/docs/resources/access_package_resource_catalog_association.md
+++ b/docs/resources/access_package_resource_catalog_association.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_access_package_resource_catalog_association
+This resource manages the resources added to access package catalogs.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner` or `Global Administrator`
+
+
+## Example Usage
+```
+resource "azuread_group" "example_group" {
+  display_name     = "example_group"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "example_catalog" {
+  display_name = "example-catalog"	
+  description  = "Example catalog"
+}
+
+resource "azuread_access_package_resource_catalog_association" "example" {
+  catalog_id             = azuread_access_package_catalog.example_catalog.id
+  resource_origin_id     = azuread_group.example_group.object_id
+  resource_origin_system = "AadGroup"
+}
+```
+
+## Argument Reference
+
+* `catalog_id` - (Required) The unique ID of the access package catalog.
+* `resource_origin_id` - (Required) The unique identifier of the resource in the origin system. In the case of an Azure AD group, this is the identifier of the group.
+* `resource_origin_system` - (Required) The type of the resource in the origin system, such as SharePointOnline, AadApplication or AadGroup.
+
+## Attributes Reference
+
+* `id` - The ID of this resource, the ID is the concatenation of `catalog_id` and `resource_origin_id` with colon in between.
+
+## Import
+
+The resource and catalog association can be imported using the `id` which is the concatenation of `catalog_id` and `resource_origin_id` with colon in between, e.g.
+
+```
+terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111
+```
+

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -52,7 +52,7 @@ resource "azuread_access_package_resource_package_association" "example" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of this resource. The ID is combined by four fields with colon in bettween, the four fileds are `access_package_id`, this package association id, `resource_origin_id` and `access_type`
+* `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
 
 ## Import
 

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -3,9 +3,11 @@ subcategory: "Identity Governance"
 ---
 
 # Resource: azuread_access_package_resource_package_association
-This resource manages the resources added to access packages.
+
+Manages the resources added to access packages within Identity Governance in Azure Active Directory.
 
 ## API Permissions
+
 The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
@@ -13,13 +15,14 @@ When authenticated with a service principal, this resource requires the followin
 When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Access package manager` or `Global Administrator`.
 
 ## Example Usage
+
 ```terraform
-resource "azuread_group" "example_group" {
-  display_name     = "example_group"
+resource "azuread_group" "example" {
+  display_name     = "example-group"
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "example_catalog" {
+resource "azuread_access_package_catalog" "example" {
   display_name = "example-catalog"
   description  = "Example catalog"
 }
@@ -44,9 +47,9 @@ resource "azuread_access_package_resource_package_association" "example" {
 
 ## Argument Reference
 
-* `access_package_id` - (Required) The ID of access package this resource association is configured to.
-* `access_type` - (Optional) The role of access type to the specified resource, valid values are `Member` and `Owner`, default is `Member`.
-* `catalog_resource_association_id` - (Required) The ID of the association from `azuread_access_package_resource_catalog_association`.
+* `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
+* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
+* `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
@@ -56,11 +59,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The resource and package association can be imported using the `id`, e.g.
+The resource and catalog association can be imported using the access package ID, the resource association ID, the resource origin ID, and the access type, e.g.
 
 ```
-terraform import azuread_access_package_resource_package_association.example_resource_package_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222:33333333-3333-3333-3333-33333333:Member
+terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222/33333333-3333-3333-3333-33333333/Member
 ```
 
-
-
+-> This ID format is unique to Terraform and is composed of the Access Package ID, the Resource Association ID, the Resource Origin ID, and the Access Type, in the format `{AccessPackageID}/{ResourceAssociationID}/{ResourceOriginID}/{AccessType}`.

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -49,14 +49,14 @@ resource "azuread_access_package_resource_package_association" "example" {
 * `access_type` - (Optional) The role of access type to the specified resource, valid values are `Member` and `Owner`, default is `Member`.
 
 ## Attributes Reference
-* `id` - The ID of this resource.
+* `id` - The ID of this resource. The ID is combined by four fields with colon in bettween, the four fileds are `access_package_id`, this package association id, `resource_origin_id` and `access_type`
 
 ## Import
 
-The resource and catalog association can be imported using the `id`, e.g.
+The resource and package association can be imported using the `id`, e.g.
 
 ```
-terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111
+terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222:33333333-3333-3333-3333-33333333:Member
 ```
 
 

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -13,15 +13,15 @@ When authenticated with a service principal, this resource requires the followin
 When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Access package manager` or `Global Administrator`.
 
 ## Example Usage
-```
+```terraform
 resource "azuread_group" "example_group" {
-	display_name     = "example_group"
-	security_enabled = true
+  display_name     = "example_group"
+  security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "example_catalog" {
-	display_name = "example-catalog"	
-  	description  = "Example catalog"
+  display_name = "example-catalog"
+  description  = "Example catalog"
 }
 
 resource "azuread_access_package_resource_catalog_association" "example" {
@@ -31,24 +31,27 @@ resource "azuread_access_package_resource_catalog_association" "example" {
 }
 
 resource "azuread_access_package" "example" {
-	display_name = "example-package"
-	description  = "Example Package"
-	catalog_id   = azuread_access_package_catalog.example_catalog.id
+  display_name = "example-package"
+  description  = "Example Package"
+  catalog_id   = azuread_access_package_catalog.example_catalog.id
 }
 
 resource "azuread_access_package_resource_package_association" "example" {
-	access_package_id               = azuread_access_package.example.id
-	catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
 }
 ```
 
 ## Argument Reference
 
 * `access_package_id` - (Required) The ID of access package this resource association is configured to.
-* `catalog_resource_association_id` - (Required) The ID of the association from `azuread_access_package_resource_catalog_association`.
 * `access_type` - (Optional) The role of access type to the specified resource, valid values are `Member` and `Owner`, default is `Member`.
+* `catalog_resource_association_id` - (Required) The ID of the association from `azuread_access_package_resource_catalog_association`.
 
 ## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
 * `id` - The ID of this resource. The ID is combined by four fields with colon in bettween, the four fileds are `access_package_id`, this package association id, `resource_origin_id` and `access_type`
 
 ## Import
@@ -56,7 +59,7 @@ resource "azuread_access_package_resource_package_association" "example" {
 The resource and package association can be imported using the `id`, e.g.
 
 ```
-terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222:33333333-3333-3333-3333-33333333:Member
+terraform import azuread_access_package_resource_package_association.example_resource_package_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222:33333333-3333-3333-3333-33333333:Member
 ```
 
 

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_access_package_resource_package_association
+This resource manages the resources added to access packages.
+
+## API Permissions
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `EntitlementManagement.ReadWrite.All`.
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Catalog owner`, `Access package manager` or `Global Administrator`.
+
+## Example Usage
+```
+resource "azuread_group" "example_group" {
+	display_name     = "example_group"
+	security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "example_catalog" {
+	display_name = "example-catalog"	
+  	description  = "Example catalog"
+}
+
+resource "azuread_access_package_resource_catalog_association" "example" {
+  catalog_id             = azuread_access_package_catalog.example_catalog.id
+  resource_origin_id     = azuread_group.example_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "example" {
+	display_name = "example-package"
+	description  = "Example Package"
+	catalog_id   = azuread_access_package_catalog.example_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "example" {
+	access_package_id               = azuread_access_package.example.id
+	catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+}
+```
+
+## Argument Reference
+
+* `access_package_id` - (Required) The ID of access package this resource association is configured to.
+* `catalog_resource_association_id` - (Required) The ID of the association from `azuread_access_package_resource_catalog_association`.
+* `access_type` - (Optional) The role of access type to the specified resource, valid values are `Member` and `Owner`, default is `Member`.
+
+## Attributes Reference
+* `id` - The ID of this resource.
+
+## Import
+
+The resource and catalog association can be imported using the `id`, e.g.
+
+```
+terraform import azuread_access_package_resource_catalog_association.example_resource_catalog_association 00000000-0000-0000-0000-000000000000:11111111-1111-1111-1111-111111111111
+```
+
+
+

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -20,6 +20,7 @@ import (
 	directoryroles "github.com/hashicorp/terraform-provider-azuread/internal/services/directoryroles/client"
 	domains "github.com/hashicorp/terraform-provider-azuread/internal/services/domains/client"
 	groups "github.com/hashicorp/terraform-provider-azuread/internal/services/groups/client"
+	identitygovernance "github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/client"
 	invitations "github.com/hashicorp/terraform-provider-azuread/internal/services/invitations/client"
 	policies "github.com/hashicorp/terraform-provider-azuread/internal/services/policies/client"
 	serviceprincipals "github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals/client"
@@ -45,6 +46,7 @@ type Client struct {
 	DirectoryRoles      *directoryroles.Client
 	Domains             *domains.Client
 	Groups              *groups.Client
+	IdentityGovernance  *identitygovernance.Client
 	Invitations         *invitations.Client
 	Policies            *policies.Client
 	ServicePrincipals   *serviceprincipals.Client
@@ -61,6 +63,7 @@ func (client *Client) build(ctx context.Context, o *common.ClientOptions) error 
 	client.ConditionalAccess = conditionalaccess.NewClient(o)
 	client.DirectoryRoles = directoryroles.NewClient(o)
 	client.Groups = groups.NewClient(o)
+	client.IdentityGovernance = identitygovernance.NewClient(o)
 	client.Invitations = invitations.NewClient(o)
 	client.Policies = policies.NewClient(o)
 	client.ServicePrincipals = serviceprincipals.NewClient(o)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/directoryroles"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/domains"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/groups"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/invitations"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/policies"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/serviceprincipals"
@@ -25,6 +26,7 @@ func SupportedServices() []ServiceRegistration {
 		directoryroles.Registration{},
 		domains.Registration{},
 		groups.Registration{},
+		identitygovernance.Registration{},
 		invitations.Registration{},
 		policies.Registration{},
 		serviceprincipals.Registration{},

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -377,7 +377,7 @@ func accessPackageAssignmentPolicyResourceRead(ctx context.Context, d *schema.Re
 	}
 
 	tf.Set(d, "requestor_settings", flattenRequestorSettings(accessPackageAssignmentPolicy.RequestorSettings))
-	tf.Set(d, "approval_settings", falttenApprovalSettings(accessPackageAssignmentPolicy.RequestApprovalSettings))
+	tf.Set(d, "approval_settings", flattenApprovalSettings(accessPackageAssignmentPolicy.RequestApprovalSettings))
 	tf.Set(d, "assignment_review_settings", flattenReviewSettings(accessPackageAssignmentPolicy.AccessReviewSettings))
 	tf.Set(d, "question", flattenAssignmentPolicyQuestions(accessPackageAssignmentPolicy.Questions))
 

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -183,10 +183,11 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 				},
 			},
 			"assignment_review_settings": {
-				Description: "The settings of whether assignment review is needed and how it's conducted.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
+				Description:      "The settings of whether assignment review is needed and how it's conducted.",
+				Type:             schema.TypeList,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+				MaxItems:         1,
+				Optional:         true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"is_enabled": {
@@ -219,7 +220,6 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 							Description:  "This is the date the access review campaign will start on, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z), default is now. Once an access review has been created, you cannot update its start date",
 							Type:         schema.TypeString,
 							Optional:     true,
-							Default:      time.Now().UTC().Format(time.RFC3339),
 							ValidateFunc: validation.IsRFC3339Time,
 						},
 						"duration_in_days": {
@@ -257,9 +257,10 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 				},
 			},
 			"question": {
-				Description: "One ore more questions to the requestor.",
-				Type:        schema.TypeList,
-				Optional:    true,
+				Description:      "One ore more questions to the requestor.",
+				Type:             schema.TypeList,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+				Optional:         true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"is_required": {
@@ -468,6 +469,10 @@ func assignmentPolicyDiffSuppress(k, old, new string, d *schema.ResourceData) bo
 	}
 
 	if k == "requestor_settings.0.scope_type" && old == msgraph.RequestorSettingsScopeTypeNoSubjects && len(new) == 0 {
+		return true
+	}
+
+	if k == "assignment_review_settings.0.starting_on" && len(new) == 0 {
 		return true
 	}
 

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -191,7 +191,7 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"is_enabled": {
-							Description: "Whether to enable assignemnt reivew.",
+							Description: "Whether to enable assignment reivew.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 						},
@@ -223,7 +223,7 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 							ValidateFunc: validation.IsRFC3339Time,
 						},
 						"duration_in_days": {
-							Description: "How many days each occurence of the access review series will run.",
+							Description: "How many days each occurrence of the access review series will run.",
 							Type:        schema.TypeInt,
 							Optional:    true,
 						},
@@ -317,7 +317,7 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 func accessPackageAssignmentPolicyResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
 
-	properties := msgraph.AccessPackageAssignmentPolicy{}
+	var properties msgraph.AccessPackageAssignmentPolicy
 	var err error
 	if properties, err = buildAssignmentPolicyResourceData(ctx, d, meta); err != nil {
 		return tf.ErrorDiagF(err, "Error building resource data from supplied parameters!")
@@ -335,7 +335,7 @@ func accessPackageAssignmentPolicyResourceCreate(ctx context.Context, d *schema.
 func accessPackageAssignmentPolicyResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
 
-	properties := msgraph.AccessPackageAssignmentPolicy{}
+	var properties msgraph.AccessPackageAssignmentPolicy
 	var err error
 	if properties, err = buildAssignmentPolicyResourceData(ctx, d, meta); err != nil {
 		return tf.ErrorDiagF(err, "Error building resource data from supplied parameters!")

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -1,0 +1,497 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+const accessPackageAssignmentPolicyResourceName = "azuread_access_package_assignment_policy"
+
+func accessPackageAssignmentPolicyResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: accessPackageAssignmentPolicyResourceCreate,
+		ReadContext:   accessPackageAssignmentPolicyResourceRead,
+		UpdateContext: accessPackageAssignmentPolicyResourceUpdate,
+		DeleteContext: accessPackageAssignmentPolicyResourceDelete,
+
+		CustomizeDiff: assignmentPolicyCustomDiff,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			if _, err := uuid.ParseUUID(id); err != nil {
+				return fmt.Errorf("specified ID (%q) is not valid: %s", id, err)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Description:      "The display name of the policy.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"description": {
+				Description:      "The description of the policy.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"can_extend": {
+				Description: "When enabled, users will be able to request extension of their access to this package before their access expires.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
+			"duration_in_days": {
+				Description:   "How many days this assignment is valid for.",
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"expiration_date"},
+				ValidateFunc:  validation.IntBetween(0, 3660),
+			},
+			"expiration_date": {
+				Description:      "The date that this assignment expires, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z).",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ConflictsWith:    []string{"duration_in_days"},
+				ValidateFunc:     validation.IsRFC3339Time,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+			},
+			"requestor_settings": {
+				Description:      "This block configures the users who can request access.",
+				Type:             schema.TypeList,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+				MaxItems:         1,
+				Optional:         true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"accept_requests": {
+							Description: "Whether to accept requets now, when disabled, no new requests can be made using this policy.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"scope_type": {
+							Description: "Specify the scopes of the requestors. Valid values are `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects`, `AllExternalSubjects`, `NoSubjects`, `SpecificConnectedOrganizationSubjects`,`SpecificDirectorySubjects`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								msgraph.RequestorSettingsScopeTypeAllConfiguredConnectedOrganizationSubjects,
+								msgraph.RequestorSettingsScopeTypeAllExistingConnectedOrganizationSubjects,
+								msgraph.RequestorSettingsScopeTypeAllExistingDirectoryMemberUsers,
+								msgraph.RequestorSettingsScopeTypeAllExistingDirectorySubjects,
+								msgraph.RequestorSettingsScopeTypeAllExternalSubjects,
+								msgraph.RequestorSettingsScopeTypeNoSubjects,
+								msgraph.RequestorSettingsScopeTypeSpecificConnectedOrganizationSubjects,
+								msgraph.RequestorSettingsScopeTypeSpecificDirectorySubjects,
+							}, false),
+						},
+						"requestor": {
+							Description: "The users who are allowed to request on this policy, which can be singleUser, groupMembers, and connectedOrganizationMembers.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        schemaUserSet(),
+						},
+					},
+				},
+			},
+			"approval_settings": {
+				Description:      "Settings of whether apporvals are required and how they are obtained.",
+				Type:             schema.TypeList,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+				MaxItems:         1,
+				Optional:         true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_approval_required": {
+							Description: "Whether an approval is required.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"is_approval_required_for_extension": {
+							Description: "Whether an approval is required to grant extension. Same approval settings used to approve initial access will apply.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"is_requestor_justification_required": {
+							Description: "Whether reuqirestor are required to provide a justification to request an access package. Justification is visible to other approvers and the requestor.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"approval_stage": {
+							Description: "The process to obtain an approval",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"approval_timeout_in_days": {
+										Description: "Decision must be made in how many days? If a request is not approved within this time period after it is made, it will be automatically rejected.",
+										Type:        schema.TypeInt,
+										Required:    true,
+									},
+									"is_approver_justification_required": {
+										Description: "Whether an approver must provide a justification for their decision. Justification is visible to other approvers and the requestor.",
+										Type:        schema.TypeBool,
+										Optional:    true,
+									},
+									"is_alternative_approval_enabled": {
+										Description: "If no action taken, forward to alternate approvers?",
+										Type:        schema.TypeBool,
+										Optional:    true,
+									},
+									"enable_alternative_approval_in_days": {
+										Description: "Forward to alternate approver(s) after how many days?",
+										Type:        schema.TypeInt,
+										Optional:    true,
+									},
+									"primary_approver": {
+										Description: "The users who will be asked to approve requests. A collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, include at least one userSet in this collection.",
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        schemaUserSet(),
+									},
+									"alternative_approver": {
+										Description: "If escalation is enabled and the primary approvers do not respond before the escalation time, the escalationApprovers are the users who will be asked to approve requests. This can be a collection of singleUser, groupMembers, requestorManager, internalSponsors and externalSponsors. When creating or updating a policy, if there are no escalation approvers, or escalation approvers are not required for the stage, the value of this property should be an empty collection.",
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        schemaUserSet(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"assignment_review_settings": {
+				Description: "The settings of whether assignment review is needed and how it's conducted.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_enabled": {
+							Description: "Whether to enable assignemnt reivew.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"review_frequency": {
+							Description: "This will determine how often the access review campaign runs, valid values are `weekly`,`monthly`,`quarterly`,`halfyearly`,`annual`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								msgraph.AccessReviewRecurranceTypeAnnual,
+								msgraph.AccessReviewRecurranceTypeHalfYearly,
+								msgraph.AccessReviewRecurranceTypeQuarterly,
+								msgraph.AccessReviewRecurranceTypeMonthly,
+								msgraph.AccessReviewRecurranceTypeWeekly,
+							}, false),
+						},
+						"review_type": {
+							Description: "Self reivew or specific reviewers, valid values are `Self`, `Reviewers`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								msgraph.AccessReviewReviewerTypeSelf,
+								msgraph.AccessReviewReviewerTypeReviewers,
+							}, false),
+						},
+						"starting_on": {
+							Description:  "This is the date the access review campaign will start on, formatted as an RFC3339 date string in UTC(e.g. 2018-01-01T01:02:03Z), default is now. Once an access review has been created, you cannot update its start date",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      time.Now().UTC().Format(time.RFC3339),
+							ValidateFunc: validation.IsRFC3339Time,
+						},
+						"duration_in_days": {
+							Description: "How many days each occurence of the access review series will run.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+						},
+						"reviewer": {
+							Description: "If the reviewerType is Reviewers, this collection specifies the users who will be reviewers, either by ID or as members of a group, using a collection of singleUser and groupMembers.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem:        schemaUserSet(),
+						},
+						"is_access_recommendation_enabled": {
+							Description: "Whether to show Show reviewer decision helpers. If enabled, system recommendations based on users' access information will be shown to the reviewers. The reviewer will be recommended to approve the review if the user has signed-in at least once during the last 30 days. The reviewer will be recommended to deny the review if the user has not signed-in during the last 30 days",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"is_approver_justification_required": {
+							Description: "Whether a reviewer need provide a justification for their decision. Justification is visible to other reviewers and the requestor.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"access_review_timeout_behavior": {
+							Description: "What actions the system takes if reviewers don't respond in time, valid values are `keepAccess`, `removeAcces`, `acceptAccessRecommendation`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								msgraph.AccessReviewTimeoutBehaviorTypeKeepAccess,
+								msgraph.AccessReviewTimeoutBehaviorTypeRemoveAccess,
+								msgraph.AccessReviewTimeoutBehaviorTypeAcceptAccessRecommendation,
+							}, false),
+						},
+					},
+				},
+			},
+			"question": {
+				Description: "One ore more questions to the requestor.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_required": {
+							Description: "Whether this question is required.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						"sequence": {
+							Description: "The sequence number of this question.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+						},
+						"choice": {
+							Description: "Configuration of a choice to the question.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"actual_value": {
+										Description: "The actual value of this choice",
+										Type:        schema.TypeString,
+										Required:    true,
+									},
+									"display_value": {
+										Description: "The display text of this choice",
+										Type:        schema.TypeList,
+										MaxItems:    1,
+										Required:    true,
+										Elem:        schemaLocalizedContent(),
+									},
+								},
+							},
+						},
+						"text": {
+							Description: "The content of this question.",
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Required:    true,
+							Elem:        schemaLocalizedContent(),
+						},
+					},
+				},
+			},
+			"access_package_id": {
+				Description:      "The ID of the access package that will contain the policy.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+		},
+	}
+}
+
+func accessPackageAssignmentPolicyResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
+
+	properties := msgraph.AccessPackageAssignmentPolicy{}
+	var err error
+	if properties, err = buildAssignmentPolicyResourceData(ctx, d, meta); err != nil {
+		return tf.ErrorDiagF(err, "Error building resource data from supplied parameters!")
+	}
+
+	accessPackageAssignmentPolicy, _, err := client.Create(ctx, properties)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Creating access package assignment policy %q", d.Get("display_name").(string))
+	}
+
+	d.SetId(*accessPackageAssignmentPolicy.ID)
+	return accessPackageAssignmentPolicyResourceRead(ctx, d, meta)
+}
+
+func accessPackageAssignmentPolicyResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
+
+	properties := msgraph.AccessPackageAssignmentPolicy{}
+	var err error
+	if properties, err = buildAssignmentPolicyResourceData(ctx, d, meta); err != nil {
+		return tf.ErrorDiagF(err, "Error building resource data from supplied parameters!")
+	}
+
+	objectId := d.Id()
+	tf.LockByName(accessPackageAssignmentPolicyResourceName, objectId)
+	defer tf.UnlockByName(accessPackageAssignmentPolicyResourceName, objectId)
+	if _, err := client.Update(ctx, properties); err != nil {
+		return tf.ErrorDiagF(err, "Could not update access package assignment policy with ID: %q", objectId)
+	}
+
+	return accessPackageAssignmentPolicyResourceRead(ctx, d, meta)
+}
+
+func accessPackageAssignmentPolicyResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
+
+	objectId := d.Id()
+	accessPackageAssignmentPolicy, status, err := client.Get(ctx, objectId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package assignment policy with Object ID %q was not found - removing from state!", objectId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving access package assignment policy with object ID: %q", objectId)
+	}
+
+	tf.Set(d, "display_name", accessPackageAssignmentPolicy.DisplayName)
+	tf.Set(d, "access_package_id", accessPackageAssignmentPolicy.AccessPackageId)
+	tf.Set(d, "description", accessPackageAssignmentPolicy.Description)
+	tf.Set(d, "can_extend", accessPackageAssignmentPolicy.CanExtend)
+	tf.Set(d, "duration_in_days", accessPackageAssignmentPolicy.DurationInDays)
+	if expirationDate := accessPackageAssignmentPolicy.ExpirationDateTime; expirationDate != nil && !expirationDate.IsZero() {
+		tf.Set(d, "expiration_date", expirationDate.UTC().Format(time.RFC3339))
+	} else {
+		tf.Set(d, "expiration_date", "")
+	}
+
+	tf.Set(d, "requestor_settings", flattenRequestorSettings(accessPackageAssignmentPolicy.RequestorSettings))
+	tf.Set(d, "approval_settings", falttenApprovalSettings(accessPackageAssignmentPolicy.RequestApprovalSettings))
+	tf.Set(d, "assignment_review_settings", flattenReviewSettings(accessPackageAssignmentPolicy.AccessReviewSettings))
+	tf.Set(d, "question", flattenAssignmentPolicyQuestions(accessPackageAssignmentPolicy.Questions))
+
+	return nil
+}
+
+func accessPackageAssignmentPolicyResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageAssignmentPolicyClient
+	accessPackageAssignmentPolicyId := d.Id()
+
+	_, status, err := client.Get(ctx, accessPackageAssignmentPolicyId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return tf.ErrorDiagPathF(fmt.Errorf("Access package assignment policy was not found"), "id", "Retrieving user with object ID %q", accessPackageAssignmentPolicyId)
+		}
+
+		return tf.ErrorDiagPathF(err, "id", "Retrieving access package assignment policy with object ID %q", accessPackageAssignmentPolicyId)
+	}
+
+	status, err = client.Delete(ctx, accessPackageAssignmentPolicyId)
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Deleting access package assignment policy with object ID %q, got status %d", accessPackageAssignmentPolicyId, status)
+	}
+
+	// Wait for user object to be deleted
+	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		client.BaseClient.DisableRetries = true
+		if _, status, err := client.Get(ctx, accessPackageAssignmentPolicyId, odata.Query{}); err != nil {
+			if status == http.StatusNotFound {
+				return utils.Bool(false), nil
+			}
+			return nil, err
+		}
+		return utils.Bool(true), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for deletion of access package assignment policy with object ID %q", accessPackageAssignmentPolicyId)
+	}
+	return nil
+}
+
+func buildAssignmentPolicyResourceData(ctx context.Context, d *schema.ResourceData, meta interface{}) (msgraph.AccessPackageAssignmentPolicy, error) {
+	accessPackageClient := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+
+	accessPackageId := d.Get("access_package_id").(string)
+	_, status, err := accessPackageClient.Get(ctx, accessPackageId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package with Object ID %q was not found - removing from state!", accessPackageId)
+		}
+		return msgraph.AccessPackageAssignmentPolicy{}, fmt.Errorf("Error retrieving access package with ID %v: %v", accessPackageId, err)
+	}
+
+	properties := msgraph.AccessPackageAssignmentPolicy{
+		ID:              utils.String(d.Id()),
+		DisplayName:     utils.String(d.Get("display_name").(string)),
+		Description:     utils.String(d.Get("description").(string)),
+		CanExtend:       utils.Bool(d.Get("can_extend").(bool)),
+		DurationInDays:  utils.Int32(int32(d.Get("duration_in_days").(int))),
+		Questions:       expandAccessPakcageAssignmentPolicyQuestions(d.Get("question").([]interface{})),
+		AccessPackageId: utils.String(d.Get("access_package_id").(string)),
+	}
+
+	expirationDateValue := d.Get("expiration_date").(string)
+	if expirationDateValue != "" {
+		expirationDate, err := time.Parse(time.RFC3339, expirationDateValue)
+		if err != nil {
+			return properties, fmt.Errorf("Error converting expiration date %v to a valide date", expirationDate)
+		}
+		properties.ExpirationDateTime = &expirationDate
+	}
+	properties.RequestorSettings = buildAssignmentPolicyRequestorSettings(d.Get("requestor_settings").([]interface{}))
+	properties.RequestApprovalSettings = buildAssignmentPolicyApprovalSettings(d.Get("approval_settings").([]interface{}))
+	reviewSettingsStruct, err := buildAssignmentPolicyReviewSettings(d.Get("assignment_review_settings").([]interface{}))
+	if err != nil {
+		return properties, fmt.Errorf("Error building assignment_review_settings configuration: %v", err)
+	}
+	properties.AccessReviewSettings = reviewSettingsStruct
+
+	return properties, nil
+}
+
+func assignmentPolicyDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if k == "approval_settings.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	if k == "requestor_settings.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	if k == "requestor_settings.0.scope_type" && old == msgraph.RequestorSettingsScopeTypeNoSubjects && len(new) == 0 {
+		return true
+	}
+
+	if k == "assignment_review_settings.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	if k == "question.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	return false
+}
+
+func assignmentPolicyCustomDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if reviewSettings := diff.Get("assignment_review_settings").([]interface{}); len(reviewSettings) > 0 {
+		reviewSetting := reviewSettings[0].(map[string]interface{})
+		if reviewSetting["is_enabled"].(bool) &&
+			(reviewSetting["duration_in_days"] == 0 ||
+				len(reviewSetting["review_frequency"].(string)) == 0 ||
+				len(reviewSetting["access_review_timeout_behavior"].(string)) == 0) {
+			return fmt.Errorf("`duration_in_days`, `review_frequency`, `access_review_timeout_behavior` must be set when review is enabled")
+		}
+	}
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -134,7 +134,7 @@ func accessPackageAssignmentPolicyResource() *schema.Resource {
 							Optional:    true,
 						},
 						"is_requestor_justification_required": {
-							Description: "Whether reuqirestor are required to provide a justification to request an access package. Justification is visible to other approvers and the requestor.",
+							Description: "Whether requestor are required to provide a justification to request an access package. Justification is visible to other approvers and the requestor.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 						},

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -1,0 +1,320 @@
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/odata"
+)
+
+type AccessPackageAssignmentPolicyResource struct{}
+
+func TestAccAccessPackageAssignmentPolicy_simple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.simple(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("access_package_id"),
+	})
+}
+
+func TestAccAccessPackageAssignmentPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("access_package_id"),
+	})
+}
+
+func TestAccAccessPackageAssignmentPolicy_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("access_package_id"),
+	})
+}
+
+func TestAccAccessPackageAssignmentPolicy_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccessPackageAssignmentPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.AccessPackageAssignmentPolicyClient
+	client.BaseClient.DisableRetries = true
+
+	accessPackageAssignmentPolicy, status, err := client.Get(ctx, state.ID, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return nil, fmt.Errorf("Access package assignment policy with object ID %q does not exist", state.ID)
+		}
+		return nil, fmt.Errorf("failed to retrieve Access package assignment policy with object ID %q: %+v", state.ID, err)
+	}
+	return utils.Bool(accessPackageAssignmentPolicy.ID != nil && *accessPackageAssignmentPolicy.ID == state.ID), nil
+}
+
+func (AccessPackageAssignmentPolicyResource) simple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-%[1]d"
+  description  = "Test Catalog %[1]d"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "access-package-%[1]d"
+  description  = "Test Access Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_assignment_policy" "test" {
+  display_name      = "access-package-assignment-policy-%[1]d"
+  description       = "Test Access Package Assignnment Policy %[1]d"
+  access_package_id = azuread_access_package.test.id
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageAssignmentPolicyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_group" "test" {
+  display_name     = "test-group-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "testacc-asscess-assignemnt-%[1]d"
+  description  = "TestAcc Catalog %[1]d for access assignment policy"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "testacc-asscess-assignemnt-%[1]d"
+  description  = "TestAcc Access Package %[1]d for access assignment policy"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_assignment_policy" "test" {
+  display_name      = "testacc-asscess-assignemnt-%[1]d"
+  description       = "TestAcc Access Package Assignnment Policy %[1]d"
+  duration_in_days  = 90
+  access_package_id = azuread_access_package.test.id
+  requestor_settings {
+    scope_type = "AllExistingDirectoryMemberUsers"
+  }
+  approval_settings {
+    is_approval_required     = true
+    approval_stage {
+	  approval_timeout_in_days = 14
+        primary_approver {
+          object_id                = azuread_group.test.object_id
+		  subject_type             = "groupMembers"
+      }
+    }
+  }
+  assignment_review_settings {
+    is_enabled                     = true
+	review_frequency               = "weekly"
+	duration_in_days               = 3
+    review_type      			   = "Self"
+	access_review_timeout_behavior = "keepAccess"	
+  }
+  question {
+	text {
+		default_text = "hello, how are you?"
+	}	
+  }
+}
+`, data.RandomInteger, data.RandomPassword)
+}
+
+func (AccessPackageAssignmentPolicyResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "requestor" {
+  user_principal_name = "testAccAssignmentPolicyCR'%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUserCR-%[1]d"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "first_approver" {
+  user_principal_name = "testAccAssignmentPolicyCF'%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUserCF-%[1]d"
+  password            = "%[2]s"
+}
+
+resource "azuread_group" "second_approver" {
+  display_name     = "test-group-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "testacc-asscess-assignemnt-%[1]d"
+  description  = "TestAcc Catalog %[1]d for access assignment policy"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "testacc-asscess-assignemnt-%[1]d"
+  description  = "Test Access Package %[1]d for assignment policy"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_assignment_policy" "test" {
+  display_name      = "access-package-assignment-policy-%[1]d"
+  description       = "Test Access Package Assignnment Policy %[1]d"
+  can_extend        = true
+  expiration_date   = "2096-09-23T01:02:03Z"
+  access_package_id = azuread_access_package.test.id
+  requestor_settings {
+    scope_type      = "SpecificDirectorySubjects"
+    accept_requests = true
+    requestor {
+      object_id    = azuread_user.requestor.object_id
+	  subject_type = "singleUser"
+    }
+  }
+  approval_settings {
+    is_approval_required                = true
+    is_approval_required_for_extension  = true
+    is_requestor_justification_required = true
+    approval_stage {
+      approval_timeout_in_days            = 14
+      is_approver_justification_required  = true
+      is_alternative_approval_enabled     = true
+      enable_alternative_approval_in_days = 8
+      primary_approver {
+        object_id    = azuread_user.first_approver.object_id
+		subject_type = "singleUser"	
+      }
+      alternative_approver {
+        object_id    = azuread_group.second_approver.object_id
+		subject_type = "groupMembers"	
+      }
+    }
+
+    approval_stage {
+      approval_timeout_in_days            = 14
+      primary_approver {
+        object_id    = azuread_group.second_approver.object_id
+		subject_type = "groupMembers"
+      }
+      primary_approver {
+        object_id    = azuread_user.first_approver.object_id
+		subject_type = "singleUser"
+		is_backup    = true
+      }
+    }
+  }
+  assignment_review_settings {
+    is_enabled                         = true
+    review_frequency                   = "annual"
+    review_type                        = "Reviewers"
+	duration_in_days                   = "10"
+	is_access_recommendation_enabled   = true
+	access_review_timeout_behavior     = "acceptAccessRecommendation"
+	reviewer {
+	  object_id    = azuread_user.first_approver.object_id
+	  subject_type = "singleUser"
+    }
+  }
+
+  question {
+    is_required             = true
+    sequence                = 1
+    text {
+      default_text = "Hello Why"
+      localized_text {
+        language_code = "CN"
+        content       = "Hello why CN?"
+      }
+      localized_text {
+        language_code = "FR"
+        content       = "Hello why BE?"
+      }
+    }
+  }
+
+  question {
+    is_required             = false
+    sequence                = 2
+	choice {
+		actual_value = "a"
+		display_value {
+			default_text = "AA"
+			localized_text {
+				language_code = "CN"
+			    content       = "AAB"
+			}
+		}
+	}
+    text {
+      default_text = "Hello Why again"
+    }
+  }
+}
+
+`, data.RandomInteger, data.RandomPassword)
+}

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -138,18 +138,18 @@ resource "azuread_group" "test" {
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-asscess-assignemnt-%[1]d"
+  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "testacc-asscess-assignemnt-%[1]d"
+  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Access Package %[1]d for access assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "testacc-asscess-assignemnt-%[1]d"
+  display_name      = "testacc-asscess-assignment-%[1]d"
   description       = "TestAcc Access Package Assignnment Policy %[1]d"
   duration_in_days  = 90
   access_package_id = azuread_access_package.test.id
@@ -202,12 +202,12 @@ resource "azuread_group" "second_approver" {
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-asscess-assignemnt-%[1]d"
+  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "testacc-asscess-assignemnt-%[1]d"
+  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "Test Access Package %[1]d for assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -236,8 +236,7 @@ resource "azuread_access_package_assignment_policy" "test" {
       is_alternative_approval_enabled     = true
       enable_alternative_approval_in_days = 8
       primary_approver {
-        object_id    = azuread_group.first_approver.object_id
-		subject_type = "groupMembers"	
+		subject_type = "requestorManager"	
       }
       alternative_approver {
         object_id    = azuread_group.second_approver.object_id

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
-	"github.com/manicminer/hamilton/odata"
 )
 
 type AccessPackageAssignmentPolicyResource struct{}
@@ -95,14 +95,14 @@ func (AccessPackageAssignmentPolicyResource) Exists(ctx context.Context, clients
 	client := clients.IdentityGovernance.AccessPackageAssignmentPolicyClient
 	client.BaseClient.DisableRetries = true
 
-	accessPackageAssignmentPolicy, status, err := client.Get(ctx, state.ID, odata.Query{})
+	_, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {
 		if status == http.StatusNotFound {
-			return nil, fmt.Errorf("Access package assignment policy with object ID %q does not exist", state.ID)
+			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("failed to retrieve Access package assignment policy with object ID %q: %+v", state.ID, err)
+		return nil, fmt.Errorf("failed to retrieve Access package assignment policy with ID %q: %+v", state.ID, err)
 	}
-	return utils.Bool(accessPackageAssignmentPolicy.ID != nil && *accessPackageAssignmentPolicy.ID == state.ID), nil
+	return utils.Bool(true), nil
 }
 
 func (AccessPackageAssignmentPolicyResource) simple(data acceptance.TestData) string {
@@ -153,26 +153,31 @@ resource "azuread_access_package_assignment_policy" "test" {
   description       = "TestAcc Access Package Assignnment Policy %[1]d"
   duration_in_days  = 90
   access_package_id = azuread_access_package.test.id
+
   requestor_settings {
     scope_type = "AllExistingDirectoryMemberUsers"
   }
+
   approval_settings {
-    is_approval_required = true
+    approval_required = true
     approval_stage {
       approval_timeout_in_days = 14
+
       primary_approver {
         object_id    = azuread_group.test.object_id
         subject_type = "groupMembers"
       }
     }
   }
+
   assignment_review_settings {
-    is_enabled                     = true
+    enabled                        = true
     review_frequency               = "weekly"
     duration_in_days               = 3
     review_type                    = "Self"
     access_review_timeout_behavior = "keepAccess"
   }
+
   question {
     text {
       default_text = "hello, how are you?"
@@ -201,42 +206,48 @@ resource "azuread_group" "second_approver" {
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "test_catalog" {  
+resource "azuread_access_package_catalog" "test_catalog" {
   display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
   display_name = "testacc-asscess-assignment-%[1]d"
-  description  = "Test Access Package %[1]d for assignment policy"  
+  description  = "Test Access Package %[1]d for assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 resource "azuread_access_package_assignment_policy" "test" {
   display_name      = "access-package-assignment-policy-%[1]d"
-  description       = "Test Access Package Assignnment Policy %[1]d"  
-  can_extend        = true
+  description       = "Test Access Package Assignnment Policy %[1]d"
+  extension_enabled = true
   expiration_date   = "2096-09-23T01:02:03Z"
   access_package_id = azuread_access_package.test.id
+
   requestor_settings {
-    scope_type      = "SpecificDirectorySubjects"
-    accept_requests = true
+    scope_type        = "SpecificDirectorySubjects"
+    requests_accepted = true
+
     requestor {
       object_id    = azuread_group.requestor.object_id
-      subject_type = "groupMembers"    
-	}
+      subject_type = "groupMembers"
+    }
   }
+
   approval_settings {
-    is_approval_required                = true
-    is_approval_required_for_extension  = true
-    is_requestor_justification_required = true
+    approval_required                = true
+    approval_required_for_extension  = true
+    requestor_justification_required = true
+
     approval_stage {
       approval_timeout_in_days            = 14
-      is_approver_justification_required  = true
-      is_alternative_approval_enabled     = true
+      approver_justification_required     = true
+      alternative_approval_enabled        = true
       enable_alternative_approval_in_days = 8
+
       primary_approver {
         subject_type = "requestorManager"
       }
+
       alternative_approver {
         object_id    = azuread_group.second_approver.object_id
         subject_type = "groupMembers"
@@ -245,24 +256,28 @@ resource "azuread_access_package_assignment_policy" "test" {
 
     approval_stage {
       approval_timeout_in_days = 14
+
       primary_approver {
         object_id    = azuread_group.second_approver.object_id
         subject_type = "groupMembers"
       }
+
       primary_approver {
         object_id    = azuread_group.first_approver.object_id
         subject_type = "groupMembers"
-        is_backup    = true
+        backup       = true
       }
     }
   }
+
   assignment_review_settings {
-    is_enabled                       = true
-    review_frequency                 = "annual"
-    review_type                      = "Reviewers"
-    duration_in_days                 = "10"
-    is_access_recommendation_enabled = true
-    access_review_timeout_behavior   = "acceptAccessRecommendation"
+    enabled                        = true
+    review_frequency               = "annual"
+    review_type                    = "Reviewers"
+    duration_in_days               = "10"
+    access_recommendation_enabled  = true
+    access_review_timeout_behavior = "acceptAccessRecommendation"
+
     reviewer {
       object_id    = azuread_group.first_approver.object_id
       subject_type = "groupMembers"
@@ -270,14 +285,17 @@ resource "azuread_access_package_assignment_policy" "test" {
   }
 
   question {
-    is_required = true
-    sequence    = 1
+    required = true
+    sequence = 1
+
     text {
       default_text = "Hello Why"
+
       localized_text {
         language_code = "CN"
         content       = "Hello why CN?"
       }
+
       localized_text {
         language_code = "FR"
         content       = "Hello why BE?"
@@ -286,18 +304,22 @@ resource "azuread_access_package_assignment_policy" "test" {
   }
 
   question {
-    is_required = false
-    sequence    = 2
+    required = false
+    sequence = 2
+
     choice {
       actual_value = "a"
+
       display_value {
         default_text = "AA"
+
         localized_text {
           language_code = "CN"
           content       = "AAB"
         }
       }
     }
+
     text {
       default_text = "Hello Why again"
     }

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -201,17 +201,20 @@ resource "azuread_group" "second_approver" {
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "test_catalog" {  display_name = "testacc-asscess-assignment-%[1]d"
+resource "azuread_access_package_catalog" "test_catalog" {  
+  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
   display_name = "testacc-asscess-assignment-%[1]d"
-  description  = "Test Access Package %[1]d for assignment policy"  catalog_id   = azuread_access_package_catalog.test_catalog.id
+  description  = "Test Access Package %[1]d for assignment policy"  
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 resource "azuread_access_package_assignment_policy" "test" {
   display_name      = "access-package-assignment-policy-%[1]d"
-  description       = "Test Access Package Assignnment Policy %[1]d"  can_extend        = true
+  description       = "Test Access Package Assignnment Policy %[1]d"  
+  can_extend        = true
   expiration_date   = "2096-09-23T01:02:03Z"
   access_package_id = azuread_access_package.test.id
   requestor_settings {
@@ -219,7 +222,8 @@ resource "azuread_access_package_assignment_policy" "test" {
     accept_requests = true
     requestor {
       object_id    = azuread_group.requestor.object_id
-      subject_type = "groupMembers"    }
+      subject_type = "groupMembers"    
+	}
   }
   approval_settings {
     is_approval_required                = true

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -157,26 +157,26 @@ resource "azuread_access_package_assignment_policy" "test" {
     scope_type = "AllExistingDirectoryMemberUsers"
   }
   approval_settings {
-    is_approval_required     = true
+    is_approval_required = true
     approval_stage {
-	  approval_timeout_in_days = 14
-        primary_approver {
-          object_id                = azuread_group.test.object_id
-		  subject_type             = "groupMembers"
+      approval_timeout_in_days = 14
+      primary_approver {
+        object_id    = azuread_group.test.object_id
+        subject_type = "groupMembers"
       }
     }
   }
   assignment_review_settings {
     is_enabled                     = true
-	review_frequency               = "weekly"
-	duration_in_days               = 3
-    review_type      			   = "Self"
-	access_review_timeout_behavior = "keepAccess"	
+    review_frequency               = "weekly"
+    duration_in_days               = 3
+    review_type                    = "Self"
+    access_review_timeout_behavior = "keepAccess"
   }
   question {
-	text {
-		default_text = "hello, how are you?"
-	}	
+    text {
+      default_text = "hello, how are you?"
+    }
   }
 }
 `, data.RandomInteger)
@@ -201,21 +201,17 @@ resource "azuread_group" "second_approver" {
   security_enabled = true
 }
 
-resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-asscess-assignment-%[1]d"
+resource "azuread_access_package_catalog" "test_catalog" {  display_name = "testacc-asscess-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
   display_name = "testacc-asscess-assignment-%[1]d"
-  description  = "Test Access Package %[1]d for assignment policy"
-  catalog_id   = azuread_access_package_catalog.test_catalog.id
+  description  = "Test Access Package %[1]d for assignment policy"  catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
-
 resource "azuread_access_package_assignment_policy" "test" {
   display_name      = "access-package-assignment-policy-%[1]d"
-  description       = "Test Access Package Assignnment Policy %[1]d"
-  can_extend        = true
+  description       = "Test Access Package Assignnment Policy %[1]d"  can_extend        = true
   expiration_date   = "2096-09-23T01:02:03Z"
   access_package_id = azuread_access_package.test.id
   requestor_settings {
@@ -223,8 +219,7 @@ resource "azuread_access_package_assignment_policy" "test" {
     accept_requests = true
     requestor {
       object_id    = azuread_group.requestor.object_id
-	  subject_type = "groupMembers"
-    }
+      subject_type = "groupMembers"    }
   }
   approval_settings {
     is_approval_required                = true
@@ -236,43 +231,43 @@ resource "azuread_access_package_assignment_policy" "test" {
       is_alternative_approval_enabled     = true
       enable_alternative_approval_in_days = 8
       primary_approver {
-		subject_type = "requestorManager"	
+        subject_type = "requestorManager"
       }
       alternative_approver {
         object_id    = azuread_group.second_approver.object_id
-		subject_type = "groupMembers"	
+        subject_type = "groupMembers"
       }
     }
 
     approval_stage {
-      approval_timeout_in_days            = 14
+      approval_timeout_in_days = 14
       primary_approver {
         object_id    = azuread_group.second_approver.object_id
-		subject_type = "groupMembers"
+        subject_type = "groupMembers"
       }
       primary_approver {
         object_id    = azuread_group.first_approver.object_id
-		subject_type = "groupMembers"
-		is_backup    = true
+        subject_type = "groupMembers"
+        is_backup    = true
       }
     }
   }
   assignment_review_settings {
-    is_enabled                         = true
-    review_frequency                   = "annual"
-    review_type                        = "Reviewers"
-	duration_in_days                   = "10"
-	is_access_recommendation_enabled   = true
-	access_review_timeout_behavior     = "acceptAccessRecommendation"
-	reviewer {
-	  object_id    = azuread_group.first_approver.object_id
-	  subject_type = "groupMembers"
+    is_enabled                       = true
+    review_frequency                 = "annual"
+    review_type                      = "Reviewers"
+    duration_in_days                 = "10"
+    is_access_recommendation_enabled = true
+    access_review_timeout_behavior   = "acceptAccessRecommendation"
+    reviewer {
+      object_id    = azuread_group.first_approver.object_id
+      subject_type = "groupMembers"
     }
   }
 
   question {
-    is_required             = true
-    sequence                = 1
+    is_required = true
+    sequence    = 1
     text {
       default_text = "Hello Why"
       localized_text {
@@ -287,23 +282,22 @@ resource "azuread_access_package_assignment_policy" "test" {
   }
 
   question {
-    is_required             = false
-    sequence                = 2
-	choice {
-		actual_value = "a"
-		display_value {
-			default_text = "AA"
-			localized_text {
-				language_code = "CN"
-			    content       = "AAB"
-			}
-		}
-	}
+    is_required = false
+    sequence    = 2
+    choice {
+      actual_value = "a"
+      display_value {
+        default_text = "AA"
+        localized_text {
+          language_code = "CN"
+          content       = "AAB"
+        }
+      }
+    }
     text {
       default_text = "Hello Why again"
     }
   }
 }
-
 `, data.RandomInteger)
 }

--- a/internal/services/identitygovernance/access_package_catalog_data_source.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source.go
@@ -1,0 +1,119 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func accessPackageCatalogDataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: accessPackageCatalogDataRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Description:  "The ID of this access package catalog.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"object_id", "display_name"},
+				ValidateFunc: validation.IsUUID,
+			},
+			"display_name": {
+				Description:  "The display name of the access package catalog.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"object_id", "display_name"},
+			},
+			"description": {
+				Description: "The description of the access package catalog.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
+			"state": {
+				Description: "Has the value published if the access packages are available for management. The possible values are: unpublished and published.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ValidateFunc: validation.StringInSlice([]string{
+					msgraph.AccessPackageCatalogStatePublished,
+					msgraph.AccessPackageCatalogStateUnpublished,
+				}, true),
+			},
+			"is_externally_visible": {
+				Description: "Whether the access packages in this catalog can be requested by users outside of the tenant.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	var catalog *msgraph.AccessPackageCatalog
+	if id, ok := d.GetOk("object_id"); ok {
+		c, _, err := client.Get(ctx, id.(string), odata.Query{})
+		if err != nil {
+			return tf.ErrorDiagF(err, "Error retrieving access package catalog with id %q", id)
+		}
+		catalog = c
+	}
+	if displayName, ok := d.GetOk("display_name"); ok {
+		query := odata.Query{
+			Filter: fmt.Sprintf("displayName eq '%s'", displayName),
+		}
+
+		result, _, err := client.List(ctx, query)
+		if err != nil {
+			return tf.ErrorDiagF(err, "Error listing access package catalog with filter %s", query.Filter)
+		}
+		if result == nil || len(*result) == 0 {
+			return tf.ErrorDiagF(fmt.Errorf("No access package catalog matched with filter %s", query.Filter), "Access access package catalog not found!")
+		}
+		if len(*result) > 1 {
+			return tf.ErrorDiagF(fmt.Errorf("Multiple access package catalog matched with filter %s", query.Filter), "Multitple access package catalog found!")
+		}
+
+		for _, c := range *result {
+			name := c.DisplayName
+			if name == nil {
+				continue
+			}
+
+			if *name == displayName.(string) {
+				catalog = &c
+				break
+			}
+		}
+	}
+
+	if catalog == nil {
+		return tf.ErrorDiagF(fmt.Errorf("No access package catalog matched with specified parameter"), "Access access package catalog not found!")
+	}
+
+	d.SetId(*catalog.ID)
+	tf.Set(d, "object_id", catalog.ID)
+	tf.Set(d, "display_name", catalog.DisplayName)
+	tf.Set(d, "description", catalog.Description)
+	tf.Set(d, "state", catalog.State)
+	tf.Set(d, "is_externally_visible", catalog.IsExternallyVisible)
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_catalog_data_source.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source.go
@@ -3,6 +3,7 @@ package identitygovernance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -46,14 +47,14 @@ func accessPackageCatalogDataSource() *schema.Resource {
 				Computed:    true,
 			},
 
-			"state": {
-				Description: "Has the value published if the access packages are available for management. The possible values are: unpublished and published",
-				Type:        schema.TypeString,
+			"externally_visible": {
+				Description: "Whether the access packages in this catalog can be requested by users outside the tenant",
+				Type:        schema.TypeBool,
 				Computed:    true,
 			},
 
-			"externally_visible": {
-				Description: "Whether the access packages in this catalog can be requested by users outside of the tenant",
+			"published": {
+				Description: "Whether the access packages in this catalog are available for management",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
@@ -107,13 +108,18 @@ func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, m
 		return tf.ErrorDiagF(fmt.Errorf("no access package catalog matched with specified parameters"), "Access access package catalog not found!")
 	}
 
+	published := false
+	if strings.EqualFold(catalog.State, msgraph.AccessPackageCatalogStatusPublished) {
+		published = true
+	}
+
 	d.SetId(*catalog.ID)
 
 	tf.Set(d, "object_id", catalog.ID)
 	tf.Set(d, "display_name", catalog.DisplayName)
 	tf.Set(d, "description", catalog.Description)
-	tf.Set(d, "state", catalog.State)
 	tf.Set(d, "externally_visible", catalog.IsExternallyVisible)
+	tf.Set(d, "published", published)
 
 	return nil
 }

--- a/internal/services/identitygovernance/access_package_catalog_data_source.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
 	"github.com/manicminer/hamilton/msgraph"
-	"github.com/manicminer/hamilton/odata"
 )
 
 func accessPackageCatalogDataSource() *schema.Resource {
@@ -24,40 +24,37 @@ func accessPackageCatalogDataSource() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"object_id": {
-				Description:  "The ID of this access package catalog.",
+				Description:  "The ID of this access package catalog",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ExactlyOneOf: []string{"object_id", "display_name"},
 				ValidateFunc: validation.IsUUID,
+				ExactlyOneOf: []string{"object_id", "display_name"},
 			},
+
 			"display_name": {
-				Description:  "The display name of the access package catalog.",
+				Description:  "The display name of the access package catalog",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ExactlyOneOf: []string{"object_id", "display_name"},
 			},
+
 			"description": {
-				Description: "The description of the access package catalog.",
+				Description: "The description of the access package catalog",
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
 			},
+
 			"state": {
-				Description: "Has the value published if the access packages are available for management. The possible values are: unpublished and published.",
+				Description: "Has the value published if the access packages are available for management. The possible values are: unpublished and published",
 				Type:        schema.TypeString,
-				Optional:    true,
 				Computed:    true,
-				ValidateFunc: validation.StringInSlice([]string{
-					msgraph.AccessPackageCatalogStatePublished,
-					msgraph.AccessPackageCatalogStateUnpublished,
-				}, true),
 			},
-			"is_externally_visible": {
-				Description: "Whether the access packages in this catalog can be requested by users outside of the tenant.",
+
+			"externally_visible": {
+				Description: "Whether the access packages in this catalog can be requested by users outside of the tenant",
 				Type:        schema.TypeBool,
-				Optional:    true,
 				Computed:    true,
 			},
 		},
@@ -67,15 +64,17 @@ func accessPackageCatalogDataSource() *schema.Resource {
 func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
 
+	objectId := d.Get("object_id").(string)
+	displayName := d.Get("display_name").(string)
+
 	var catalog *msgraph.AccessPackageCatalog
-	if id, ok := d.GetOk("object_id"); ok {
-		c, _, err := client.Get(ctx, id.(string), odata.Query{})
+	var err error
+	if objectId != "" {
+		catalog, _, err = client.Get(ctx, objectId, odata.Query{})
 		if err != nil {
-			return tf.ErrorDiagF(err, "Error retrieving access package catalog with id %q", id)
+			return tf.ErrorDiagF(err, "Error retrieving access package catalog with id %q", objectId)
 		}
-		catalog = c
-	}
-	if displayName, ok := d.GetOk("display_name"); ok {
+	} else if displayName != "" {
 		query := odata.Query{
 			Filter: fmt.Sprintf("displayName eq '%s'", displayName),
 		}
@@ -85,10 +84,10 @@ func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, m
 			return tf.ErrorDiagF(err, "Error listing access package catalog with filter %s", query.Filter)
 		}
 		if result == nil || len(*result) == 0 {
-			return tf.ErrorDiagF(fmt.Errorf("No access package catalog matched with filter %s", query.Filter), "Access access package catalog not found!")
+			return tf.ErrorDiagF(fmt.Errorf("no access package catalog matched with filter %s", query.Filter), "Access package catalog not found!")
 		}
 		if len(*result) > 1 {
-			return tf.ErrorDiagF(fmt.Errorf("Multiple access package catalog matched with filter %s", query.Filter), "Multitple access package catalog found!")
+			return tf.ErrorDiagF(fmt.Errorf("multiple access package catalog matched with filter %s", query.Filter), "Multiple access package catalog found!")
 		}
 
 		for _, c := range *result {
@@ -97,7 +96,7 @@ func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, m
 				continue
 			}
 
-			if *name == displayName.(string) {
+			if *name == displayName {
 				catalog = &c
 				break
 			}
@@ -105,15 +104,16 @@ func accessPackageCatalogDataRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if catalog == nil {
-		return tf.ErrorDiagF(fmt.Errorf("No access package catalog matched with specified parameter"), "Access access package catalog not found!")
+		return tf.ErrorDiagF(fmt.Errorf("no access package catalog matched with specified parameters"), "Access access package catalog not found!")
 	}
 
 	d.SetId(*catalog.ID)
+
 	tf.Set(d, "object_id", catalog.ID)
 	tf.Set(d, "display_name", catalog.DisplayName)
 	tf.Set(d, "description", catalog.Description)
 	tf.Set(d, "state", catalog.State)
-	tf.Set(d, "is_externally_visible", catalog.IsExternallyVisible)
+	tf.Set(d, "externally_visible", catalog.IsExternallyVisible)
 
 	return nil
 }

--- a/internal/services/identitygovernance/access_package_catalog_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source_test.go
@@ -1,0 +1,66 @@
+package identitygovernance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type AccessPackageCatalogDataSource struct{}
+
+func TestAccAccessPackageCatalogDataSource_byId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_access_package_catalog", "test")
+	r := AccessPackageCatalogDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.byId(data),
+			Check:  r.testCheckFunc(data),
+		},
+	})
+}
+
+func TestAccAccessPackageCatalogDataSource_byDisplayName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_access_package_catalog", "test")
+	r := AccessPackageCatalogDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.byDisplayName(data),
+			Check:  r.testCheckFunc(data),
+		},
+	})
+}
+
+func (AccessPackageCatalogDataSource) testCheckFunc(data acceptance.TestData) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Test access package catalog %[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("test-access-package-catalog-%[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("state").HasValue(msgraph.AccessPackageCatalogStateUnpublished),
+		check.That(data.ResourceName).Key("is_externally_visible").HasValue("false"),
+	)
+}
+
+func (AccessPackageCatalogDataSource) byId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_access_package_catalog" "test" {
+  object_id = azuread_access_package_catalog.test.id
+}
+`, AccessPackageCatalogResource{}.complete(data))
+}
+
+func (AccessPackageCatalogDataSource) byDisplayName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_access_package_catalog" "test" {
+  display_name = azuread_access_package_catalog.test.display_name
+}
+`, AccessPackageCatalogResource{}.complete(data))
+}

--- a/internal/services/identitygovernance/access_package_catalog_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source_test.go
@@ -41,7 +41,7 @@ func (AccessPackageCatalogDataSource) testCheckFunc(data acceptance.TestData) re
 		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Test access package catalog %[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("test-access-package-catalog-%[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("state").HasValue(msgraph.AccessPackageCatalogStateUnpublished),
-		check.That(data.ResourceName).Key("is_externally_visible").HasValue("false"),
+		check.That(data.ResourceName).Key("externally_visible").HasValue("false"),
 	)
 }
 

--- a/internal/services/identitygovernance/access_package_catalog_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
-	"github.com/manicminer/hamilton/msgraph"
 )
 
 type AccessPackageCatalogDataSource struct{}
@@ -40,8 +39,8 @@ func (AccessPackageCatalogDataSource) testCheckFunc(data acceptance.TestData) re
 	return resource.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Test access package catalog %[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("test-access-package-catalog-%[1]d", data.RandomInteger)),
-		check.That(data.ResourceName).Key("state").HasValue(msgraph.AccessPackageCatalogStateUnpublished),
 		check.That(data.ResourceName).Key("externally_visible").HasValue("false"),
+		check.That(data.ResourceName).Key("published").HasValue("false"),
 	)
 }
 

--- a/internal/services/identitygovernance/access_package_catalog_resource.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource.go
@@ -1,0 +1,175 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+const accessPackageCatalogResourceName = "azuread_access_package_catalog"
+
+func accessPackageCatalogResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: accessPackageCatalogResourceCreate,
+		ReadContext:   accessPackageCatalogResourceRead,
+		UpdateContext: accessPackageCatalogResourceUpdate,
+		DeleteContext: accessPackageCatalogResourceDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			if _, err := uuid.ParseUUID(id); err != nil {
+				return fmt.Errorf("specified ID (%q) is not valid: %s", id, err)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Description:      "The display name of the access package catalog.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"description": {
+				Description:      "The description of the access package catalog.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"state": {
+				Description: "Has the value published if the access packages are available for management. The possible values are: unpublished and published.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "published",
+				ValidateFunc: validation.StringInSlice([]string{
+					msgraph.AccessPackageCatalogStatePublished,
+					msgraph.AccessPackageCatalogStateUnpublished,
+				}, true),
+			},
+			"is_externally_visible": {
+				Description: "Whether the access packages in this catalog can be requested by users outside of the tenant.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
+		},
+	}
+}
+
+func accessPackageCatalogResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	display_name := d.Get("display_name").(string)
+	properties := msgraph.AccessPackageCatalog{
+		DisplayName:         utils.String(display_name),
+		Description:         utils.String(d.Get("description").(string)),
+		State:               d.Get("state").(string),
+		IsExternallyVisible: utils.Bool(d.Get("is_externally_visible").(bool)),
+	}
+	accessPackageCatalog, _, err := client.Create(ctx, properties)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Creating access package catalog %q", display_name)
+	}
+
+	d.SetId(*accessPackageCatalog.ID)
+	return accessPackageCatalogResourceRead(ctx, d, meta)
+}
+
+func accessPackageCatalogResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	objectId := d.Id()
+	tf.LockByName(accessPackageCatalogResourceName, objectId)
+	defer tf.UnlockByName(accessPackageCatalogResourceName, objectId)
+
+	properties := msgraph.AccessPackageCatalog{
+		ID:                  utils.String(d.Id()),
+		DisplayName:         utils.String(d.Get("display_name").(string)),
+		Description:         utils.String(d.Get("description").(string)),
+		State:               d.Get("state").(string),
+		IsExternallyVisible: utils.Bool(d.Get("is_externally_visible").(bool)),
+	}
+
+	if _, err := client.Update(ctx, properties); err != nil {
+		return tf.ErrorDiagF(err, "Could not update access package catalog with ID: %q", objectId)
+	}
+
+	return accessPackageCatalogResourceRead(ctx, d, meta)
+}
+
+func accessPackageCatalogResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	objectId := d.Id()
+	accessPackageCatalog, status, err := client.Get(ctx, objectId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package catalog with Object ID %q was not found - removing from state!", objectId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving access package catalog with object ID: %q", objectId)
+	}
+
+	tf.Set(d, "display_name", accessPackageCatalog.DisplayName)
+	tf.Set(d, "description", accessPackageCatalog.Description)
+	tf.Set(d, "state", accessPackageCatalog.State)
+	tf.Set(d, "is_externally_visible", accessPackageCatalog.IsExternallyVisible)
+
+	return nil
+}
+
+func accessPackageCatalogResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+	accessPackageCatalogId := d.Id()
+
+	_, status, err := client.Get(ctx, accessPackageCatalogId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return tf.ErrorDiagPathF(fmt.Errorf("Access package catalog was not found"), "id", "Retrieving user with object ID %q", accessPackageCatalogId)
+		}
+
+		return tf.ErrorDiagPathF(err, "id", "Retrieving access package catalog with object ID %q", accessPackageCatalogId)
+	}
+
+	status, err = client.Delete(ctx, accessPackageCatalogId)
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Deleting access package catalog with object ID %q, got status %d", accessPackageCatalogId, status)
+	}
+
+	// Wait for user object to be deleted
+	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		client.BaseClient.DisableRetries = true
+		if _, status, err := client.Get(ctx, accessPackageCatalogId, odata.Query{}); err != nil {
+			if status == http.StatusNotFound {
+				return utils.Bool(false), nil
+			}
+			return nil, err
+		}
+		return utils.Bool(true), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for deletion of access package catalog with object ID %q", accessPackageCatalogId)
+	}
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_catalog_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource_test.go
@@ -1,0 +1,115 @@
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/odata"
+)
+
+type AccessPackageCatalogResource struct{}
+
+func TestAccAccessPackageCatalog_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_catalog", "test")
+	r := AccessPackageCatalogResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageCatalog_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_catalog", "test")
+	r := AccessPackageCatalogResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageCatalog_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_catalog", "test")
+	r := AccessPackageCatalogResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccessPackageCatalogResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.AccessPackageCatalogClient
+	client.BaseClient.DisableRetries = true
+
+	accessPackageCatalog, status, err := client.Get(ctx, state.ID, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return nil, fmt.Errorf("Access package catalog with object ID %q does not exist", state.ID)
+		}
+		return nil, fmt.Errorf("failed to retrieve access package catalog with object ID %q: %+v", state.ID, err)
+	}
+	return utils.Bool(accessPackageCatalog.ID != nil && *accessPackageCatalog.ID == state.ID), nil
+}
+
+func (AccessPackageCatalogResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test" {
+  display_name = "test-access-package-catalog-%[1]d"
+  description  = "Test access package catalog %[1]d"
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageCatalogResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test" {
+  display_name 			= "test-access-package-catalog-%[1]d"
+  description  			= "Test access package catalog %[1]d"
+  state		   			= "unpublished"
+  is_externally_visible = false
+}
+`, data.RandomInteger)
+}

--- a/internal/services/identitygovernance/access_package_catalog_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource_test.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
-	"github.com/manicminer/hamilton/odata"
 )
 
 type AccessPackageCatalogResource struct{}
@@ -80,14 +80,15 @@ func (AccessPackageCatalogResource) Exists(ctx context.Context, clients *clients
 	client := clients.IdentityGovernance.AccessPackageCatalogClient
 	client.BaseClient.DisableRetries = true
 
-	accessPackageCatalog, status, err := client.Get(ctx, state.ID, odata.Query{})
+	_, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {
 		if status == http.StatusNotFound {
-			return nil, fmt.Errorf("Access package catalog with object ID %q does not exist", state.ID)
+			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("failed to retrieve access package catalog with object ID %q: %+v", state.ID, err)
+
+		return nil, fmt.Errorf("failed to retrieve access package catalog with ID %q: %+v", state.ID, err)
 	}
-	return utils.Bool(accessPackageCatalog.ID != nil && *accessPackageCatalog.ID == state.ID), nil
+	return utils.Bool(true), nil
 }
 
 func (AccessPackageCatalogResource) basic(data acceptance.TestData) string {
@@ -106,10 +107,10 @@ func (AccessPackageCatalogResource) complete(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test" {
-  display_name 			= "test-access-package-catalog-%[1]d"
-  description  			= "Test access package catalog %[1]d"
-  state		   			= "unpublished"
-  is_externally_visible = false
+  display_name       = "test-access-package-catalog-%[1]d"
+  description        = "Test access package catalog %[1]d"
+  state              = "unpublished"
+  externally_visible = false
 }
 `, data.RandomInteger)
 }

--- a/internal/services/identitygovernance/access_package_catalog_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource_test.go
@@ -109,8 +109,8 @@ provider "azuread" {}
 resource "azuread_access_package_catalog" "test" {
   display_name       = "test-access-package-catalog-%[1]d"
   description        = "Test access package catalog %[1]d"
-  state              = "unpublished"
   externally_visible = false
+  published          = false
 }
 `, data.RandomInteger)
 }

--- a/internal/services/identitygovernance/access_package_data_source.go
+++ b/internal/services/identitygovernance/access_package_data_source.go
@@ -1,0 +1,120 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func accessPackageDataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: accessPackageDataRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Description:  "The ID of this access package.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"display_name": {
+				Description:   "The display name of the access package.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id"},
+				RequiredWith:  []string{"catalog_id"},
+			},
+			"description": {
+				Description: "The description of the access package.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
+			"is_hidden": {
+				Description: "Whether the access package is hidden from the requestor.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+			"catalog_id": {
+				Description:  "The ID of the Catalog this access package is in.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"display_name"},
+			},
+		},
+	}
+}
+
+func accessPackageDataRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+
+	var accessPackage *msgraph.AccessPackage
+	if id, ok := d.GetOk("object_id"); ok {
+		c, _, err := client.Get(ctx, id.(string), odata.Query{})
+		if err != nil {
+			return tf.ErrorDiagF(err, "Error retrieving access package with id %q", id)
+		}
+		accessPackage = c
+	}
+
+	displayName, ok := d.GetOk("display_name")
+	catalogId, okCatalog := d.GetOk("catalog_id")
+	if ok && okCatalog {
+		query := odata.Query{
+			// Filter: fmt.Sprintf("displayName eq '%s' and catalogId eq '%s'", displayName, catalogId),
+			// Filter: fmt.Sprintf("catalogId eq '%s'", catalogId),
+		}
+
+		result, _, err := client.List(ctx, query)
+		if err != nil {
+			return tf.ErrorDiagF(err, "Error listing access package with filter %s", query.Filter)
+		}
+		if result == nil || len(*result) == 0 {
+			return tf.ErrorDiagF(fmt.Errorf("No access package matched with filter %s", query.Filter), "Access access package not found!")
+		}
+		// if len(*result) > 1 {
+		// return tf.ErrorDiagF(fmt.Errorf("Multiple access package matched with filter %s", query.Filter), "Multitple access package found!")
+		// }
+
+		for _, c := range *result {
+			name := c.DisplayName
+			catalog := c.CatalogId
+			if name == nil || catalog == nil {
+				continue
+			}
+
+			if *name == displayName.(string) && *c.CatalogId == catalogId.(string) {
+				accessPackage = &c
+				break
+			}
+		}
+	}
+
+	if accessPackage == nil {
+		return tf.ErrorDiagF(fmt.Errorf("No access package matched with specified parameter"), "Access access package not found!")
+	}
+
+	d.SetId(*accessPackage.ID)
+	tf.Set(d, "object_id", accessPackage.ID)
+	tf.Set(d, "display_name", accessPackage.DisplayName)
+	tf.Set(d, "description", accessPackage.Description)
+	tf.Set(d, "is_hidden", accessPackage.IsHidden)
+	tf.Set(d, "catalog_id", accessPackage.CatalogId)
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_data_source_test.go
@@ -1,0 +1,67 @@
+package identitygovernance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+)
+
+type AccessPackageDataSource struct{}
+
+func TestAccAccessPackageDataSource_byId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_access_package", "test")
+	r := AccessPackageDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.byId(data),
+			Check:  r.testCheckFunc(data),
+		},
+	})
+}
+
+func TestAccAccessPackageDataSource_byDisplayName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_access_package", "test")
+	r := AccessPackageDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.byDisplayName(data),
+			Check:  r.testCheckFunc(data),
+		},
+	})
+}
+
+func (AccessPackageDataSource) testCheckFunc(data acceptance.TestData) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Access Package %[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("access-package-%[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("is_hidden").HasValue("true"),
+		check.That(data.ResourceName).Key("catalog_id").Exists(),
+		// check.That(data.ResourceName).Key("object_id").Exists(),
+	)
+}
+
+func (AccessPackageDataSource) byId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_access_package" "test" {
+  object_id = azuread_access_package.test.id
+}
+`, AccessPackageResource{}.complete(data))
+}
+
+func (AccessPackageDataSource) byDisplayName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_access_package" "test" {
+  display_name = azuread_access_package.test.display_name
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+`, AccessPackageResource{}.complete(data))
+}

--- a/internal/services/identitygovernance/access_package_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_data_source_test.go
@@ -39,9 +39,8 @@ func (AccessPackageDataSource) testCheckFunc(data acceptance.TestData) resource.
 	return resource.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Access Package %[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("access-package-%[1]d", data.RandomInteger)),
-		check.That(data.ResourceName).Key("is_hidden").HasValue("true"),
+		check.That(data.ResourceName).Key("hidden").HasValue("true"),
 		check.That(data.ResourceName).Key("catalog_id").Exists(),
-		// check.That(data.ResourceName).Key("object_id").Exists(),
 	)
 }
 

--- a/internal/services/identitygovernance/access_package_resource.go
+++ b/internal/services/identitygovernance/access_package_resource.go
@@ -1,0 +1,189 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+)
+
+const accessPackageResourceName = "azuread_access_package"
+
+func accessPackageResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: accessPackageResourceCreate,
+		ReadContext:   accessPackageResourceRead,
+		UpdateContext: accessPackageResourceUpdate,
+		DeleteContext: accessPackageResourceDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			if _, err := uuid.ParseUUID(id); err != nil {
+				return fmt.Errorf("specified ID (%q) is not valid: %s", id, err)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Description:      "The display name of the access package.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"description": {
+				Description:      "The description of the access package.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.NoEmptyStrings,
+			},
+			"is_hidden": {
+				Description: "Whether the access package is hidden from the requestor.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
+			"catalog_id": {
+				Description:      "The ID of the Catalog this access package will be created in.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validate.UUID,
+			},
+		},
+	}
+}
+
+func accessPackageResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+	accessPackageCatalogClient := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	displayName := d.Get("display_name").(string)
+	catalogId := d.Get("catalog_id").(string)
+	accessPackageCatalog, _, err := accessPackageCatalogClient.Get(ctx, catalogId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Retrieving access package catalog with object ID: %q", catalogId)
+	}
+
+	properties := msgraph.AccessPackage{
+		DisplayName: utils.String(displayName),
+		Description: utils.String(d.Get("description").(string)),
+		IsHidden:    utils.Bool(d.Get("is_hidden").(bool)),
+		Catalog:     accessPackageCatalog,
+		CatalogId:   accessPackageCatalog.ID,
+	}
+	accessPackage, _, err := client.Create(ctx, properties)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Creating access package %q", displayName)
+	}
+
+	d.SetId(*accessPackage.ID)
+	return accessPackageResourceRead(ctx, d, meta)
+}
+
+func accessPackageResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+	accessPackageCatalogClient := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	objectId := d.Id()
+	catalogId := d.Get("catalog_id").(string)
+	accessPackageCatalog, _, err := accessPackageCatalogClient.Get(ctx, catalogId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Retrieving access package with object ID: %q", catalogId)
+	}
+
+	tf.LockByName(accessPackageResourceName, objectId)
+	defer tf.UnlockByName(accessPackageResourceName, objectId)
+
+	properties := msgraph.AccessPackage{
+		ID:          utils.String(objectId),
+		DisplayName: utils.String(d.Get("display_name").(string)),
+		Description: utils.String(d.Get("description").(string)),
+		IsHidden:    utils.Bool(d.Get("is_hidden").(bool)),
+		Catalog:     accessPackageCatalog,
+		CatalogId:   accessPackageCatalog.ID,
+	}
+
+	if _, err := client.Update(ctx, properties); err != nil {
+		return tf.ErrorDiagF(err, "Could not update access package with ID: %q", objectId)
+	}
+
+	return accessPackageResourceRead(ctx, d, meta)
+}
+
+func accessPackageResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+
+	objectId := d.Id()
+	accessPackage, status, err := client.Get(ctx, objectId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package with Object ID %q was not found - removing from state!", objectId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving access package with object ID: %q", objectId)
+	}
+
+	tf.Set(d, "display_name", accessPackage.DisplayName)
+	tf.Set(d, "description", accessPackage.Description)
+	tf.Set(d, "is_hidden", accessPackage.IsHidden)
+	//v1.0 graph API doesn't contain this info however beta contains
+	tf.Set(d, "catalog_id", accessPackage.CatalogId)
+
+	return nil
+}
+
+func accessPackageResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+	accessPackageId := d.Id()
+
+	_, status, err := client.Get(ctx, accessPackageId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return tf.ErrorDiagPathF(fmt.Errorf("Access package was not found"), "id", "Retrieving user with object ID %q", accessPackageId)
+		}
+
+		return tf.ErrorDiagPathF(err, "id", "Retrieving access package with object ID %q", accessPackageId)
+	}
+
+	status, err = client.Delete(ctx, accessPackageId)
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Deleting access package with object ID %q, got status %d", accessPackageId, status)
+	}
+
+	// Wait for user object to be deleted
+	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		client.BaseClient.DisableRetries = true
+		if _, status, err := client.Get(ctx, accessPackageId, odata.Query{}); err != nil {
+			if status == http.StatusNotFound {
+				return utils.Bool(false), nil
+			}
+			return nil, err
+		}
+		return utils.Bool(true), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for deletion of access package with object ID %q", accessPackageId)
+	}
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
@@ -18,8 +18,6 @@ import (
 	"github.com/manicminer/hamilton/odata"
 )
 
-const resourceCatalogAssociationResourceName = "azuread_access_package_resource_catalog_association"
-
 func accessPackageResourceCatalogAssociationResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: accessPackageResourceCatalogAssociationResourceCreate,
@@ -154,7 +152,7 @@ func accessPackageResourceCatalogAssociationResourceDelete(ctx context.Context, 
 		CatalogId:             &catalogId,
 		AccessPackageResource: resource,
 	}
-	status, err = client.Delete(ctx, resourceCatalogAssociation)
+	_, err = client.Delete(ctx, resourceCatalogAssociation)
 	if err != nil {
 		return tf.ErrorDiagPathF(err, "id", "Deleting access package resource and catalog association with resource %q@%q and catalog id %q.",
 			*resourceCatalogAssociation.AccessPackageResource.OriginId, resourceCatalogAssociation.AccessPackageResource.OriginSystem, *resourceCatalogAssociation.CatalogId)

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
@@ -1,0 +1,164 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+const resourceCatalogAssociationResourceName = "azuread_access_package_resource_catalog_association"
+
+func accessPackageResourceCatalogAssociationResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: accessPackageResourceCatalogAssociationResourceCreate,
+		ReadContext:   accessPackageResourceCatalogAssociationResourceRead,
+		DeleteContext: accessPackageResourceCatalogAssociationResourceDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			ids := strings.Split(id, idDelimitor)
+			if len(ids) != 2 {
+				return fmt.Errorf("The ID must be in the format of catalog_id%sresource_origin_id", idDelimitor)
+			}
+			for _, i := range ids {
+				if _, err := uuid.ParseUUID(i); err != nil {
+					return fmt.Errorf("specified ID (%q) is not valid: %s", i, err)
+				}
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"resource_origin_id": {
+				Description: "The unique identifier of the resource in the origin system. In the case of an Azure AD group, this is the identifier of the group.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"resource_origin_system": {
+				Description: "The type of the resource in the origin system, such as SharePointOnline, AadApplication or AadGroup.",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+			},
+			"catalog_id": {
+				Description: "The unique ID of the access package catalog.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func accessPackageResourceCatalogAssociationResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRequestClient
+	accessPackageCatalogClient := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogClient
+
+	catalogId := d.Get("catalog_id").(string)
+	_, status, err := accessPackageCatalogClient.Get(ctx, catalogId, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package catalog with Object ID %q was not found - removing from state!", catalogId)
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving access package catalog with object ID: %q", catalogId)
+	}
+
+	resourceOriginId := d.Get("resource_origin_id").(string)
+	resourceOriginSystem := d.Get("resource_origin_system").(string)
+	properties := msgraph.AccessPackageResourceRequest{
+		CatalogId:   &catalogId,
+		RequestType: utils.String("AdminAdd"),
+		AccessPackageResource: &msgraph.AccessPackageResource{
+			OriginId:     &resourceOriginId,
+			OriginSystem: resourceOriginSystem,
+		},
+	}
+	resourceCatalogAssociation, _, err := client.Create(ctx, properties, true)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Failed to link resource %q@%q with access catalog %q.", resourceOriginId, resourceOriginSystem, catalogId)
+	}
+
+	catalogOriginIds := strings.Join([]string{*resourceCatalogAssociation.CatalogId, *resourceCatalogAssociation.AccessPackageResource.OriginId}, idDelimitor)
+	d.SetId(catalogOriginIds)
+	return accessPackageResourceCatalogAssociationResourceRead(ctx, d, meta)
+}
+
+func accessPackageResourceCatalogAssociationResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	resourceClient := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceClient
+
+	ids := strings.Split(d.Id(), idDelimitor)
+	catalogId := ids[0]
+	resourceOriginId := ids[1]
+	accessPackageResource, status, err := resourceClient.Get(ctx, catalogId, resourceOriginId)
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package resource and catalog association with resource %q@%q and catalog id %q was not found - removing from state!",
+				resourceOriginId, accessPackageResource.OriginSystem, catalogId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Error retrieving access package resource and catalog association with resource %q@%q and catalog id %q.",
+			resourceOriginId, accessPackageResource.OriginSystem, catalogId)
+	}
+
+	tf.Set(d, "catalog_id", catalogId)
+	tf.Set(d, "resource_origin_id", resourceOriginId)
+	tf.Set(d, "resource_origin_system", accessPackageResource.OriginSystem)
+
+	return nil
+}
+
+func accessPackageResourceCatalogAssociationResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRequestClient
+	resourceClient := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceClient
+
+	ids := strings.Split(d.Id(), idDelimitor)
+	catalogId := ids[0]
+	resourceOriginId := ids[1]
+
+	resource, status, err := resourceClient.Get(ctx, catalogId, resourceOriginId)
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package resource and catalog association with resource %q@%q and catalog id %q was not found - removing from state!",
+				resourceOriginId, resource.OriginSystem, catalogId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving access package resource and catalog association with resource %q@%q and catalog id %q.",
+			resourceOriginId, resource.OriginSystem, catalogId)
+	}
+
+	if err != nil {
+		return tf.ErrorDiagF(err, "Error retrieving access package resource with origin ID %q in catalog %q.", resourceOriginId, catalogId)
+	}
+	resourceCatalogAssociation := msgraph.AccessPackageResourceRequest{
+		CatalogId:             &catalogId,
+		AccessPackageResource: resource,
+	}
+	status, err = client.Delete(ctx, resourceCatalogAssociation)
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Deleting access package resource and catalog association with resource %q@%q and catalog id %q.",
+			*resourceCatalogAssociation.AccessPackageResource.OriginId, resourceCatalogAssociation.AccessPackageResource.OriginSystem, *resourceCatalogAssociation.CatalogId)
+	}
+
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
@@ -111,13 +111,13 @@ func accessPackageResourceCatalogAssociationResourceRead(ctx context.Context, d 
 	accessPackageResource, status, err := resourceClient.Get(ctx, catalogId, resourceOriginId)
 	if err != nil {
 		if status == http.StatusNotFound {
-			log.Printf("[DEBUG] Access package resource and catalog association with resource %q@%q and catalog id %q was not found - removing from state!",
-				resourceOriginId, accessPackageResource.OriginSystem, catalogId)
+			log.Printf("[DEBUG] Access package resource and catalog association with resource origin id %q and catalog id %q was not found - removing from state!",
+				resourceOriginId, catalogId)
 			d.SetId("")
 			return nil
 		}
-		return tf.ErrorDiagF(err, "Error retrieving access package resource and catalog association with resource %q@%q and catalog id %q.",
-			resourceOriginId, accessPackageResource.OriginSystem, catalogId)
+		return tf.ErrorDiagF(err, "Error retrieving access package resource and catalog association with resource origin id %q and catalog id %q.",
+			resourceOriginId, catalogId)
 	}
 
 	tf.Set(d, "catalog_id", catalogId)

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
@@ -1,0 +1,83 @@
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+)
+
+type AccessPackageResourceCatalogAssociationResource struct{}
+
+func TestAccAccessPackageResourceCatalogAssociation_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_catalog_association", "test")
+	r := AccessPackageResourceCatalogAssociationResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccessPackageResourceCatalogAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.AccessPackageResourceClient
+	client.BaseClient.DisableRetries = true
+
+	var exists = false
+	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("[DEBUG] This needs to be fixed in the upstream libaray: %v", err)
+			exists = false
+		}
+		exists = false
+	}()
+
+	ids := strings.Split(state.ID, idDelimitor)
+	catalogId := ids[0]
+	resourceOriginId := ids[1]
+	catalogResource, status, err := client.Get(ctx, catalogId, resourceOriginId)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return nil, fmt.Errorf("Access package catalog association with object ID %q does not exist", state.ID)
+		}
+		return nil, fmt.Errorf("failed to retrieve access package catalog association with object ID %q: %+v", state.ID, err)
+	}
+	exists = catalogResource.ID != nil && *catalogResource.OriginId == state.Attributes["resource_origin_id"]
+
+	return &exists, nil
+}
+
+func (AccessPackageResourceCatalogAssociationResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+	display_name     = "test-access-package-resource-catalog-association-%[1]d"
+	security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+	display_name = "test-catalog-%[1]d"	
+  	description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+`, data.RandomInteger)
+}

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
@@ -3,7 +3,6 @@ package identitygovernance_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
 )
 
 type AccessPackageResourceCatalogAssociationResource struct{}
@@ -36,15 +36,6 @@ func (AccessPackageResourceCatalogAssociationResource) Exists(ctx context.Contex
 	client := clients.IdentityGovernance.AccessPackageResourceClient
 	client.BaseClient.DisableRetries = true
 
-	var exists = false
-	defer func() {
-		if err := recover(); err != nil {
-			log.Printf("[DEBUG] This needs to be fixed in the upstream libaray: %v", err)
-			exists = false
-		}
-		exists = false
-	}()
-
 	ids := strings.Split(state.ID, idDelimitor)
 	catalogId := ids[0]
 	resourceOriginId := ids[1]
@@ -55,9 +46,8 @@ func (AccessPackageResourceCatalogAssociationResource) Exists(ctx context.Contex
 		}
 		return nil, fmt.Errorf("failed to retrieve access package catalog association with object ID %q: %+v", state.ID, err)
 	}
-	exists = catalogResource.ID != nil && *catalogResource.OriginId == state.Attributes["resource_origin_id"]
 
-	return &exists, nil
+	return utils.Bool(catalogResource.ID != nil && *catalogResource.OriginId == state.Attributes["resource_origin_id"]), nil
 }
 
 func (AccessPackageResourceCatalogAssociationResource) complete(data acceptance.TestData) string {

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
@@ -65,13 +65,13 @@ func (AccessPackageResourceCatalogAssociationResource) complete(data acceptance.
 provider "azuread" {}
 
 resource "azuread_group" "test_group" {
-	display_name     = "test-access-package-resource-catalog-association-%[1]d"
-	security_enabled = true
+  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-	display_name = "test-catalog-%[1]d"	
-  	description  = "Test catalog %[1]d"
+  display_name = "test-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package_resource_catalog_association" "test" {

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -19,8 +19,6 @@ import (
 	"github.com/manicminer/hamilton/odata"
 )
 
-const resourcePackageAssociationResourceName = "azuread_access_package_resource_catalog_association"
-
 func accessPackageResourcePackageAssociationResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: accessPackageResourcePackageAssociationResourceCreate,
@@ -49,7 +47,7 @@ func accessPackageResourcePackageAssociationResource() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"access_package_id": {
-				Description:  "The ID of access package this resouce association is configured to.",
+				Description:  "The ID of access package this resource association is configured to.",
 				Type:         schema.TypeString,
 				ValidateFunc: validation.IsUUID,
 				ForceNew:     true,
@@ -153,7 +151,7 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 }
 
 func accessPackageResourcePackageAssociationResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Println("There is no destory implemented because Microsoft doesn't provide a valid API doing so for resource roles in an access package, you have to delete it manually, remove this resource from state now.")
+	log.Println("There is no destroy implemented because Microsoft doesn't provide a valid API doing so for resource roles in an access package, you have to delete it manually, remove this resource from state now.")
 	d.SetId("")
 	return nil
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -1,0 +1,159 @@
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+const resourcePackageAssociationResourceName = "azuread_access_package_resource_catalog_association"
+
+func accessPackageResourcePackageAssociationResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: accessPackageResourcePackageAssociationResourceCreate,
+		ReadContext:   accessPackageResourcePackageAssociationResourceRead,
+		DeleteContext: accessPackageResourcePackageAssociationResourceDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: tf.ValidateResourceIDPriorToImport(func(id string) error {
+			ids := strings.Split(id, idDelimitor)
+			if len(ids) != 4 {
+				return fmt.Errorf("The ID must be in the format of catalog_id%sthis_association_id%sresource_origin_id%saccess_type", idDelimitor, idDelimitor, idDelimitor)
+			}
+			if _, err := uuid.ParseUUID(ids[0]); err != nil {
+				return fmt.Errorf("Specified catalog id part (%q) is not valid: %s", ids[0], err)
+			}
+			if _, err := uuid.ParseUUID(ids[2]); err != nil {
+				return fmt.Errorf("Specified resource origin id part (%q) is not valid: %s", ids[2], err)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"access_package_id": {
+				Description:  "The ID of access package this resouce association is configured to.",
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsUUID,
+				ForceNew:     true,
+				Required:     true,
+			},
+			"catalog_resource_association_id": {
+				Description: "The ID of the association from `azuread_access_package_resource_catalog_association`",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+			},
+			"access_type": {
+				Description: "The role of access type to the specified resource, valid values are `Member` and `Owner`",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "Member",
+				ValidateFunc: validation.StringInSlice([]string{
+					"Member",
+					"Owner",
+				}, false),
+			},
+		},
+	}
+}
+
+func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRoleScopeClient
+	resourceClient := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceClient
+
+	accessType := d.Get("access_type").(string)
+	resourceCatalogIds := strings.Split(d.Get("catalog_resource_association_id").(string), idDelimitor)
+	catalogId := resourceCatalogIds[0]
+	resourceOriginId := resourceCatalogIds[1]
+	accessPackageId := d.Get("access_package_id").(string)
+
+	resource, _, err := resourceClient.Get(ctx, catalogId, resourceOriginId)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Error retrieving access package resource and catalog association with resource id %q and catalog id %q.",
+			resourceOriginId, catalogId)
+	}
+
+	properties := msgraph.AccessPackageResourceRoleScope{
+		AccessPackageId: &accessPackageId,
+		AccessPackageResourceRole: &msgraph.AccessPackageResourceRole{
+			DisplayName:  utils.String(accessType),
+			OriginId:     utils.String(fmt.Sprintf("%s_%s", accessType, resourceOriginId)),
+			OriginSystem: resource.OriginSystem,
+			AccessPackageResource: &msgraph.AccessPackageResource{
+				ID:           resource.ID,
+				ResourceType: resource.ResourceType,
+				OriginId:     resource.OriginId,
+			},
+		},
+		AccessPackageResourceScope: &msgraph.AccessPackageResourceScope{
+			OriginSystem: resource.OriginSystem,
+			OriginId:     &resourceOriginId,
+		},
+	}
+
+	resourcePackageAssociation, _, err := client.Create(ctx, properties)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Error creating access package resource association from resource %q@%q to access package %q.", resourceOriginId, resource.OriginSystem, accessPackageId)
+	}
+
+	id := strings.Join([]string{accessPackageId, *resourcePackageAssociation.ID, *resource.OriginId, accessType}, idDelimitor)
+	d.SetId(id)
+	return accessPackageResourcePackageAssociationResourceRead(ctx, d, meta)
+}
+
+func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRoleScopeClient
+	accessPackageClient := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
+
+	ids := strings.Split(d.Id(), idDelimitor)
+	accessPackageId := ids[0]
+	resourcePackageId := ids[1]
+	resourceOriginId := ids[2]
+	accessType := ids[3]
+	resourcePackage, status, err := client.Get(ctx, accessPackageId, resourcePackageId)
+	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Access package resource association with ID %q was not found - removing from state!", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Error retrieving resource id %v in access package %v", resourcePackageId, accessPackageId)
+	}
+
+	accessPackage, _, err := accessPackageClient.Get(ctx, accessPackageId, odata.Query{})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Err retrieving access package with id %v", accessPackageId)
+	}
+
+	tf.Set(d, "access_package_id", resourcePackage.AccessPackageId)
+	// No mature API and library available to provide such information
+	tf.Set(d, "access_type", accessType)
+	tf.Set(d, "catalog_resource_association_id", strings.Join([]string{*accessPackage.CatalogId, resourceOriginId}, idDelimitor))
+
+	return nil
+}
+
+func accessPackageResourcePackageAssociationResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Println("There is no destory implemented because Microsoft doesn't provide a valid API doing so for resource roles in an access package, you have to delete it manually, remove this resource from state now.")
+	d.SetId("")
+	return nil
+}

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -151,7 +151,7 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 }
 
 func accessPackageResourcePackageAssociationResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Println("There is no destroy implemented because Microsoft doesn't provide a valid API doing so for resource roles in an access package, you have to delete it manually, remove this resource from state now.")
+	//log.Println("There is no destroy implemented because Microsoft doesn't provide a valid API doing so for resource roles in an access package, you have to delete it manually, remove this resource from state now.")
 	d.SetId("")
 	return nil
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -1,0 +1,81 @@
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+)
+
+type AccessPackageResourcePackageAssociationResource struct{}
+
+func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccessPackageResourcePackageAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.AccessPackageResourceRoleScopeClient
+	client.BaseClient.DisableRetries = true
+
+	ids := strings.Split(state.ID, idDelimitor)
+	packageId := ids[0]
+	resourceId := ids[1]
+	resource, _, err := client.Get(ctx, packageId, resourceId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve access package resource association with object ID %q: %+v", resourceId, err)
+	}
+
+	return utils.Bool(*resource.ID == resourceId), nil
+}
+
+func (AccessPackageResourcePackageAssociationResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+	display_name     = "test-access-package-resource-catalog-association-%[1]d"
+	security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+	display_name = "test-catalog-%[1]d"	
+  	description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+	display_name = "test-package-%[1]d"
+	description  = "Test Package %[1]d"
+	catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+	access_package_id               = azuread_access_package.test.id
+	catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+}
+
+`, data.RandomInteger)
+}

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -51,13 +51,13 @@ func (AccessPackageResourcePackageAssociationResource) complete(data acceptance.
 provider "azuread" {}
 
 resource "azuread_group" "test_group" {
-	display_name     = "test-access-package-resource-catalog-association-%[1]d"
-	security_enabled = true
+  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-	display_name = "test-catalog-%[1]d"	
-  	description  = "Test catalog %[1]d"
+  display_name = "test-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package_resource_catalog_association" "test" {
@@ -67,15 +67,14 @@ resource "azuread_access_package_resource_catalog_association" "test" {
 }
 
 resource "azuread_access_package" "test" {
-	display_name = "test-package-%[1]d"
-	description  = "Test Package %[1]d"
-	catalog_id   = azuread_access_package_catalog.test_catalog.id
+  display_name = "test-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_resource_package_association" "test" {
-	access_package_id               = azuread_access_package.test.id
-	catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
 }
-
 `, data.RandomInteger)
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -22,7 +22,8 @@ func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.complete(data),
+			Config:  r.complete(data),
+			Destroy: false,
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/identitygovernance/access_package_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_test.go
@@ -1,0 +1,126 @@
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/odata"
+)
+
+type AccessPackageResource struct{}
+
+func TestAccAccessPackage_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package", "test")
+	r := AccessPackageResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("catalog_id"),
+	})
+}
+
+func TestAccAccessPackage_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package", "test")
+	r := AccessPackageResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("catalog_id"),
+	})
+}
+
+func TestAccAccessPackage_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package", "test")
+	r := AccessPackageResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccessPackageResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.AccessPackageClient
+	client.BaseClient.DisableRetries = true
+
+	accessPackage, status, err := client.Get(ctx, state.ID, odata.Query{})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return nil, fmt.Errorf("Access package with object ID %q does not exist", state.ID)
+		}
+		return nil, fmt.Errorf("failed to retrieve access package with object ID %q: %+v", state.ID, err)
+	}
+	return utils.Bool(accessPackage.ID != nil && *accessPackage.ID == state.ID), nil
+}
+
+func (AccessPackageResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+	display_name = "test-catalog-%[1]d"	
+  	description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "access-package-%[1]d"
+  description  = "Access Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+	display_name = "test-catalog-%[1]d"	
+  	description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "access-package-%[1]d"
+  description  = "Access Package %[1]d"
+  is_hidden    = true
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+`, data.RandomInteger)
+}

--- a/internal/services/identitygovernance/access_package_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_test.go
@@ -95,8 +95,8 @@ func (AccessPackageResource) basic(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test_catalog" {
-	display_name = "test-catalog-%[1]d"	
-  	description  = "Test catalog %[1]d"
+  display_name = "test-catalog-%[1]d"	
+  description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package" "test" {
@@ -112,8 +112,8 @@ func (AccessPackageResource) complete(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test_catalog" {
-	display_name = "test-catalog-%[1]d"	
-  	description  = "Test catalog %[1]d"
+  display_name = "test-catalog-%[1]d"	
+  description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package" "test" {

--- a/internal/services/identitygovernance/client/client.go
+++ b/internal/services/identitygovernance/client/client.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"github.com/manicminer/hamilton/msgraph"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+)
+
+type Client struct {
+	AccessPackageCatalogClient           *msgraph.AccessPackageCatalogClient
+	AccessPackageClient                  *msgraph.AccessPackageClient
+	AccessPackageAssignmentPolicyClient  *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageResourceRoleScopeClient *msgraph.AccessPackageResourceRoleScopeClient
+	AccessPackageResourceRequestClient   *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceClient          *msgraph.AccessPackageResourceClient
+}
+
+func NewClient(o *common.ClientOptions) *Client {
+	accessPackageCatalogClient := msgraph.NewAccessPackageCatalogClient(o.TenantID)
+	// Use beta version because it replies more info than v1.0
+	accessPackageClient := &msgraph.AccessPackageClient{
+		BaseClient: msgraph.NewClient(msgraph.VersionBeta, o.TenantID),
+	}
+	accessPackageAssignmentPolicyClient := msgraph.NewAccessPackageAssignmentPolicyClient(o.TenantID)
+	accessPackageResourceRoleScopeClient := msgraph.NewAccessPackageResourceRoleScopeClient(o.TenantID)
+	accessPackageResourceRequestClient := msgraph.NewAccessPackageResourceRequestClient(o.TenantID)
+	accessPackageResourceClient := msgraph.NewAccessPackageResourceClient(o.TenantID)
+
+	o.ConfigureClient(&accessPackageCatalogClient.BaseClient)
+	o.ConfigureClient(&accessPackageClient.BaseClient)
+	o.ConfigureClient(&accessPackageAssignmentPolicyClient.BaseClient)
+	o.ConfigureClient(&accessPackageResourceRoleScopeClient.BaseClient)
+	o.ConfigureClient(&accessPackageResourceRequestClient.BaseClient)
+	o.ConfigureClient(&accessPackageResourceClient.BaseClient)
+
+	return &Client{
+		AccessPackageCatalogClient:           accessPackageCatalogClient,
+		AccessPackageClient:                  accessPackageClient,
+		AccessPackageAssignmentPolicyClient:  accessPackageAssignmentPolicyClient,
+		AccessPackageResourceRoleScopeClient: accessPackageResourceRoleScopeClient,
+		AccessPackageResourceRequestClient:   accessPackageResourceRequestClient,
+		AccessPackageResourceClient:          accessPackageResourceClient,
+	}
+}

--- a/internal/services/identitygovernance/client/client.go
+++ b/internal/services/identitygovernance/client/client.go
@@ -1,44 +1,54 @@
 package client
 
 import (
-	"github.com/manicminer/hamilton/msgraph"
-
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+	"github.com/manicminer/hamilton/msgraph"
 )
 
 type Client struct {
+	AccessPackageAssignmentPolicyClient  *msgraph.AccessPackageAssignmentPolicyClient
 	AccessPackageCatalogClient           *msgraph.AccessPackageCatalogClient
 	AccessPackageClient                  *msgraph.AccessPackageClient
-	AccessPackageAssignmentPolicyClient  *msgraph.AccessPackageAssignmentPolicyClient
-	AccessPackageResourceRoleScopeClient *msgraph.AccessPackageResourceRoleScopeClient
-	AccessPackageResourceRequestClient   *msgraph.AccessPackageResourceRequestClient
 	AccessPackageResourceClient          *msgraph.AccessPackageResourceClient
+	AccessPackageResourceRequestClient   *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceRoleScopeClient *msgraph.AccessPackageResourceRoleScopeClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
-	accessPackageCatalogClient := msgraph.NewAccessPackageCatalogClient(o.TenantID)
-	// Use beta version because it replies more info than v1.0
-	accessPackageClient := &msgraph.AccessPackageClient{
-		BaseClient: msgraph.NewClient(msgraph.VersionBeta, o.TenantID),
-	}
-	accessPackageAssignmentPolicyClient := msgraph.NewAccessPackageAssignmentPolicyClient(o.TenantID)
-	accessPackageResourceRoleScopeClient := msgraph.NewAccessPackageResourceRoleScopeClient(o.TenantID)
-	accessPackageResourceRequestClient := msgraph.NewAccessPackageResourceRequestClient(o.TenantID)
-	accessPackageResourceClient := msgraph.NewAccessPackageResourceClient(o.TenantID)
-
-	o.ConfigureClient(&accessPackageCatalogClient.BaseClient)
-	o.ConfigureClient(&accessPackageClient.BaseClient)
+	// Resource only available in beta API
+	accessPackageAssignmentPolicyClient := msgraph.NewAccessPackageAssignmentPolicyClient()
 	o.ConfigureClient(&accessPackageAssignmentPolicyClient.BaseClient)
-	o.ConfigureClient(&accessPackageResourceRoleScopeClient.BaseClient)
-	o.ConfigureClient(&accessPackageResourceRequestClient.BaseClient)
+	accessPackageAssignmentPolicyClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
+	accessPackageCatalogClient := msgraph.NewAccessPackageCatalogClient()
+	o.ConfigureClient(&accessPackageCatalogClient.BaseClient)
+
+	// Use beta version because it replies more info than v1.0
+	accessPackageClient := msgraph.NewAccessPackageClient()
+	o.ConfigureClient(&accessPackageClient.BaseClient)
+	accessPackageClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
+	// Use beta version because it replies more info than v1.0 and the URL is different
+	accessPackageResourceClient := msgraph.NewAccessPackageResourceClient()
 	o.ConfigureClient(&accessPackageResourceClient.BaseClient)
+	accessPackageResourceClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
+	// Resource only available in beta API
+	accessPackageResourceRequestClient := msgraph.NewAccessPackageResourceRequestClient()
+	o.ConfigureClient(&accessPackageResourceRequestClient.BaseClient)
+	accessPackageResourceRequestClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
+	// Resource only available in beta API
+	accessPackageResourceRoleScopeClient := msgraph.NewAccessPackageResourceRoleScopeClient()
+	o.ConfigureClient(&accessPackageResourceRoleScopeClient.BaseClient)
+	accessPackageResourceRoleScopeClient.BaseClient.ApiVersion = msgraph.VersionBeta
 
 	return &Client{
+		AccessPackageAssignmentPolicyClient:  accessPackageAssignmentPolicyClient,
 		AccessPackageCatalogClient:           accessPackageCatalogClient,
 		AccessPackageClient:                  accessPackageClient,
-		AccessPackageAssignmentPolicyClient:  accessPackageAssignmentPolicyClient,
-		AccessPackageResourceRoleScopeClient: accessPackageResourceRoleScopeClient,
-		AccessPackageResourceRequestClient:   accessPackageResourceRequestClient,
 		AccessPackageResourceClient:          accessPackageResourceClient,
+		AccessPackageResourceRequestClient:   accessPackageResourceRequestClient,
+		AccessPackageResourceRoleScopeClient: accessPackageResourceRoleScopeClient,
 	}
 }

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -100,10 +100,6 @@ func buildAssignmentPolicyReviewSettings(input []interface{}) (*msgraph.Assignme
 		return nil, nil
 	}
 	in := input[0].(map[string]interface{})
-	startOn, err := time.Parse(time.RFC3339, in["starting_on"].(string))
-	if err != nil {
-		return nil, fmt.Errorf("Error converting starting date %q to a valid date: %q", in["starting_on"].(string), err)
-	}
 
 	result := msgraph.AssignmentReviewSettings{
 		IsEnabled:                       utils.Bool(in["is_enabled"].(bool)),
@@ -113,7 +109,15 @@ func buildAssignmentPolicyReviewSettings(input []interface{}) (*msgraph.Assignme
 		IsAccessRecommendationEnabled:   utils.Bool(in["is_access_recommendation_enabled"].(bool)),
 		IsApprovalJustificationRequired: utils.Bool(in["is_approver_justification_required"].(bool)),
 		AccessReviewTimeoutBehavior:     in["access_review_timeout_behavior"].(string),
-		StartDateTime:                   &startOn,
+	}
+
+	startOnDate := in["starting_on"].(string)
+	if startOnDate != "" {
+		startOn, err := time.Parse(time.RFC3339, startOnDate)
+		if err != nil {
+			return nil, fmt.Errorf("Error converting starting date %q to a valid date: %q", in["starting_on"].(string), err)
+		}
+		result.StartDateTime = &startOn
 	}
 
 	result.Reviewers = buildUserSet(in["reviewer"].([]interface{}))

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -147,10 +147,13 @@ func buildUserSet(input []interface{}) *[]msgraph.UserSet {
 	userSets := make([]msgraph.UserSet, 0)
 	for _, v := range input {
 		v_map := v.(map[string]interface{})
+		oDataType, needId := userSetODataType(v_map["subject_type"].(string))
 		userSet := msgraph.UserSet{
-			ODataType: userSetODataType(v_map["subject_type"].(string)),
-			ID:        utils.String(v_map["object_id"].(string)),
+			ODataType: oDataType,
 			IsBackup:  utils.Bool(v_map["is_backup"].(bool)),
+		}
+		if needId {
+			userSet.ID = utils.String(v_map["object_id"].(string))
 		}
 
 		userSets = append(userSets, userSet)
@@ -176,8 +179,9 @@ func flattenUserSet(input *[]msgraph.UserSet) []interface{} {
 	return userSets
 }
 
-func userSetODataType(in string) *string {
+func userSetODataType(in string) (*string, bool) {
 	odataType := odata.TypeSingleUser
+	needId := true
 	switch in {
 	case odata.ShortTypeGroupMembers:
 		odataType = odata.TypeGroupMembers
@@ -185,13 +189,16 @@ func userSetODataType(in string) *string {
 		odataType = odata.TypeConnectedOrganizationMembers
 	case odata.ShortTypeRequestorManager:
 		odataType = odata.TypeRequestorManager
+		needId = false
 	case odata.ShortTypeInternalSponsors:
 		odataType = odata.TypeInternalSponsors
+		needId = false
 	case odata.ShortTypeExternalSponsors:
 		odataType = odata.TypeExternalSponsors
+		needId = false
 	}
 
-	return &odataType
+	return &odataType, needId
 }
 
 func userSetShortType(in string) *string {

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -233,12 +233,12 @@ func expandAccessPakcageAssignmentPolicyQuestions(questions []interface{}) *[]ms
 			Text:       expandAccessPakcageAssignmentPolicyQuestionContent(v_text),
 		}
 
-		v_map_chocies := v_map["choice"].([]interface{})
+		v_map_choices := v_map["choice"].([]interface{})
 		q.ODataType = utils.String(odata.TypeAccessPackageTextInputQuestion)
-		if len(v_map_chocies) > 0 {
+		if len(v_map_choices) > 0 {
 			q.ODataType = utils.String(odata.TypeAccessPackageMultipleChoiceQuestion)
 			choices := make([]msgraph.AccessPackageMultipleChoiceQuestions, 0)
-			for _, c := range v_map_chocies {
+			for _, c := range v_map_choices {
 				c_map := c.(map[string]interface{})
 				c_map_display_value := c_map["display_value"].([]interface{})
 				choices = append(choices, msgraph.AccessPackageMultipleChoiceQuestions{

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -1,0 +1,312 @@
+package identitygovernance
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
+)
+
+const idDelimitor = ":"
+
+func buildAssignmentPolicyRequestorSettings(input []interface{}) *msgraph.RequestorSettings {
+	if len(input) == 0 {
+		return nil
+	}
+	in := input[0].(map[string]interface{})
+	result := msgraph.RequestorSettings{
+		ScopeType:      in["scope_type"].(string),
+		AcceptRequests: utils.Bool(in["accept_requests"].(bool)),
+	}
+	result.AllowedRequestors = buildUserSet(in["requestor"].([]interface{}))
+
+	return &result
+}
+
+func flattenRequestorSettings(input *msgraph.RequestorSettings) []map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{{
+		"accept_requests": input.AcceptRequests,
+		"scope_type":      input.ScopeType,
+		"requestor":       flattenUserSet(input.AllowedRequestors),
+	}}
+}
+
+func buildAssignmentPolicyApprovalSettings(input []interface{}) *msgraph.ApprovalSettings {
+	if len(input) == 0 {
+		return nil
+	}
+	in := input[0].(map[string]interface{})
+	result := msgraph.ApprovalSettings{
+		IsApprovalRequired:               utils.Bool(in["is_approval_required"].(bool)),
+		IsApprovalRequiredForExtension:   utils.Bool(in["is_approval_required_for_extension"].(bool)),
+		IsRequestorJustificationRequired: utils.Bool(in["is_requestor_justification_required"].(bool)),
+	}
+	approvalStages := make([]msgraph.ApprovalStage, 0)
+	for _, v := range in["approval_stage"].([]interface{}) {
+		v_map := v.(map[string]interface{})
+		stage := msgraph.ApprovalStage{
+			ApprovalStageTimeOutInDays:      utils.Int32(int32(v_map["approval_timeout_in_days"].(int))),
+			IsApproverJustificationRequired: utils.Bool(v_map["is_approver_justification_required"].(bool)),
+			IsEscalationEnabled:             utils.Bool(v_map["is_alternative_approval_enabled"].(bool)),
+			EscalationTimeInMinutes:         utils.Int32((int32(v_map["enable_alternative_approval_in_days"].(int) * 24 * 60))),
+		}
+		stage.PrimaryApprovers = buildUserSet(v_map["primary_approver"].([]interface{}))
+		stage.EscalationApprovers = buildUserSet(v_map["alternative_approver"].([]interface{}))
+
+		approvalStages = append(approvalStages, stage)
+	}
+	result.ApprovalStages = &approvalStages
+
+	return &result
+}
+
+func falttenApprovalSettings(input *msgraph.ApprovalSettings) []map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := []map[string]interface{}{{
+		"is_approval_required":                input.IsApprovalRequired,
+		"is_approval_required_for_extension":  input.IsApprovalRequiredForExtension,
+		"is_requestor_justification_required": input.IsRequestorJustificationRequired,
+	}}
+
+	approvalStages := make([]interface{}, 0)
+	for _, v := range *input.ApprovalStages {
+		approvalStage := map[string]interface{}{
+			"approval_timeout_in_days":            v.ApprovalStageTimeOutInDays,
+			"is_approver_justification_required":  v.IsApproverJustificationRequired,
+			"is_alternative_approval_enabled":     v.IsEscalationEnabled,
+			"enable_alternative_approval_in_days": *v.EscalationTimeInMinutes / 60 / 24,
+			"primary_approver":                    flattenUserSet(v.PrimaryApprovers),
+			"alternative_approver":                flattenUserSet(v.EscalationApprovers),
+		}
+
+		approvalStages = append(approvalStages, approvalStage)
+	}
+	result[0]["approval_stage"] = approvalStages
+
+	return result
+}
+
+func buildAssignmentPolicyReviewSettings(input []interface{}) (*msgraph.AssignmentReviewSettings, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	in := input[0].(map[string]interface{})
+	startOn, err := time.Parse(time.RFC3339, in["starting_on"].(string))
+	if err != nil {
+		return nil, fmt.Errorf("Error converting starting date %q to a valid date: %q", in["starting_on"].(string), err)
+	}
+
+	result := msgraph.AssignmentReviewSettings{
+		IsEnabled:                       utils.Bool(in["is_enabled"].(bool)),
+		RecurrenceType:                  in["review_frequency"].(string),
+		ReviewerType:                    in["review_type"].(string),
+		DurationInDays:                  utils.Int32(int32(in["duration_in_days"].(int))),
+		IsAccessRecommendationEnabled:   utils.Bool(in["is_access_recommendation_enabled"].(bool)),
+		IsApprovalJustificationRequired: utils.Bool(in["is_approver_justification_required"].(bool)),
+		AccessReviewTimeoutBehavior:     in["access_review_timeout_behavior"].(string),
+		StartDateTime:                   &startOn,
+	}
+
+	result.Reviewers = buildUserSet(in["reviewer"].([]interface{}))
+
+	return &result, nil
+}
+
+func flattenReviewSettings(input *msgraph.AssignmentReviewSettings) []map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{{
+		"is_enabled":                         input.IsEnabled,
+		"review_frequency":                   input.RecurrenceType,
+		"review_type":                        input.ReviewerType,
+		"starting_on":                        input.StartDateTime.Format(time.RFC3339),
+		"duration_in_days":                   input.DurationInDays,
+		"reviewer":                           flattenUserSet(input.Reviewers),
+		"is_access_recommendation_enabled":   input.IsAccessRecommendationEnabled,
+		"is_approver_justification_required": input.IsApprovalJustificationRequired,
+		"access_review_timeout_behavior":     input.AccessReviewTimeoutBehavior,
+	}}
+}
+
+func buildUserSet(input []interface{}) *[]msgraph.UserSet {
+	userSets := make([]msgraph.UserSet, 0)
+	for _, v := range input {
+		v_map := v.(map[string]interface{})
+		userSet := msgraph.UserSet{
+			ODataType: userSetODataType(v_map["subject_type"].(string)),
+			ID:        utils.String(v_map["object_id"].(string)),
+			IsBackup:  utils.Bool(v_map["is_backup"].(bool)),
+		}
+
+		userSets = append(userSets, userSet)
+	}
+
+	return &userSets
+}
+
+func flattenUserSet(input *[]msgraph.UserSet) []interface{} {
+	if input == nil || len(*input) == 0 {
+		return nil
+	}
+
+	userSets := make([]interface{}, 0)
+	for _, v := range *input {
+		userSet := map[string]interface{}{
+			"subject_type": userSetShortType(*v.ODataType),
+			"is_backup":    v.IsBackup,
+			"object_id":    v.ID,
+		}
+		userSets = append(userSets, userSet)
+	}
+	return userSets
+}
+
+func userSetODataType(in string) *string {
+	odataType := odata.TypeSingleUser
+	switch in {
+	case odata.ShortTypeGroupMembers:
+		odataType = odata.TypeGroupMembers
+	case odata.ShortTypeConnectedOrganizationMembers:
+		odataType = odata.TypeConnectedOrganizationMembers
+	case odata.ShortTypeRequestorManager:
+		odataType = odata.TypeRequestorManager
+	case odata.ShortTypeInternalSponsors:
+		odataType = odata.TypeInternalSponsors
+	case odata.ShortTypeExternalSponsors:
+		odataType = odata.TypeExternalSponsors
+	}
+
+	return &odataType
+}
+
+func userSetShortType(in string) *string {
+	shortType := odata.ShortTypeSingleUser
+	switch in {
+	case odata.TypeGroupMembers:
+		shortType = odata.ShortTypeGroupMembers
+	case odata.TypeConnectedOrganizationMembers:
+		shortType = odata.ShortTypeConnectedOrganizationMembers
+	case odata.TypeRequestorManager:
+		shortType = odata.ShortTypeRequestorManager
+	case odata.TypeInternalSponsors:
+		shortType = odata.ShortTypeInternalSponsors
+	case odata.TypeExternalSponsors:
+		shortType = odata.ShortTypeExternalSponsors
+	}
+
+	return &shortType
+}
+
+func expandAccessPakcageAssignmentPolicyQuestions(questions []interface{}) *[]msgraph.AccessPackageQuestion {
+	result := make([]msgraph.AccessPackageQuestion, 0)
+
+	for _, v := range questions {
+		v_map := v.(map[string]interface{})
+		v_text_list := v_map["text"].([]interface{})
+		v_text := v_text_list[0].(map[string]interface{})
+
+		q := msgraph.AccessPackageQuestion{
+			IsRequired: utils.Bool(v_map["is_required"].(bool)),
+			Sequence:   utils.Int32(int32(v_map["sequence"].(int))),
+			Text:       expandAccessPakcageAssignmentPolicyQuestionContent(v_text),
+		}
+
+		v_map_chocies := v_map["choice"].([]interface{})
+		q.ODataType = utils.String(odata.TypeAccessPackageTextInputQuestion)
+		if len(v_map_chocies) > 0 {
+			q.ODataType = utils.String(odata.TypeAccessPackageMultipleChoiceQuestion)
+			choices := make([]msgraph.AccessPackageMultipleChoiceQuestions, 0)
+			for _, c := range v_map_chocies {
+				c_map := c.(map[string]interface{})
+				c_map_display_value := c_map["display_value"].([]interface{})
+				choices = append(choices, msgraph.AccessPackageMultipleChoiceQuestions{
+					ActualValue:  utils.String(c_map["actual_value"].(string)),
+					DisplayValue: expandAccessPakcageAssignmentPolicyQuestionContent(c_map_display_value[0].(map[string]interface{})),
+				})
+			}
+			q.Choices = &choices
+		}
+
+		result = append(result, q)
+	}
+
+	return &result
+}
+
+func flattenAssignmentPolicyQuestions(input *[]msgraph.AccessPackageQuestion) []map[string]interface{} {
+	if input == nil || len(*input) == 0 {
+		return nil
+	}
+
+	questions := make([]map[string]interface{}, 0)
+	for _, v := range *input {
+		question := map[string]interface{}{
+			"is_required": v.IsRequired,
+			"sequence":    v.Sequence,
+			"text":        flattenAssignmentPolicyQuestionContent(v.Text),
+		}
+
+		if c_array := v.Choices; c_array != nil && len(*c_array) > 0 {
+			choices := make([]map[string]interface{}, 0)
+			for _, c := range *c_array {
+				choice := map[string]interface{}{
+					"actual_value":  c.ActualValue,
+					"display_value": flattenAssignmentPolicyQuestionContent(c.DisplayValue),
+				}
+
+				choices = append(choices, choice)
+			}
+			question["choice"] = choices
+		}
+
+		questions = append(questions, question)
+	}
+
+	return questions
+}
+
+func expandAccessPakcageAssignmentPolicyQuestionContent(input map[string]interface{}) *msgraph.AccessPackageLocalizedContent {
+	result := msgraph.AccessPackageLocalizedContent{
+		DefaultText: utils.String(input["default_text"].(string)),
+	}
+
+	texts := make([]msgraph.AccessPackageLocalizedTexts, 0)
+	for _, v := range input["localized_text"].([]interface{}) {
+		v_map := v.(map[string]interface{})
+		texts = append(texts, msgraph.AccessPackageLocalizedTexts{
+			LanguageCode: utils.String(v_map["language_code"].(string)),
+			Text:         utils.String(v_map["content"].(string)),
+		})
+	}
+	result.LocalizedTexts = &texts
+
+	return &result
+}
+
+func flattenAssignmentPolicyQuestionContent(input *msgraph.AccessPackageLocalizedContent) []map[string]interface{} {
+	result := []map[string]interface{}{{
+		"default_text": input.DefaultText,
+	}}
+	texts := make([]map[string]interface{}, 0)
+	for _, v := range *input.LocalizedTexts {
+		text := map[string]interface{}{
+			"language_code": v.LanguageCode,
+			"content":       v.Text,
+		}
+		texts = append(texts, text)
+	}
+	result[0]["localized_text"] = texts
+
+	return result
+}

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -66,7 +66,7 @@ func buildAssignmentPolicyApprovalSettings(input []interface{}) *msgraph.Approva
 	return &result
 }
 
-func falttenApprovalSettings(input *msgraph.ApprovalSettings) []map[string]interface{} {
+func flattenApprovalSettings(input *msgraph.ApprovalSettings) []map[string]interface{} {
 	if input == nil {
 		return nil
 	}

--- a/internal/services/identitygovernance/identitygovernance_test.go
+++ b/internal/services/identitygovernance/identitygovernance_test.go
@@ -1,0 +1,3 @@
+package identitygovernance_test
+
+const idDelimitor = ":"

--- a/internal/services/identitygovernance/identitygovernance_test.go
+++ b/internal/services/identitygovernance/identitygovernance_test.go
@@ -1,3 +1,0 @@
-package identitygovernance_test
-
-const idDelimitor = ":"

--- a/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
@@ -1,0 +1,42 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+type AccessPackageResourceCatalogAssociationId struct {
+	CatalogId string
+	OriginId  string
+}
+
+func (id AccessPackageResourceCatalogAssociationId) ID() string {
+	return fmt.Sprintf("%s/%s", id.CatalogId, id.OriginId)
+}
+
+func NewAccessPackageResourceCatalogAssociationID(catalogId, originId string) AccessPackageResourceCatalogAssociationId {
+	return AccessPackageResourceCatalogAssociationId{
+		CatalogId: catalogId,
+		OriginId:  originId,
+	}
+}
+
+func AccessPackageResourceCatalogAssociationID(idString string) (*AccessPackageResourceCatalogAssociationId, error) {
+	parts := strings.Split(idString, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("ID should be in the format {catalogId}/{originId} - but got %q", idString)
+	}
+
+	for i, p := range parts {
+		if _, err := uuid.ParseUUID(p); err != nil {
+			return nil, fmt.Errorf("specified ID segment #%d (%q) is not a valid UUID: %s", i, p, err)
+		}
+	}
+
+	return &AccessPackageResourceCatalogAssociationId{
+		CatalogId: parts[0],
+		OriginId:  parts[1],
+	}, nil
+}

--- a/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
@@ -1,0 +1,50 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+type AccessPackageResourcePackageAssociationId struct {
+	AccessPackageId              string
+	ResourcePackageAssociationId string
+	OriginId                     string
+	AccessType                   string
+}
+
+func (id AccessPackageResourcePackageAssociationId) ID() string {
+	return fmt.Sprintf("%s/%s/%s/%s", id.AccessPackageId, id.ResourcePackageAssociationId, id.OriginId, id.AccessType)
+}
+
+func NewAccessPackageResourcePackageAssociationID(catalogId, resourcePackageAssociationId, originId, accessType string) AccessPackageResourcePackageAssociationId {
+	return AccessPackageResourcePackageAssociationId{
+		AccessPackageId:              catalogId,
+		ResourcePackageAssociationId: resourcePackageAssociationId,
+		OriginId:                     originId,
+		AccessType:                   accessType,
+	}
+}
+
+func AccessPackageResourcePackageAssociationID(idString string) (*AccessPackageResourcePackageAssociationId, error) {
+	parts := strings.Split(idString, "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("ID should be in the format {accessPackageId}/{resourcePackageAssociationId}/{originId}/{accessType} - but got %q", idString)
+	}
+
+	for i, p := range parts {
+		if i == 0 || i == 2 {
+			if _, err := uuid.ParseUUID(p); err != nil {
+				return nil, fmt.Errorf("specified ID segment #%d (%q) is not a valid UUID: %s", i, p, err)
+			}
+		}
+	}
+
+	return &AccessPackageResourcePackageAssociationId{
+		AccessPackageId:              parts[0],
+		ResourcePackageAssociationId: parts[1],
+		OriginId:                     parts[2],
+		AccessType:                   parts[3],
+	}, nil
+}

--- a/internal/services/identitygovernance/registration.go
+++ b/internal/services/identitygovernance/registration.go
@@ -1,0 +1,38 @@
+package identitygovernance
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type Registration struct{}
+
+// Name is the name of this Service
+func (r Registration) Name() string {
+	return "Identity Governance"
+}
+
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Identity Governance",
+	}
+}
+
+// SupportedDataSources returns the supported Data Sources supported by this Service
+func (r Registration) SupportedDataSources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"azuread_access_package_catalog": accessPackageCatalogDataSource(),
+		"azuread_access_package":         accessPackageDataSource(),
+	}
+}
+
+// SupportedResources returns the supported Resources supported by this Service
+func (r Registration) SupportedResources() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"azuread_access_package_catalog":                      accessPackageCatalogResource(),
+		"azuread_access_package":                              accessPackageResource(),
+		"azuread_access_package_assignment_policy":            accessPackageAssignmentPolicyResource(),
+		"azuread_access_package_resource_catalog_association": accessPackageResourceCatalogAssociationResource(),
+		"azuread_access_package_resource_package_association": accessPackageResourcePackageAssociationResource(),
+	}
+}

--- a/internal/services/identitygovernance/registration.go
+++ b/internal/services/identitygovernance/registration.go
@@ -21,17 +21,17 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azuread_access_package_catalog": accessPackageCatalogDataSource(),
 		"azuread_access_package":         accessPackageDataSource(),
+		"azuread_access_package_catalog": accessPackageCatalogDataSource(),
 	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azuread_access_package_catalog":                      accessPackageCatalogResource(),
 		"azuread_access_package":                              accessPackageResource(),
 		"azuread_access_package_assignment_policy":            accessPackageAssignmentPolicyResource(),
+		"azuread_access_package_catalog":                      accessPackageCatalogResource(),
 		"azuread_access_package_resource_catalog_association": accessPackageResourceCatalogAssociationResource(),
 		"azuread_access_package_resource_package_association": accessPackageResourcePackageAssociationResource(),
 	}

--- a/internal/services/identitygovernance/schema.go
+++ b/internal/services/identitygovernance/schema.go
@@ -1,0 +1,70 @@
+package identitygovernance
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
+	"github.com/manicminer/hamilton/odata"
+)
+
+func schemaLocalizedContent() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"default_text": {
+				Description: "The default text of this question",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"localized_text": {
+				Description: "The localized text of the this question",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"language_code": {
+							Description:      "The language code of this question content",
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validate.ISO639Language,
+						},
+						"content": {
+							Description: "The localized content of this questions",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaUserSet() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"subject_type": {
+				Description: "Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ValidateFunc: validation.StringInSlice([]string{
+					odata.ShortTypeExternalSponsors,
+					odata.ShortTypeInternalSponsors,
+					odata.ShortTypeRequestorManager,
+					odata.ShortTypeConnectedOrganizationMembers,
+					odata.ShortTypeGroupMembers,
+					odata.ShortTypeSingleUser,
+				}, true),
+			},
+			"is_backup": {
+				Description: "For a user in an approval stage, this property indicates whether the user is a backup fallback approver.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
+			"object_id": {
+				Description: "The ID of the subject.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+		},
+	}
+}

--- a/internal/services/identitygovernance/schema.go
+++ b/internal/services/identitygovernance/schema.go
@@ -1,10 +1,10 @@
 package identitygovernance
 
 import (
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azuread/internal/validate"
-	"github.com/manicminer/hamilton/odata"
 )
 
 func schemaLocalizedContent() *schema.Resource {
@@ -15,6 +15,7 @@ func schemaLocalizedContent() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+
 			"localized_text": {
 				Description: "The localized text of the this question",
 				Type:        schema.TypeList,
@@ -27,8 +28,9 @@ func schemaLocalizedContent() *schema.Resource {
 							Required:         true,
 							ValidateDiagFunc: validate.ISO639Language,
 						},
+
 						"content": {
-							Description: "The localized content of this questions",
+							Description: "The localized content of this question",
 							Type:        schema.TypeString,
 							Required:    true,
 						},
@@ -43,25 +45,27 @@ func schemaUserSet() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"subject_type": {
-				Description: "Type of users, valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`.",
+				Description: "Type of users",
 				Type:        schema.TypeString,
 				Required:    true,
 				ValidateFunc: validation.StringInSlice([]string{
+					odata.ShortTypeConnectedOrganizationMembers,
 					odata.ShortTypeExternalSponsors,
+					odata.ShortTypeGroupMembers,
 					odata.ShortTypeInternalSponsors,
 					odata.ShortTypeRequestorManager,
-					odata.ShortTypeConnectedOrganizationMembers,
-					odata.ShortTypeGroupMembers,
 					odata.ShortTypeSingleUser,
 				}, true),
 			},
-			"is_backup": {
-				Description: "For a user in an approval stage, this property indicates whether the user is a backup fallback approver.",
+
+			"backup": {
+				Description: "For a user in an approval stage, this property indicates whether the user is a backup fallback approver",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+
 			"object_id": {
-				Description: "The ID of the subject.",
+				Description: "The object ID of the subject",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},

--- a/internal/services/identitygovernance/schema.go
+++ b/internal/services/identitygovernance/schema.go
@@ -17,7 +17,7 @@ func schemaLocalizedContent() *schema.Resource {
 			},
 
 			"localized_text": {
-				Description: "The localized text of the this question",
+				Description: "The localized text of this question",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem: &schema.Resource{

--- a/internal/services/identitygovernance/validate/access_package_resource_catalog_association_id.go
+++ b/internal/services/identitygovernance/validate/access_package_resource_catalog_association_id.go
@@ -1,0 +1,10 @@
+package validate
+
+import (
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/parse"
+)
+
+func AccessPackageResourceCatalogAssociationID(input string) (err error) {
+	_, err = parse.AccessPackageResourceCatalogAssociationID(input)
+	return
+}

--- a/internal/services/identitygovernance/validate/access_package_resource_package_association_id.go
+++ b/internal/services/identitygovernance/validate/access_package_resource_package_association_id.go
@@ -1,0 +1,10 @@
+package validate
+
+import (
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/parse"
+)
+
+func AccessPackageResourcePackageAssociationID(input string) (err error) {
+	_, err = parse.AccessPackageResourcePackageAssociationID(input)
+	return
+}


### PR DESCRIPTION
Resources added:

1. Access package catalog (azuread_access_package_catalog)
2. Access package (azuread_access_package)
3. Access package assignment policy (azuread_access_package_assignment_policy)
4. Add resources into catalog (only AadGroup tested) (azuread_access_package_resource_catalog_association)
5. Add resource roles to package (only AadGropu tested) (azuread_access_package_resource_package_association)

Data resource added:

1. Access package catalog (azuread_access_package_catalog)
2. Access package (azuread_access_package)

Issues:

1. azuread_access_package_resource_catalog_association throws a panic when there is no matched resource in the specified catalog because of a bug in the upstream library, have raised a PR [manicminer/hamilton #187](https://github.com/manicminer/hamilton/pull/187) to fix this.
2. There is no valid MS graph API to delete the resource roles from an access package, hence can't be deleted programatically.
3. Unit tests and acceptance tests passed except for the above two issues.
4. No documentation just yet.

Minor:
1. When testing azuread_access_package_assignment_policy against my MS developer environment, randomly some users and groups in the test might not be ready before the policy is created, this could be caused by MS API throttling, not necessarily a bug in this code
2. Personally I haven't use this code to create resources just yet, will do next week.

Closes: #218
Closes: #547