### PR TITLE
azuread_group: fix for issue that prevents replacing a group when `prevent_duplicate_names = true`

### DIFF
--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -314,7 +314,7 @@ func groupResourceCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, 
 
 	// Check for duplicate names
 	oldDisplayName, newDisplayName := diff.GetChange("display_name")
-	if diff.Get("prevent_duplicate_names").(bool) && tf.ValueIsNotEmptyOrUnknown(newDisplayName) &&
+	if tf.ValueIsNotEmptyOrUnknown(diff.Id()) && diff.Get("prevent_duplicate_names").(bool) && tf.ValueIsNotEmptyOrUnknown(newDisplayName) &&
 		(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
 		result, err := groupFindByName(ctx, client, newDisplayName.(string))
 		if err != nil {


### PR DESCRIPTION
Rather than coming up with a heuristic for determining whether a create is likely to be a replacement, we'll omit the duplicate name check at plan time when creating (but keep the check when updating) and defer the check to the create func (i.e. apply time). This is a workaround to be revisited when we move to terraform-plugin-framework at a future point.

Closes: #697
Replaces: #702