### PR TITLE
`azuread_conditional_access_policy` set `built_in_controls` to optional

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -227,10 +227,12 @@ The following arguments are supported:
 
 `grant_controls` block supports the following:
 
-* `built_in_controls` - (Required) List of built-in controls required by the policy. Possible values are: `block`, `mfa`, `approvedApplication`, `compliantApplication`, `compliantDevice`, `domainJoinedDevice`, `passwordChange` or `unknownFutureValue`.
+* `built_in_controls` - (Optional) List of built-in controls required by the policy. Possible values are: `block`, `mfa`, `approvedApplication`, `compliantApplication`, `compliantDevice`, `domainJoinedDevice`, `passwordChange` or `unknownFutureValue`.
 * `custom_authentication_factors` - (Optional) List of custom controls IDs required by the policy.
 * `operator` - (Required) Defines the relationship of the grant controls. Possible values are: `AND`, `OR`.
 * `terms_of_use` - (Optional) List of terms of use IDs required by the policy.
+
+-> At least one of `built_in_controls` or `terms_of_use` must be specified.
 
 ---
 

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -387,8 +387,9 @@ func conditionalAccessPolicyResource() *schema.Resource {
 						},
 
 						"built_in_controls": {
-							Type:     schema.TypeList,
-							Required: true,
+							Type:         schema.TypeList,
+							Optional:     true,
+							AtLeastOneOf: []string{"grant_controls.0.built_in_controls", "grant_controls.0.terms_of_use"},
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{
@@ -414,8 +415,9 @@ func conditionalAccessPolicyResource() *schema.Resource {
 						},
 
 						"terms_of_use": {
-							Type:     schema.TypeList,
-							Optional: true,
+							Type:         schema.TypeList,
+							Optional:     true,
+							AtLeastOneOf: []string{"grant_controls.0.built_in_controls", "grant_controls.0.terms_of_use"},
 							Elem: &schema.Schema{
 								Type:             schema.TypeString,
 								ValidateDiagFunc: validate.NoEmptyStrings,


### PR DESCRIPTION
During some recent work I noticed you could not create a CA policy in terraform that only has a terms of use set and no other controls.

This is possible through the portal, the below policy is valid and with this modification applies successfully.

```hcl
resource "azuread_conditional_access_policy" "tou" {
  display_name = "Require All Users agree to terms"
  state        = "disabled"

  conditions {
    client_app_types = ["all"]

    applications {
      included_applications = ["All"]
    }

    users {
      included_users = ["All"]
    }

    locations {
      included_locations = ["All"]
    }
  }

  grant_controls {
    operator                      = "OR"
    terms_of_use                  = ["<<TOU-GUID>>"]
  }
}
```

Creating a policy with neither field is not possible (at least not until authentication strengths are supported) so I have set it to at least one of `built_in_controls` or `terms_of_use`