### PR TITLE
allow zero length string for user password

### DIFF
--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -230,7 +230,7 @@ func userResource() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				Sensitive:    true,
-				ValidateFunc: validation.StringLenBetween(1, 256), // Currently the max length for AAD passwords is 256
+				ValidateFunc: validation.StringLenBetween(0, 256), // Currently the max length for AAD passwords is 256
 			},
 
 			"disable_strong_password": {


### PR DESCRIPTION
According to [document](https://github.com/hashicorp/terraform-provider-azuread/blob/debc25099fb72e88b0cb2e2d796c7825188102ef/docs/resources/user.md?plain=1#L60), setting password to empty string is allowed.
Also, [code](https://github.com/hashicorp/terraform-provider-azuread/blob/debc25099fb72e88b0cb2e2d796c7825188102ef/internal/services/users/user_resource.go#L550-L555) checks if password is empty and does not update password if it is.
Therefore, I think zero length string(empty string) should be allowed.

<details>
<summary>Screenshot</summary>

1. Document
![image](https://github.com/hashicorp/terraform-provider-azuread/assets/46488521/027419a8-eb81-424c-bb87-e13c79336c9c)

2. Code
![image](https://github.com/hashicorp/terraform-provider-azuread/assets/46488521/38bc26fb-7d36-4abb-8751-a54f18e9fa6c)
</details>

I created a test, but I'm not sure if I created it correctly.