### PR TITLE
Fix accuracy in documentation of Application permissions for azuread_group and azuread_group_member

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -10,7 +10,9 @@ Manages a group within Azure Active Directory.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`. Alternatively you can grant the principal the application role `Group.Create`, and make the principal as part of the owners of the group.
+When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`.
+
+Alternatively, if the authenticated service principal is also an owner of the group being managed, this resource can use the application role: `Group.Create`.
 
 If using the `assignable_to_role` property, this resource additionally requires one of the following application roles: `RoleManagement.ReadWrite.Directory` or `Directory.ReadWrite.All`
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -10,7 +10,7 @@ Manages a group within Azure Active Directory.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`
+When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`. Alternatively you can grant the principal the application role `Group.Create`, and make the principal as part of the owners of the group.
 
 If using the `assignable_to_role` property, this resource additionally requires one of the following application roles: `RoleManagement.ReadWrite.Directory` or `Directory.ReadWrite.All`
 

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -12,7 +12,7 @@ Manages a single group membership within Azure Active Directory.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`
+When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`. If the service principal is an owner of the group, these permissions are not required.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Groups Administrator`, `User Administrator` or `Global Administrator`
 

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -12,7 +12,9 @@ Manages a single group membership within Azure Active Directory.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`. If the service principal is an owner of the group, these permissions are not required.
+When authenticated with a service principal, this resource requires one of the following application roles: `Group.ReadWrite.All` or `Directory.ReadWrite.All`.
+
+However, if the authenticated service principal is an owner of the group being managed, an application role is not required.
 
 When authenticated with a user principal, this resource requires one of the following directory roles: `Groups Administrator`, `User Administrator` or `Global Administrator`
 


### PR DESCRIPTION
Tested the changes described today and it works. This is a more least-privilege way to grant access to create AAD groups and memberships.