### PR TITLE
Fix api permission docs on azuread_application resource

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -10,7 +10,7 @@ Manages an application registration within Azure Active Directory.
 
 The following API permissions are required in order to use this resource.
 
-When authenticated with a service principal, this resource requires one of the following application roles: `Application.ReadWrite.All` or `Directory.ReadWrite.All`
+When authenticated with a service principal, this resource requires the following application role: `Application.ReadWrite.All`
 
 -> It is usually possible to create applications using this resource with just the `Application.ReadWrite.OwnedBy` application role, provided the principal being used to run Terraform is included in the `owners` property. However, this is not officially supported by the API so if you receive a `403` you need to investigate what API call is failing and add additional permissions as necessary. One commonly needed additional permission is `User.Read.All`, in case you specify additional `owners`.
 


### PR DESCRIPTION
According to the provider docs one of `Directory.ReadWrite.All` or `Application.ReadWrite.All` are sufficient to use the `azuread_application` resource. This is not true. According to my experience and to the official REST api docs just `Application.ReadWrite.All` is required: https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-beta&tabs=http#permissions