### PR TITLE
Add `template_ids` to `azuread_directory_roles`

### DIFF
--- a/docs/data-sources/directory_roles.md
+++ b/docs/data-sources/directory_roles.md
@@ -33,6 +33,7 @@ This data source does not have any arguments.
 The following attributes are exported:
 
 * `object_ids` - The object IDs of the roles.
+* `template_ids` - The template IDs of the roles.
 * `roles` - A list of users. Each `role` object provides the attributes documented below.
 
 ---

--- a/internal/services/directoryroles/directory_roles_data_source.go
+++ b/internal/services/directoryroles/directory_roles_data_source.go
@@ -33,6 +33,15 @@ func directoryRolesDataSource() *schema.Resource {
 				},
 			},
 
+			"template_ids": {
+				Description: "The template IDs of the roles",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"roles": {
 				Description: "A list of roles",
 				Type:        schema.TypeList,
@@ -81,10 +90,12 @@ func directoryRolesDataSourceRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	objectIds := make([]string, 0)
+	templateIds := make([]string, 0)
 	roleList := make([]map[string]interface{}, 0)
 
 	for _, r := range *directoryRoles {
 		objectIds = append(objectIds, *r.ID())
+		templateIds = append(templateIds, *r.RoleTemplateId)
 
 		role := make(map[string]interface{})
 		role["description"] = r.Description
@@ -104,6 +115,7 @@ func directoryRolesDataSourceRead(ctx context.Context, d *schema.ResourceData, m
 
 	tf.Set(d, "roles", roleList)
 	tf.Set(d, "object_ids", objectIds)
+	tf.Set(d, "template_ids", templateIds)
 
 	return nil
 }

--- a/internal/services/directoryroles/directory_roles_data_source_test.go
+++ b/internal/services/directoryroles/directory_roles_data_source_test.go
@@ -29,6 +29,8 @@ func (DirectoryRolesDataSource) testCheckFunc(data acceptance.TestData, addition
 		check.That(data.ResourceName).Key("roles.0.display_name").Exists(),
 		check.That(data.ResourceName).Key("roles.0.object_id").Exists(),
 		check.That(data.ResourceName).Key("roles.0.template_id").Exists(),
+		check.That(data.ResourceName).Key("object_ids.#").Exists(),
+		check.That(data.ResourceName).Key("template_ids.#").Exists(),
 	}
 	checks = append(checks, additionalChecks...)
 	return resource.ComposeTestCheckFunc(checks...)


### PR DESCRIPTION
Just a minor one, it turns out when using this with conditional access policies you need to provide the template IDs not the object IDs.. woops!

Adding them in so they can be easily used