### PR TITLE
Update Users Data Source permission requirements

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -10,7 +10,7 @@ Gets basic information for multiple Azure Active Directory users.
 
 The following API permissions are required in order to use this data source.
 
-When authenticated with a service principal, this data source requires one of the following application roles: `User.ReadBasic.All` or `Directory.Read.All`
+When authenticated with a service principal, this data source requires one of the following application roles: `User.ReadBasic.All`, `User.Read.All` or `Directory.Read.All`
 
 When authenticated with a user principal, this data source does not require any additional roles.
 


### PR DESCRIPTION
I was able to use User.ReadBasic.All application role instead of User.Read.All to get an user's data. Allowing read only to basic properties is preferred when the principle of least privilege is applied.