### PR TITLE
Remove Workaround for US Gov Bug

### DIFF
--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -19,14 +19,6 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	applicationTemplatesClient := msgraph.NewApplicationTemplatesClient(o.TenantID)
 
-	if o.Environment.MsGraph.Endpoint == environments.MsGraphUSGovL4Endpoint {
-		//Short term fix while we wait for Microsoft to fix an intermittent 504 error causing an applicationTemplate instantiate
-		//call to produce a 504. However MS api doesnt cancel request and you end up creating multiple app registrations and service principals
-		//as the client retries. Bug is not present in the beta API.
-		//Expected fix Feb 2023
-		applicationTemplatesClient.BaseClient.ApiVersion = msgraph.VersionBeta
-	}
-
 	o.ConfigureClient(&applicationTemplatesClient.BaseClient)
 
 	directoryObjectsClient := msgraph.NewDirectoryObjectsClient(o.TenantID)

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"github.com/manicminer/hamilton/msgraph"
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+	"github.com/manicminer/hamilton/msgraph"
 )
 
 type Client struct {

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -1,9 +1,7 @@
 package client
 
 import (
-	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/msgraph"
-
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
-	"github.com/manicminer/hamilton/environments"
 	"github.com/manicminer/hamilton/msgraph"
 )
 


### PR DESCRIPTION
Remove the workaround as the bug is now resolved. This was confirmed to me by Microsoft in a support ticket and I've also no longer been able to reproduce the issue using V1.0 of the API. 

PR change reverses the use of the beta endpoint. 

Original PR to fix bug can be found here https://github.com/hashicorp/terraform-provider-azuread/pull/936