### PR TITLE
Update service principal permissions requirements

### DIFF
--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -12,7 +12,7 @@ The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires one of the following application roles: `Application.ReadWrite.All` or `Directory.ReadWrite.All`
 
-It is possible to manage service principals whilst having only the `Application.ReadWrite.OwnedBy` role granted, however only the service principal itself can be set as the owner.
+It may be possible to manage service principals whilst having only the `Application.ReadWrite.OwnedBy` role granted, however you must ensure that both the underlying application and the service principal have the Terraform principal as an owner.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Application Administrator` or `Global Administrator`
 

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -12,7 +12,7 @@ The following API permissions are required in order to use this resource.
 
 When authenticated with a service principal, this resource requires one of the following application roles: `Application.ReadWrite.All` or `Directory.ReadWrite.All`
 
-It is not currently possible to manage service principals whilst having only the `Application.ReadWrite.OwnedBy` role granted.
+It is possible to manage service principals whilst having only the `Application.ReadWrite.OwnedBy` role granted, however only the service principal itself can be set as the owner.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Application Administrator` or `Global Administrator`
 


### PR DESCRIPTION
It is possible now to create an application and service principal by making use of a service principal with the `Application.ReadWrite.OwnedBy` permissions. The documentation should be updated to reflect this.