### PR TITLE
data.azuread_group: allow lookup by mail_nickname

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -28,11 +28,12 @@ data "azuread_group" "example" {
 The following arguments are supported:
 
 * `display_name` - (Optional) The display name for the group.
+* `mail_nickname` - (Optional) The mail alias for the group, unique in the organisation.
 * `mail_enabled` - (Optional) Whether the group is mail-enabled.
 * `object_id` - (Optional) Specifies the object ID of the group.
 * `security_enabled` - (Optional) Whether the group is a security group.
 
-~> One of `display_name` or `object_id` must be specified.
+~> One of `display_name`, `object_id` or `mail_nickname` must be specified.
 
 ## Attributes Reference
 

--- a/internal/services/groups/group_data_source_test.go
+++ b/internal/services/groups/group_data_source_test.go
@@ -254,7 +254,7 @@ func (GroupDataSource) mailNickname(data acceptance.TestData) string {
 %[1]s
 
 data "azuread_group" "test" {
-	mail_nickname = azuread_group.test.mail_nickname
+  mail_nickname = azuread_group.test.mail_nickname
 }
 `, GroupResource{}.basic(data))
 }
@@ -264,8 +264,8 @@ func (GroupDataSource) mailNicknameSecurity(data acceptance.TestData) string {
 %[1]s
 
 data "azuread_group" "test" {
-	mail_nickname    = azuread_group.test.mail_nickname
-	security_enabled = true
+  mail_nickname    = azuread_group.test.mail_nickname
+  security_enabled = true
 }
 `, GroupResource{}.basic(data))
 }
@@ -276,9 +276,9 @@ func (GroupDataSource) mailNicknameSecurityNotMail(data acceptance.TestData) str
 %[2]s
 
 data "azuread_group" "test" {
-	mail_nickname    = azuread_group.test.mail_nickname
-	mail_enabled     = false
-	security_enabled = true
+  mail_nickname    = azuread_group.test.mail_nickname
+  mail_enabled     = false
+  security_enabled = true
 }
 `, GroupResource{}.basic(data), GroupResource{}.basicUnified(data))
 }

--- a/internal/services/groups/group_data_source_test.go
+++ b/internal/services/groups/group_data_source_test.go
@@ -65,6 +65,45 @@ func TestAccGroupDataSource_byCaseInsensitiveDisplayName(t *testing.T) {
 	})
 }
 
+func TestAccGroupDataSource_byMailNickname(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.mailNickname(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
+
+func TestAccGroupDataSource_byMailNicknameWithSecurity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.mailNicknameSecurity(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
+
+func TestAccGroupDataSource_byMailNicknameWithSecurityNotMail(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: GroupDataSource{}.mailNicknameSecurityNotMail(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+	})
+}
+
 func TestAccGroupDataSource_byObjectId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azuread_group", "test")
 
@@ -208,6 +247,40 @@ data "azuread_group" "test" {
   display_name = upper(azuread_group.test.display_name)
 }
 `, GroupResource{}.basic(data))
+}
+
+func (GroupDataSource) mailNickname(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_group" "test" {
+	mail_nickname = azuread_group.test.mail_nickname
+}
+`, GroupResource{}.basic(data))
+}
+
+func (GroupDataSource) mailNicknameSecurity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_group" "test" {
+	mail_nickname    = azuread_group.test.mail_nickname
+	security_enabled = true
+}
+`, GroupResource{}.basic(data))
+}
+
+func (GroupDataSource) mailNicknameSecurityNotMail(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+data "azuread_group" "test" {
+	mail_nickname    = azuread_group.test.mail_nickname
+	mail_enabled     = false
+	security_enabled = true
+}
+`, GroupResource{}.basic(data), GroupResource{}.basicUnified(data))
 }
 
 func (GroupDataSource) objectId(data acceptance.TestData) string {


### PR DESCRIPTION
Adding the option to look up `data.azuread_group` items by `mail_nickname` field.

The need for this arose as we ran into the issue with display name not necessarily being unique in a larger AAD instance, thus making it impossible to pick the data for such a group from AAD without resorting to the object id. This isn't really possible in our case, as obtaining the object UUID from the group name is the reason we're using this data source in the first place 🙈 .

I've also added tests based on the ones already present for the `displayName` option but was not able to run the acceptance tests due to missing a proper Azure subscription satisfying the requirements to run those.