### PR TITLE
provider: ensuring the provider version is appended to the release user agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X main.Version={{.Version}}
+      - -s -w -X github.com/hashicorp/terraform-provider-azuread/version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   algorithm: sha256


### PR DESCRIPTION
Before:

> User-Agent: HashiCorp Terraform/1.6.0-dev (+https://www.terraform.io) Terraform Plugin SDK/2.10.1 terraform-provider-azuread/dev Hamilton (Go-http-client/1.1) pid-222c6c49-1b0a-5959-a213-6608f9eb8820

After:

> User-Agent: HashiCorp Terraform/1.6.0-dev (+https://www.terraform.io) Terraform Plugin SDK/2.10.1 terraform-provider-azuread/99.99.99 Hamilton (Go-http-client/1.1) pid-222c6c49-1b0a-5959-a213-6608f9eb8820