### PR TITLE
Fix regression: writeback configuration should be omitted on creation

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 !> **Warning** Do not use the `members` property at the same time as the [azuread_group_member](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group_member) resource for the same group. Doing so will cause a conflict and group members will be removed.
 
-* `onpremises_group_type` - (Optional) The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are `UniversalDistributionGroup`, `UniversalMailEnabledSecurityGroup`, or `UniversalSecurityGroup`.
+* `onpremises_group_type` - (Optional) The on-premises group type that the AAD group will be written as, when writeback is enabled. Possible values are `UniversalDistributionGroup`, `UniversalMailEnabledSecurityGroup`, or `UniversalSecurityGroup`. Once set, unsetting this property forces a new resource to be created.
 * `owners` - (Optional) A set of object IDs of principals that will be granted ownership of the group. Supported object types are users or service principals. By default, the principal being used to execute Terraform is assigned as the sole owner. Groups cannot be created with no owners or have all their owners removed.
 
 -> **Group Ownership**  It's recommended to always specify one or more group owners, including the principal being used to execute Terraform, such as in the example above. When removing group owners, if a user principal has been assigned ownership, the last user cannot be removed as an owner. Microsoft 365 groups are required to always have at least one owner which _must be a user_ (i.e. not a service principal).

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -493,6 +493,14 @@ func TestAccGroup_writeback(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccGroup_writebackUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group", "test")
+	r := GroupResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
@@ -521,13 +529,6 @@ func TestAccGroup_writebackUnified(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalDistributionGroup"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.unified(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -1101,9 +1102,11 @@ resource "azuread_group" "test" {
 func (GroupResource) withWriteback(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azuread_group" "test" {
-  display_name      = "acctestGroup-%[1]d"
-  security_enabled  = true
-  writeback_enabled = true
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+
+  writeback_enabled     = true
+  onpremises_group_type = "UniversalSecurityGroup"
 }
 `, data.RandomInteger)
 }


### PR DESCRIPTION
Writeback configuration should be omitted on creation instead of using the default value, and unsetting `onpremises_group_type` should cause a ForceNew

Fixes: #1067