### PR TITLE
Update conditional_access_policy.md - missing none value for included_applications

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 `applications` block supports the following:
 
 * `excluded_applications` - (Optional) A list of application IDs explicitly excluded from the policy. Can also be set to `Office365`.
-* `included_applications` - (Optional) A list of application IDs the policy applies to, unless explicitly excluded (in `excluded_applications`). Can also be set to `All` or `Office365`. Cannot be specified with `included_user_actions`. One of `included_applications` or `included_user_actions` must be specified.
+* `included_applications` - (Optional) A list of application IDs the policy applies to, unless explicitly excluded (in `excluded_applications`). Can also be set to `All`, `None` or `Office365`. Cannot be specified with `included_user_actions`. One of `included_applications` or `included_user_actions` must be specified.
 * `included_user_actions` - (Optional) A list of user actions to include. Supported values are `urn:user:registerdevice` and `urn:user:registersecurityinfo`. Cannot be specified with `included_applications`. One of `included_applications` or `included_user_actions` must be specified.
 
 ---

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -298,7 +298,7 @@ resource "azuread_conditional_access_policy" "test" {
     client_app_types = ["browser"]
 
     applications {
-      included_applications = ["All"]
+      included_applications = ["None"]
     }
 
     users {


### PR DESCRIPTION
Add missing value to "included_applications" attribute for setting no included applications.  If this value isn't set to "None" Terraform fails with the following error:

Error: Could not create conditional access policy
│ 
│   with module.conditional-access.azuread_conditional_access_policy.block_basic_auth_policy,
│   on ../conditional-access/main.tf line 30, in resource "azuread_conditional_access_policy" "block_basic_auth_policy":
│   30: resource "azuread_conditional_access_policy" "block_basic_auth_policy" {
│ 
│ ConditionalAccessPoliciesClient.BaseClient.Post(): unexpected status 500 with OData error: Internal Server Error: There was an internal server error while processing the request. Error ID: c9b4f7ac-cbe5-45fe-8d4c-16961e3b872f