### PR TITLE
Bugfix: serviceprincipal owner removal #1049

### DIFF
--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -539,13 +539,13 @@ func servicePrincipalResourceUpdate(ctx context.Context, d *schema.ResourceData,
 		return tf.ErrorDiagF(err, "Updating service principal with object ID: %q", d.Id())
 	}
 
-	if v, ok := d.GetOk("owners"); ok && d.HasChange("owners") {
+	if d.HasChange("owners") {
 		owners, _, err := client.ListOwners(ctx, d.Id())
 		if err != nil {
 			return tf.ErrorDiagF(err, "Could not retrieve owners for service principal with object ID: %q", d.Id())
 		}
 
-		desiredOwners := *tf.ExpandStringSlicePtr(v.(*schema.Set).List())
+		desiredOwners := *tf.ExpandStringSlicePtr(d.Get("owners").(*schema.Set).List())
 		existingOwners := *owners
 		ownersForRemoval := utils.Difference(existingOwners, desiredOwners)
 		ownersToAdd := utils.Difference(desiredOwners, existingOwners)

--- a/internal/services/serviceprincipals/service_principal_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_resource_test.go
@@ -235,7 +235,7 @@ func TestAccServicePrincipal_owners(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data),
+			Config: r.noOwners(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("owners.#").HasValue("0"),
@@ -534,19 +534,19 @@ resource "azuread_user" "testC" {
 `, data.RandomInteger, data.RandomPassword)
 }
 
-func (ServicePrincipalResource) noOwners(data acceptance.TestData) string {
+func (r ServicePrincipalResource) noOwners(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azuread" {}
+%[1]s
 
 resource "azuread_application" "test" {
-  display_name = "acctestServicePrincipal-%[1]d"
+  display_name = "acctestServicePrincipal-%[2]d"
 }
 
 resource "azuread_service_principal" "test" {
   application_id = azuread_application.test.application_id
   owners         = []
 }
-`, data.RandomInteger)
+`, r.templateThreeUsers(data), data.RandomInteger)
 }
 
 func (r ServicePrincipalResource) singleOwner(data acceptance.TestData) string {


### PR DESCRIPTION
GetOK does not (I believe) return ok when passed an empty set or null value. Therefore the code section is not executed when trying to clear all owners. Resolution matches that for #901 as applied to applications. Reviewed tests and these are the same as those made against applications - though there is a gap in the tests given this issue was not caught but I see no way to address it.