### PR TITLE
Bugfix: mitigate inheritence or long race condition between resource functions when clients have retries disabled

### DIFF
--- a/internal/services/administrativeunits/administrative_unit_member_resource.go
+++ b/internal/services/administrativeunits/administrative_unit_member_resource.go
@@ -177,6 +177,7 @@ func administrativeUnitMemberResourceDelete(ctx context.Context, d *schema.Resou
 
 	// Wait for membership link to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.GetMember(ctx, id.AdministrativeUnitId, id.MemberId); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/administrativeunits/administrative_unit_member_resource_test.go
+++ b/internal/services/administrativeunits/administrative_unit_member_resource_test.go
@@ -109,6 +109,7 @@ func TestAccAdministrativeUnitMember_requiresImport(t *testing.T) {
 func (r AdministrativeUnitMemberResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.AdministrativeUnits.AdministrativeUnitsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.AdministrativeUnitMemberID(state.ID)
 	if err != nil {

--- a/internal/services/administrativeunits/administrative_unit_resource.go
+++ b/internal/services/administrativeunits/administrative_unit_resource.go
@@ -356,6 +356,7 @@ func administrativeUnitResourceDelete(ctx context.Context, d *schema.ResourceDat
 
 	// Wait for administrative unit object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, administrativeUnitId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/administrativeunits/administrative_unit_resource_test.go
+++ b/internal/services/administrativeunits/administrative_unit_resource_test.go
@@ -92,6 +92,7 @@ func TestAccGroup_preventDuplicateNamesFail(t *testing.T) {
 func (r AdministrativeUnitResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.AdministrativeUnits.AdministrativeUnitsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	role, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/applications/application_certificate_resource.go
+++ b/internal/services/applications/application_certificate_resource.go
@@ -294,6 +294,7 @@ func applicationCertificateResourceDelete(ctx context.Context, d *schema.Resourc
 
 	// Wait for application certificate to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		app, _, err := client.Get(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/applications/application_certificate_resource_test.go
+++ b/internal/services/applications/application_certificate_resource_test.go
@@ -171,6 +171,7 @@ func TestAccApplicationCertificate_requiresImport(t *testing.T) {
 func (ApplicationCertificateResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.CertificateID(state.ID)
 	if err != nil {

--- a/internal/services/applications/application_data_source.go
+++ b/internal/services/applications/application_data_source.go
@@ -495,6 +495,7 @@ func applicationDataSource() *schema.Resource {
 func applicationDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var app *msgraph.Application
 

--- a/internal/services/applications/application_federated_identity_credential_resource.go
+++ b/internal/services/applications/application_federated_identity_credential_resource.go
@@ -247,6 +247,7 @@ func applicationFederatedIdentityCredentialResourceDelete(ctx context.Context, d
 
 	// Wait for credential to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		credentials, _, err := client.ListFederatedIdentityCredentials(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/applications/application_federated_identity_credential_resource_test.go
+++ b/internal/services/applications/application_federated_identity_credential_resource_test.go
@@ -85,6 +85,7 @@ func TestAccApplicationFederatedIdentityCredential_update(t *testing.T) {
 func (r ApplicationFederatedIdentityCredentialResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.FederatedIdentityCredentialID(state.ID)
 	if err != nil {

--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -271,6 +271,7 @@ func applicationPasswordResourceDelete(ctx context.Context, d *schema.ResourceDa
 
 	// Wait for application password to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		app, _, err := client.Get(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -79,6 +79,7 @@ func TestAccApplicationPassword_relativeEndDate(t *testing.T) {
 func (r ApplicationPasswordResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.PasswordID(state.ID)
 	if err != nil {

--- a/internal/services/applications/application_pre_authorized_resource_test.go
+++ b/internal/services/applications/application_pre_authorized_resource_test.go
@@ -54,6 +54,7 @@ func TestAccApplicationPreAuthorized_requiresImport(t *testing.T) {
 func (ApplicationPreAuthorizedResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.ApplicationPreAuthorizedID(state.ID)
 	if err != nil {

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1343,6 +1343,7 @@ func applicationResourceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	// Wait for application object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, appId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -587,6 +587,7 @@ func TestAccApplication_logo(t *testing.T) {
 func (r ApplicationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 	app, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {
 		if status == http.StatusNotFound {

--- a/internal/services/applications/application_template_data_source.go
+++ b/internal/services/applications/application_template_data_source.go
@@ -94,6 +94,7 @@ func applicationTemplateDataSource() *schema.Resource {
 func applicationTemplateDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Applications.ApplicationTemplatesClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var template *msgraph.ApplicationTemplate
 

--- a/internal/services/approleassignments/app_role_assignment_resource_test.go
+++ b/internal/services/approleassignments/app_role_assignment_resource_test.go
@@ -97,6 +97,7 @@ func TestAccAppRoleAssignment_userForTenantApp(t *testing.T) {
 func (r AppRoleAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.AppRoleAssignments.AppRoleAssignedToClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.AppRoleAssignmentID(state.ID)
 	if err != nil {

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -601,6 +601,7 @@ func conditionalAccessPolicyResourceDelete(ctx context.Context, d *schema.Resour
 	}
 
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, policyId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/conditionalaccess/named_location_resource.go
+++ b/internal/services/conditionalaccess/named_location_resource.go
@@ -303,6 +303,7 @@ func namedLocationResourceDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, namedLocationId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/directoryobjects/directory_object_data_source.go
+++ b/internal/services/directoryobjects/directory_object_data_source.go
@@ -41,6 +41,7 @@ func directoryObjectDataSource() *schema.Resource {
 func directoryObjectDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Users.DirectoryObjectsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var directoryObject *msgraph.DirectoryObject
 

--- a/internal/services/directoryroles/custom_directory_role_resource_test.go
+++ b/internal/services/directoryroles/custom_directory_role_resource_test.go
@@ -129,6 +129,7 @@ func TestAccCustomDirectoryRole_templateId(t *testing.T) {
 func (r CustomDirectoryRoleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.DirectoryRoles.RoleDefinitionsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	role, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/directoryroles/directory_role_assignment_resource_test.go
+++ b/internal/services/directoryroles/directory_role_assignment_resource_test.go
@@ -145,6 +145,7 @@ func TestAccDirectoryRoleAssignment_multipleUser(t *testing.T) {
 func (r DirectoryRoleAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.DirectoryRoles.RoleAssignmentsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	if _, status, err := client.Get(ctx, state.ID, odata.Query{}); err != nil {
 		if status == http.StatusNotFound {

--- a/internal/services/directoryroles/directory_role_member_resource.go
+++ b/internal/services/directoryroles/directory_role_member_resource.go
@@ -179,6 +179,7 @@ func directoryRoleMemberResourceDelete(ctx context.Context, d *schema.ResourceDa
 
 	// Wait for membership link to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.GetMember(ctx, id.DirectoryRoleId, id.MemberId); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/directoryroles/directory_role_member_resource_test.go
+++ b/internal/services/directoryroles/directory_role_member_resource_test.go
@@ -109,6 +109,7 @@ func TestAccDirectoryRoleMember_requiresImport(t *testing.T) {
 func (r DirectoryRoleMemberResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.DirectoryRoles.DirectoryRolesClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.DirectoryRoleMemberID(state.ID)
 	if err != nil {

--- a/internal/services/directoryroles/directory_role_resource_test.go
+++ b/internal/services/directoryroles/directory_role_resource_test.go
@@ -53,6 +53,7 @@ func TestAccDirectoryRole_byTemplateId(t *testing.T) {
 func (r DirectoryRoleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.DirectoryRoles.DirectoryRolesClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	role, status, err := client.Get(ctx, state.ID)
 	if err != nil {

--- a/internal/services/domains/domains_data_source.go
+++ b/internal/services/domains/domains_data_source.go
@@ -133,6 +133,8 @@ func domainsDataSource() *schema.Resource {
 func domainsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Domains.DomainsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
+
 	tenantId := meta.(*clients.Client).TenantID
 
 	adminManaged := d.Get("admin_managed").(bool)

--- a/internal/services/groups/group_data_source.go
+++ b/internal/services/groups/group_data_source.go
@@ -246,6 +246,7 @@ func groupDataSource() *schema.Resource {
 func groupDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Groups.GroupsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var group msgraph.Group
 	var displayName string

--- a/internal/services/groups/group_member_resource.go
+++ b/internal/services/groups/group_member_resource.go
@@ -167,6 +167,7 @@ func groupMemberResourceDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	// Wait for membership link to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.GetMember(ctx, id.GroupId, id.MemberId); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/groups/group_member_resource_test.go
+++ b/internal/services/groups/group_member_resource_test.go
@@ -138,6 +138,7 @@ func TestAccGroupMember_requiresImport(t *testing.T) {
 func (r GroupMemberResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Groups.GroupsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.GroupMemberID(state.ID)
 	if err != nil {

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -727,6 +727,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Wait for DisplayName to be updated
 	if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		group, status, err := client.Get(ctx, *group.ID(), odata.Query{})
 		if err != nil {
@@ -746,6 +747,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		if description == "" {
 			// Ignoring the error result here because the description might not be updated out of band, in which case we skip over this
 			if updated, _ := helpers.WaitForUpdateWithTimeout(ctx, 2*time.Minute, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				group, _, err := client.Get(ctx, *group.ID(), odata.Query{})
 				if err != nil {
@@ -768,6 +770,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 				// Wait for Description to be removed
 				if err = helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+					defer func() { client.BaseClient.DisableRetries = false }()
 					client.BaseClient.DisableRetries = true
 					group, _, err = client.Get(ctx, *group.ID(), odata.Query{})
 					if err != nil {
@@ -798,6 +801,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for AllowExternalSenders to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -822,6 +826,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for AutoSubscribeNewMembers to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -846,6 +851,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for HideFromAddressLists to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -870,6 +876,7 @@ func groupResourceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for HideFromOutlookClients to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -1032,6 +1039,7 @@ func groupResourceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for AllowExternalSenders to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -1056,6 +1064,7 @@ func groupResourceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for AutoSubscribeNewMembers to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -1080,6 +1089,7 @@ func groupResourceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for HideFromAddressLists to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -1104,6 +1114,7 @@ func groupResourceUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 			// Wait for HideFromOutlookClients to be updated
 			if err := helpers.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				defer func() { client.BaseClient.DisableRetries = false }()
 				client.BaseClient.DisableRetries = true
 				groupExtra, err := groupGetAdditional(ctx, client, *group.ID())
 				if err != nil {
@@ -1383,6 +1394,7 @@ func groupResourceDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Wait for group object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, groupId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -553,6 +553,7 @@ func TestAccGroup_writebackUnified(t *testing.T) {
 func (r GroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Groups.GroupsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	group, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -99,6 +99,7 @@ func groupsDataSource() *schema.Resource {
 func groupsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Groups.GroupsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var groups []msgraph.Group
 	var expectedCount int

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -437,6 +437,7 @@ func accessPackageAssignmentPolicyResourceDelete(ctx context.Context, d *schema.
 
 	// Wait for user object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, accessPackageAssignmentPolicyId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -94,6 +94,7 @@ func TestAccAccessPackageAssignmentPolicy_update(t *testing.T) {
 func (AccessPackageAssignmentPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageAssignmentPolicyClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	_, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/identitygovernance/access_package_catalog_resource.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource.go
@@ -177,6 +177,7 @@ func accessPackageCatalogResourceDelete(ctx context.Context, d *schema.ResourceD
 
 	// Wait for object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, accessPackageCatalogId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/identitygovernance/access_package_catalog_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource_test.go
@@ -79,6 +79,7 @@ func TestAccAccessPackageCatalog_update(t *testing.T) {
 func (AccessPackageCatalogResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageCatalogClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	_, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/identitygovernance/access_package_catalog_role_assignment_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_role_assignment_resource_test.go
@@ -74,6 +74,7 @@ func TestAccAccessPackageCatalogRoleAssignmentResource_user(t *testing.T) {
 func (r AccessPackageCatalogRoleAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageCatalogRoleAssignmentsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	if _, status, err := client.Get(ctx, state.ID, odata.Query{}); err != nil {
 		if status == http.StatusNotFound {

--- a/internal/services/identitygovernance/access_package_resource.go
+++ b/internal/services/identitygovernance/access_package_resource.go
@@ -180,6 +180,7 @@ func accessPackageResourceDelete(ctx context.Context, d *schema.ResourceData, me
 
 	// Wait for object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, accessPackageId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
@@ -50,6 +50,7 @@ func TestAccAccessPackageResourceCatalogAssociation_requiresImport(t *testing.T)
 func (r AccessPackageResourceCatalogAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageResourceClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.AccessPackageResourceCatalogAssociationID(state.ID)
 	if err != nil {

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -36,6 +36,7 @@ func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 func (AccessPackageResourcePackageAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageResourceRoleScopeClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.AccessPackageResourcePackageAssociationID(state.ID)
 	if err != nil {

--- a/internal/services/identitygovernance/access_package_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_test.go
@@ -79,6 +79,7 @@ func TestAccAccessPackage_update(t *testing.T) {
 func (AccessPackageResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	_, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/invitations/invitation_resource.go
+++ b/internal/services/invitations/invitation_resource.go
@@ -234,6 +234,7 @@ func invitationResourceDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	// Wait for user object to be deleted, this seems much slower for invited users
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, userID, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/invitations/invitation_resource_test.go
+++ b/internal/services/invitations/invitation_resource_test.go
@@ -140,6 +140,7 @@ func TestAccInvitation_withGroupMembership(t *testing.T) {
 func (r InvitationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Invitations.UsersClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	userID := state.Attributes["user_id"]
 

--- a/internal/services/policies/claims_mapping_policy_resource_test.go
+++ b/internal/services/policies/claims_mapping_policy_resource_test.go
@@ -67,6 +67,7 @@ resource "azuread_claims_mapping_policy" "test" {
 func (r ClaimsMappingPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Policies.ClaimsMappingPolicyClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	exists := false
 	_, status, err := client.Get(ctx, state.ID, odata.Query{})

--- a/internal/services/serviceprincipals/service_principal_certificate_resource.go
+++ b/internal/services/serviceprincipals/service_principal_certificate_resource.go
@@ -294,6 +294,7 @@ func servicePrincipalCertificateResourceDelete(ctx context.Context, d *schema.Re
 
 	// Wait for service principal certificate to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		servicePrincipal, _, err := client.Get(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/serviceprincipals/service_principal_certificate_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_certificate_resource_test.go
@@ -171,6 +171,7 @@ func TestAccServicePrincipalCertificate_requiresImport(t *testing.T) {
 func (r ServicePrincipalCertificateResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.CertificateID(state.ID)
 	if err != nil {

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_resource_test.go
@@ -58,6 +58,7 @@ resource "azuread_service_principal_claims_mapping_policy_assignment" "test" {
 func (r ServicePrincipalClaimsMappingPolicyAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.ClaimsMappingPolicyAssignmentID(state.ID)
 	if err != nil {

--- a/internal/services/serviceprincipals/service_principal_data_source.go
+++ b/internal/services/serviceprincipals/service_principal_data_source.go
@@ -281,6 +281,7 @@ func servicePrincipalData() *schema.Resource {
 func servicePrincipalDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var servicePrincipal *msgraph.ServicePrincipal
 

--- a/internal/services/serviceprincipals/service_principal_delegated_permission_grant_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_delegated_permission_grant_resource_test.go
@@ -50,6 +50,7 @@ func TestAccServicePrincipalDelegatedPermissionGrant_singleUser(t *testing.T) {
 func (r ServicePrincipalDelegatedPermissionGrantResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.DelegatedPermissionGrantsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	if _, status, err := client.Get(ctx, state.ID, odata.Query{}); err != nil {
 		if status == http.StatusNotFound {

--- a/internal/services/serviceprincipals/service_principal_password_resource.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource.go
@@ -270,6 +270,7 @@ func servicePrincipalPasswordResourceDelete(ctx context.Context, d *schema.Resou
 
 	// Wait for service principal password to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		servicePrincipal, _, err := client.Get(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/serviceprincipals/service_principal_password_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource_test.go
@@ -79,6 +79,7 @@ func TestAccServicePrincipalPassword_relativeEndDate(t *testing.T) {
 func (r ServicePrincipalPasswordResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.PasswordID(state.ID)
 	if err != nil {

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -660,6 +660,7 @@ func servicePrincipalResourceDelete(ctx context.Context, d *schema.ResourceData,
 
 		// Wait for service principal object to be deleted
 		if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+			defer func() { client.BaseClient.DisableRetries = false }()
 			client.BaseClient.DisableRetries = true
 			if _, status, err := client.Get(ctx, servicePrincipalId, odata.Query{}); err != nil {
 				if status == http.StatusNotFound {

--- a/internal/services/serviceprincipals/service_principal_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_resource_test.go
@@ -314,6 +314,7 @@ func TestAccServicePrincipal_fromApplicationTemplate(t *testing.T) {
 func (r ServicePrincipalResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	servicePrincipal, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource.go
+++ b/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource.go
@@ -289,6 +289,7 @@ func servicePrincipalTokenSigningCertificateResourceDelete(ctx context.Context, 
 
 	// Wait for service principal token signing certificate to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		servicePrincipal, _, err := client.Get(ctx, id.ObjectId, odata.Query{})

--- a/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
@@ -63,6 +63,7 @@ func TestAccServicePrincipalTokenSigningCertificate_complete(t *testing.T) {
 func (r servicePrincipalTokenSigningCertificateResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.SigningCertificateID(state.ID)
 	if err != nil {

--- a/internal/services/serviceprincipals/service_principals_data_source.go
+++ b/internal/services/serviceprincipals/service_principals_data_source.go
@@ -174,6 +174,7 @@ func servicePrincipalsDataSource() *schema.Resource {
 func servicePrincipalsDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).ServicePrincipals.ServicePrincipalsClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var servicePrincipals []msgraph.ServicePrincipal
 	var expectedCount int

--- a/internal/services/serviceprincipals/synchronization_job_resource.go
+++ b/internal/services/serviceprincipals/synchronization_job_resource.go
@@ -226,6 +226,7 @@ func synchronizationJobResourceDelete(ctx context.Context, d *schema.ResourceDat
 
 	// Wait for synchronization job to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		job, _, _ := client.Get(ctx, id.JobId, id.ServicePrincipalId)

--- a/internal/services/serviceprincipals/synchronization_job_resource_test.go
+++ b/internal/services/serviceprincipals/synchronization_job_resource_test.go
@@ -54,6 +54,7 @@ func TestAccSynchronizationJob_disabled(t *testing.T) {
 func (r SynchronizationJobResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.SynchronizationJobClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.SynchronizationJobID(state.ID)
 	if err != nil {

--- a/internal/services/serviceprincipals/synchronization_secret_resource.go
+++ b/internal/services/serviceprincipals/synchronization_secret_resource.go
@@ -195,6 +195,7 @@ func synchronizationSecretResourceDelete(ctx context.Context, d *schema.Resource
 
 	// Wait for synchronization secret to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 
 		synchronizationSecrets, _, _ := client.GetSecrets(ctx, id.ServicePrincipalId)

--- a/internal/services/serviceprincipals/synchronization_secret_resource_test.go
+++ b/internal/services/serviceprincipals/synchronization_secret_resource_test.go
@@ -39,6 +39,7 @@ func TestAccSynchronizationSecret_basic(t *testing.T) {
 func (r SynchronizationSecretResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ServicePrincipals.SynchronizationJobClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	id, err := parse.SynchronizationSecretID(state.ID)
 	if err != nil {

--- a/internal/services/userflows/user_flow_attribute_resource.go
+++ b/internal/services/userflows/user_flow_attribute_resource.go
@@ -164,6 +164,7 @@ func userFlowAttributeResourceDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, id, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/userflows/user_flow_attribute_resource_test.go
+++ b/internal/services/userflows/user_flow_attribute_resource_test.go
@@ -69,6 +69,7 @@ func TestAccUserFlowAttribute_requiresImport(t *testing.T) {
 func (r UserflowAttributeResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.UserFlows.UserFlowAttributesClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	userFlowAttr, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/users/user_data_source.go
+++ b/internal/services/users/user_data_source.go
@@ -314,6 +314,7 @@ func userDataSource() *schema.Resource {
 func userDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Users.UsersClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var user msgraph.User
 

--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -699,6 +699,7 @@ func userResourceDelete(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Wait for user object to be deleted
 	if err := helpers.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		defer func() { client.BaseClient.DisableRetries = false }()
 		client.BaseClient.DisableRetries = true
 		if _, status, err := client.Get(ctx, userId, odata.Query{}); err != nil {
 			if status == http.StatusNotFound {

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -128,6 +128,7 @@ func TestAccUser_passwordOmitted(t *testing.T) {
 func (r UserResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Users.UsersClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	user, status, err := client.Get(ctx, state.ID, odata.Query{})
 	if err != nil {

--- a/internal/services/users/users_data_source.go
+++ b/internal/services/users/users_data_source.go
@@ -157,6 +157,7 @@ func usersData() *schema.Resource {
 func usersDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client).Users.UsersClient
 	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
 
 	var users []msgraph.User
 	var expectedCount int


### PR DESCRIPTION
Because clients are shared between different operations on resources, sometimes a client can have Retries disabled and this is inherited by another resource function. This aims to mitigate this by always trying to re-enable retries wherever they are temporarily disabled for polling etc.

Closes: #1083 

(Linking the above issue since whilst this doesn't entirely mitigate the shared memory aspect, it should mitigate the particular case being reported in that issue)