### PR TITLE
Bugfix: retrieve authenticated principal from MS Graph when `oid` claim is missing from access token

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -311,5 +311,5 @@ func testCheckProvider(provider *schema.Provider) (errs []error) {
 		errs = append(errs, fmt.Errorf("ObjectId was not populated in client.Claims"))
 	}
 
-	return
+	return //nolint:nakedret
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -299,6 +299,10 @@ func testCheckProvider(provider *schema.Provider) (errs []error) {
 		errs = append(errs, fmt.Errorf("client.TenantID was empty"))
 	}
 
+	if client.ObjectID == "" {
+		errs = append(errs, fmt.Errorf("client.ObjectID was empty"))
+	}
+
 	if client.Claims.TenantId == "" {
 		errs = append(errs, fmt.Errorf("TenantId was not populated in client.Claims"))
 	}

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -886,7 +886,7 @@ func applicationResourceCreate(ctx context.Context, d *schema.ResourceData, meta
 	client := meta.(*clients.Client).Applications.ApplicationsClient
 	appTemplatesClient := meta.(*clients.Client).Applications.ApplicationTemplatesClient
 	directoryObjectsClient := meta.(*clients.Client).Applications.DirectoryObjectsClient
-	callerId := meta.(*clients.Client).Claims.ObjectId
+	callerId := meta.(*clients.Client).ObjectID
 	displayName := d.Get("display_name").(string)
 	templateId := d.Get("template_id").(string)
 

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -406,7 +406,7 @@ func groupResourceCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, 
 func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Groups.GroupsClient
 	directoryObjectsClient := meta.(*clients.Client).Groups.DirectoryObjectsClient
-	callerId := meta.(*clients.Client).Claims.ObjectId
+	callerId := meta.(*clients.Client).ObjectID
 
 	displayName := d.Get("display_name").(string)
 
@@ -801,7 +801,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 func groupResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Groups.GroupsClient
 	directoryObjectsClient := meta.(*clients.Client).Groups.DirectoryObjectsClient
-	callerId := meta.(*clients.Client).Claims.ObjectId
+	callerId := meta.(*clients.Client).ObjectID
 
 	groupId := d.Id()
 	displayName := d.Get("display_name").(string)

--- a/internal/services/serviceprincipals/client_config_data_source.go
+++ b/internal/services/serviceprincipals/client_config_data_source.go
@@ -44,9 +44,9 @@ func clientConfigDataSource() *schema.Resource {
 
 func clientConfigDataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	d.SetId(fmt.Sprintf("%s-%s-%s", client.TenantID, client.ClientID, client.Claims.ObjectId))
+	d.SetId(fmt.Sprintf("%s-%s-%s", client.TenantID, client.ClientID, client.ObjectID))
 	tf.Set(d, "tenant_id", client.TenantID)
 	tf.Set(d, "client_id", client.ClientID)
-	tf.Set(d, "object_id", client.Claims.ObjectId)
+	tf.Set(d, "object_id", client.ObjectID)
 	return nil
 }

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -353,7 +353,7 @@ func servicePrincipalDiffSuppress(k, old, new string, d *schema.ResourceData) bo
 func servicePrincipalResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
 	directoryObjectsClient := meta.(*clients.Client).ServicePrincipals.DirectoryObjectsClient
-	callerId := meta.(*clients.Client).Claims.ObjectId
+	callerId := meta.(*clients.Client).ObjectID
 
 	appId := d.Get("application_id").(string)
 	result, _, err := client.List(ctx, odata.Query{Filter: fmt.Sprintf("appId eq '%s'", appId)})

--- a/internal/services/users/client/client.go
+++ b/internal/services/users/client/client.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"github.com/manicminer/hamilton/msgraph"
-
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+	"github.com/manicminer/hamilton/msgraph"
 )
 
 type Client struct {
 	DirectoryObjectsClient *msgraph.DirectoryObjectsClient
+	MeClient               *msgraph.MeClient
 	UsersClient            *msgraph.UsersClient
 }
 
@@ -15,11 +15,15 @@ func NewClient(o *common.ClientOptions) *Client {
 	directoryObjectsClient := msgraph.NewDirectoryObjectsClient(o.TenantID)
 	o.ConfigureClient(&directoryObjectsClient.BaseClient)
 
+	meClient := msgraph.NewMeClient(o.TenantID)
+	o.ConfigureClient(&meClient.BaseClient)
+
 	usersClient := msgraph.NewUsersClient(o.TenantID)
 	o.ConfigureClient(&usersClient.BaseClient)
 
 	return &Client{
 		DirectoryObjectsClient: directoryObjectsClient,
+		MeClient:               meClient,
 		UsersClient:            usersClient,
 	}
 }


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform-provider-azurerm/pull/20465