### PR TITLE
Acceptance testing: build separate client for checks

### DIFF
--- a/internal/acceptance/check/that.go
+++ b/internal/acceptance/check/that.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
@@ -29,7 +29,10 @@ func That(resourceName string) thatType {
 // ExistsInAzure validates that the specified resource exists within Azure
 func (t thatType) ExistsInAzure(testResource types.TestResource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := acceptance.AzureADProvider.Meta().(*clients.Client)
+		client, err := testclient.Build()
+		if err != nil {
+			return fmt.Errorf("building client: %+v", err)
+		}
 		return helpers.ExistsInAzure(client, testResource, t.resourceName)(s)
 	}
 }
@@ -109,8 +112,12 @@ func (t thatWithKeyType) ValidatesWith(validationFunc KeyValidationFunc) resourc
 			}
 		}
 
-		clients := acceptance.AzureADProvider.Meta().(*clients.Client)
-		return validationFunc(clients.StopContext, clients, values)
+		client, err := testclient.Build()
+		if err != nil {
+			return fmt.Errorf("building client: %+v", err)
+		}
+
+		return validationFunc(client.StopContext, client, values)
 	}
 }
 

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/helpers"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/types"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 )
@@ -77,5 +79,10 @@ func PreCheck(t *testing.T) {
 }
 
 func buildClient() *clients.Client {
-	return AzureADProvider.Meta().(*clients.Client)
+	client, err := testclient.Build()
+	if err != nil {
+		log.Fatalf("building client: %+v", err)
+	}
+
+	return client
 }

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -1,0 +1,76 @@
+package testclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+)
+
+var (
+	_client    *clients.Client
+	clientLock = &sync.Mutex{}
+)
+
+func Build() (*clients.Client, error) {
+	clientLock.Lock()
+	defer clientLock.Unlock()
+
+	if _client == nil {
+		var (
+			ctx          = context.Background()
+			metadataHost = os.Getenv("ARM_METADATA_HOSTNAME")
+
+			env *environments.Environment
+			err error
+		)
+
+		envName, exists := os.LookupEnv("ARM_ENVIRONMENT")
+		if !exists {
+			envName = "public"
+		}
+
+		if metadataHost != "" {
+			if env, err = environments.FromEndpoint(ctx, fmt.Sprintf("https://%s", metadataHost), envName); err != nil {
+				return nil, fmt.Errorf("building test client: %+v", err)
+			}
+		} else if env, err = environments.FromName(envName); err != nil {
+			return nil, fmt.Errorf("building test client: %+v", err)
+		}
+
+		authConfig := auth.Credentials{
+			Environment: *env,
+			ClientID:    os.Getenv("ARM_CLIENT_ID"),
+			TenantID:    os.Getenv("ARM_TENANT_ID"),
+
+			ClientCertificatePath:     os.Getenv("ARM_CLIENT_CERTIFICATE_PATH"),
+			ClientCertificatePassword: os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD"),
+			ClientSecret:              os.Getenv("ARM_CLIENT_SECRET"),
+
+			EnableAuthenticatingUsingClientCertificate: true,
+			EnableAuthenticatingUsingClientSecret:      true,
+			EnableAuthenticatingUsingAzureCLI:          false,
+			EnableAuthenticatingUsingManagedIdentity:   false,
+			EnableAuthenticationUsingOIDC:              false,
+			EnableAuthenticationUsingGitHubOIDC:        false,
+		}
+
+		builder := clients.ClientBuilder{
+			AuthConfig:       &authConfig,
+			TerraformVersion: os.Getenv("TERRAFORM_CORE_VERSION"),
+		}
+
+		client, err := builder.Build(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("building test client: %+v", err)
+		}
+
+		_client = client
+	}
+
+	return _client, nil
+}


### PR DESCRIPTION
Needed since terraform-plugin-sdk v2.24.1 cancels the context for the test provider once the config has been applied, causing checks to fail

Based on the [AzureRM implementation](https://github.com/hashicorp/terraform-provider-azurerm/blob/42367ac6c4799252c9c3ac54da51d2e76314266c/internal/acceptance/check/that.go#L42-L45)