### PR TITLE
Bug in error message

### DIFF
--- a/internal/services/users/user_data_source.go
+++ b/internal/services/users/user_data_source.go
@@ -358,9 +358,9 @@ func userDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 		count := len(*users)
 		if count > 1 {
-			return tf.ErrorDiagPathF(nil, "mail_nickname", "More than one user found with email alias: %q", upn)
+			return tf.ErrorDiagPathF(nil, "mail_nickname", "More than one user found with email alias: %q", mailNickname)
 		} else if count == 0 {
-			return tf.ErrorDiagPathF(err, "mail_nickname", "User not found with email alias: %q", upn)
+			return tf.ErrorDiagPathF(err, "mail_nickname", "User not found with email alias: %q", mailNickname)
 		}
 		user = (*users)[0]
 	} else {


### PR DESCRIPTION
Error message is incorrect for mailNickname logic - trying to use upn vs mailNickname, results in an invalid error message/makes troubleshooting more difficult.

```
│ Error: User not found with email alias: ""
│
│   with module.groupmember["test"].data.azuread_user.user,
│   on ../../../modules/aadgroupassignment/main.tf line 3, in data "azuread_user" "user":
│    3:   mail_nickname = "test@test.com"
│
```