### PR TITLE
Add debug support

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,20 +6,14 @@ import (
 )
 
 func main() {
-	var debugMode bool
+	var debug bool
 
-	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	if debugMode {
-		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: Provider,
-			ProviderAddr: "registry.terraform.io/hashicorp/azuread",
-			Debug:        true,
-		})
-	} else {
-		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: Provider,
-		})
-	}
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: Provider,
+		ProviderAddr: "registry.terraform.io/hashicorp/azuread",
+		Debug:        debug,
+	})
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,25 @@
 package main
 
 import (
+	"flag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: Provider,
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	if debugMode {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: Provider,
+			ProviderAddr: "registry.terraform.io/hashicorp/azuread",
+			Debug:        true,
+		})
+	} else {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: Provider,
+		})
+	}
 }


### PR DESCRIPTION
Add debug mode to support provider debugging as described in the [plugin development documentation](https://developer.hashicorp.com/terraform/plugin/debugging#debugger-based-debugging).

The azurerm provider supports debug mode (see [main.go](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/main.go#L21)) as well. I am not sure if it was intended not to support it in azuread, but to me it would seem reasonable as it might help when developing new features or fixing bugs. The name of the flag to activate/deactivate debug mode is "debug" in contrast to "debuggable", which seemed more intuitive to me.