### PR TITLE
Fix error creating rbac example

### DIFF
--- a/examples/create-for-rbac/main.tf
+++ b/examples/create-for-rbac/main.tf
@@ -27,7 +27,7 @@ resource "tls_self_signed_cert" "example" {
   private_key_pem = tls_private_key.example.private_key_pem
 
   subject {
-    common_name  = azuread_application.example.name
+    common_name  = azuread_application.example.display_name
     organization = "Example Corp"
   }
 

--- a/examples/create-for-rbac/outputs.tf
+++ b/examples/create-for-rbac/outputs.tf
@@ -12,6 +12,7 @@ output "client_certificate" {
 
 output "client_key" {
   value = tls_private_key.example.private_key_pem
+  sensitive = true
 }
 
 output "client_secret" {


### PR DESCRIPTION
When I create rbac example using **terraform apply** command found some problems.

1. [Refer to **display_name** of resource **azuread_application** instead of **name**.](https://github.com/hashicorp/terraform-provider-azuread/blob/66c01cca4a3ba0e644ac147420acbe345c6739f1/examples/create-for-rbac/main.tf#L30)
2. [The **private_key_pem** output by resource **tls_private_key** needs to set **sensitive = true**.](https://github.com/hashicorp/terraform-provider-azuread/blob/66c01cca4a3ba0e644ac147420acbe345c6739f1/examples/create-for-rbac/outputs.tf#L14)
` Error: Output refers to sensitive values
│ 
│   on main.tf line 194:
│  194: output "tls_private_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your
│ intent.
│ 
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true
`

Please take a look at this question.Thank you. @manicminer 