### PR TITLE
Workaround: revert to using the beta API for applications

### DIFF
--- a/internal/services/administrativeunits/client/client.go
+++ b/internal/services/administrativeunits/client/client.go
@@ -15,6 +15,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	administrativeUnitsClient := msgraph.NewAdministrativeUnitsClient(o.TenantID)
 	o.ConfigureClient(&administrativeUnitsClient.BaseClient)
 
+	// SDK uses wrong endpoint for v1.0 API, see https://github.com/manicminer/hamilton/issues/222
+	administrativeUnitsClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
 	directoryObjectsClient := msgraph.NewDirectoryObjectsClient(o.TenantID)
 	o.ConfigureClient(&directoryObjectsClient.BaseClient)
 

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -15,6 +15,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	applicationsClient := msgraph.NewApplicationsClient(o.TenantID)
 	o.ConfigureClient(&applicationsClient.BaseClient)
 
+	// See https://github.com/microsoftgraph/msgraph-metadata/issues/273
+	applicationsClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
 	applicationTemplatesClient := msgraph.NewApplicationTemplatesClient(o.TenantID)
 
 	o.ConfigureClient(&applicationTemplatesClient.BaseClient)

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -19,7 +19,6 @@ func NewClient(o *common.ClientOptions) *Client {
 	applicationsClient.BaseClient.ApiVersion = msgraph.VersionBeta
 
 	applicationTemplatesClient := msgraph.NewApplicationTemplatesClient(o.TenantID)
-
 	o.ConfigureClient(&applicationTemplatesClient.BaseClient)
 
 	directoryObjectsClient := msgraph.NewDirectoryObjectsClient(o.TenantID)

--- a/internal/services/groups/client/client.go
+++ b/internal/services/groups/client/client.go
@@ -18,6 +18,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	groupsClient := msgraph.NewGroupsClient(o.TenantID)
 	o.ConfigureClient(&groupsClient.BaseClient)
 
+	// Group members not returned in full when using v1.0 API, see https://github.com/hashicorp/terraform-provider-azuread/issues/1018
+	groupsClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
 	return &Client{
 		DirectoryObjectsClient: directoryObjectsClient,
 		GroupsClient:           groupsClient,

--- a/internal/services/users/client/client.go
+++ b/internal/services/users/client/client.go
@@ -21,6 +21,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	usersClient := msgraph.NewUsersClient(o.TenantID)
 	o.ConfigureClient(&usersClient.BaseClient)
 
+	// See https://learn.microsoft.com/en-us/graph/known-issues#showinaddresslist-property-is-out-of-sync-with-microsoft-exchange (it works in the beta API)
+	usersClient.BaseClient.ApiVersion = msgraph.VersionBeta
+
 	return &Client{
 		DirectoryObjectsClient: directoryObjectsClient,
 		MeClient:               meClient,


### PR DESCRIPTION
- v1.0 API for applications is broken, see https://github.com/microsoftgraph/msgraph-metadata/issues/273
  - Resolves: #1017
  - Resolves: #1016

- Beta API for users does not exhibit this issue: https://learn.microsoft.com/en-us/graph/known-issues#showinaddresslist-property-is-out-of-sync-with-microsoft-exchange
  - Resolves: #1020

- v1.0 API for groups does not return full membership list, see https://github.com/hashicorp/terraform-provider-azuread/issues/1018
  - Resolves: #1018

- SDK uses wrong endpoint for administrative units in v1.0 API, see https://github.com/manicminer/hamilton/issues/222
  - Resolves: #1015