### PR TITLE
Fix typo on debugging docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,6 @@ It's also possible to use multiple Provider blocks within a single Terraform con
 
 ## Logging and Tracing
 
-Logging output can be controlled with the `TF_LOG` or `TF_PROVIDER_LOG` environment variables. Exporting `TF_LOG=DEBUG` will increase the log verbosity and emit HTTP request and response traces to stdout when running Terraform. This output is very useful when reporting a bug in the provider.
+Logging output can be controlled with the `TF_LOG` or `TF_LOG_PROVIDER` environment variables. Exporting `TF_LOG=DEBUG` will increase the log verbosity and emit HTTP request and response traces to stdout when running Terraform. This output is very useful when reporting a bug in the provider.
 
 Note that whilst we make every effort to remove authentication tokens from HTTP traces, they can still contain very identifiable and personal information which you should carefully censor before posting on our issue tracker.


### PR DESCRIPTION
Fixing typo as per https://developer.hashicorp.com/terraform/plugin/log/managing