### PR TITLE
`azuread_conditional_access_policy` - Add `disable_session_resilience` property

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -61,6 +61,7 @@ resource "azuread_conditional_access_policy" "example" {
 
   session_controls {
     application_enforced_restrictions_enabled = true
+    disable_resilience_defaults               = false
     sign_in_frequency                         = 10
     sign_in_frequency_period                  = "hours"
     cloud_app_security_policy                 = "monitorOnly"
@@ -157,6 +158,7 @@ The following arguments are supported:
 -> Only Office 365, Exchange Online and Sharepoint Online support application enforced restrictions.
 
 * `cloud_app_security_policy` - (Optional) Enables cloud app security and specifies the cloud app security policy to use. Possible values are: `blockDownloads`, `mcasConfigured`, `monitorOnly` or `unknownFutureValue`.
+* `disable_resilience_defaults` - (Optional) Disables [resilience defaults](https://learn.microsoft.com/en-us/azure/active-directory/conditional-access/resilience-defaults). Defaults to `false`.
 * `persistent_browser_mode` - (Optional) Session control to define whether to persist cookies or not. Possible values are: `always` or `never`.
 * `sign_in_frequency` - (Optional) Number of days or hours to enforce sign-in frequency. Required when `sign_in_frequency_period` is specified. Due to an API issue, removing this property forces a new resource to be created.
 * `sign_in_frequency_period` - (Optional) The time period to enforce sign-in frequency. Possible values are: `hours` or `days`. Required when `sign_in_frequency_period` is specified. Due to an API issue, removing this property forces a new resource to be created.

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -405,6 +405,11 @@ func conditionalAccessPolicyResource() *schema.Resource {
 							}, false),
 						},
 
+						"disable_resilience_defaults": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
 						"persistent_browser_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -466,6 +471,9 @@ func conditionalAccessPolicyDiffSuppress(k, old, new string, d *schema.ResourceD
 				suppress = false
 			}
 			if v, ok := sessionControls["cloud_app_security_policy"]; ok && v.(string) != "" {
+				suppress = false
+			}
+			if v, ok := sessionControls["disable_resilience_defaults"]; ok && v.(bool) {
 				suppress = false
 			}
 			if v, ok := sessionControls["persistent_browser_mode"]; ok && v.(string) != "" {

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -510,6 +510,7 @@ resource "azuread_conditional_access_policy" "test" {
 
   session_controls {
     application_enforced_restrictions_enabled = true
+    disable_resilience_defaults               = true
     cloud_app_security_policy                 = "monitorOnly"
     persistent_browser_mode                   = "never"
     sign_in_frequency                         = 10
@@ -553,6 +554,7 @@ resource "azuread_conditional_access_policy" "test" {
 
   session_controls {
     application_enforced_restrictions_enabled = true
+    disable_resilience_defaults               = false
     cloud_app_security_policy                 = "blockDownloads"
     persistent_browser_mode                   = "always"
     sign_in_frequency                         = 2

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -127,6 +127,11 @@ func flattenConditionalAccessSessionControls(in *msgraph.ConditionalAccessSessio
 		cloudAppSecurity = *in.CloudAppSecurity.CloudAppSecurityType
 	}
 
+	disableResilienceDefaults := false
+	if in.DisableResilienceDefaults != nil {
+		disableResilienceDefaults = *in.DisableResilienceDefaults
+	}
+
 	signInFrequency := 0
 	signInFrequencyPeriod := ""
 	if in.SignInFrequency != nil && in.SignInFrequency.Value != nil && in.SignInFrequency.Type != nil {
@@ -143,6 +148,7 @@ func flattenConditionalAccessSessionControls(in *msgraph.ConditionalAccessSessio
 		map[string]interface{}{
 			"application_enforced_restrictions_enabled": applicationEnforceRestrictions,
 			"cloud_app_security_policy":                 cloudAppSecurity,
+			"disable_resilience_defaults":               disableResilienceDefaults,
 			"persistent_browser_mode":                   persistentBrowserMode,
 			"sign_in_frequency":                         signInFrequency,
 			"sign_in_frequency_period":                  signInFrequencyPeriod,
@@ -381,6 +387,9 @@ func expandConditionalAccessSessionControls(in []interface{}) *msgraph.Condition
 			CloudAppSecurityType: utils.String(cloudAppSecurity),
 		}
 	}
+
+	DisableResilienceDefaults := config["disable_resilience_defaults"]
+	result.DisableResilienceDefaults = utils.Bool(DisableResilienceDefaults.(bool))
 
 	if persistentBrowserMode := config["persistent_browser_mode"].(string); persistentBrowserMode != "" {
 		result.PersistentBrowser = &msgraph.PersistentBrowserSessionControl{


### PR DESCRIPTION
Adds the `disable_session_resilience` property in the `azuread_conditional_access_policy` resource.

Fixes #931

- Updated docs
- Updated tests