### PR TITLE
Fix group member resource to survive refresh when group is missing

### DIFF
--- a/internal/services/groups/group_member_resource.go
+++ b/internal/services/groups/group_member_resource.go
@@ -126,8 +126,13 @@ func groupMemberResourceRead(ctx context.Context, d *schema.ResourceData, meta i
 		return tf.ErrorDiagPathF(err, "id", "Parsing Group Member ID %q", d.Id())
 	}
 
-	members, _, err := client.ListMembers(ctx, id.GroupId)
+	members, status, err := client.ListMembers(ctx, id.GroupId)
 	if err != nil {
+		if status == http.StatusNotFound {
+			log.Printf("[DEBUG] Group with ID %q was not found - removing group member with ID %q from state", id.GroupId, d.Id())
+			d.SetId("")
+			return nil
+		}
 		return tf.ErrorDiagF(err, "Retrieving members for group with object ID: %q", id.GroupId)
 	}
 


### PR DESCRIPTION
This PR proposes a fix for issue #1172 regarding `azuread_group_member` resource failing to refresh  when the referenced group is missing.

It handles the case where `client.ListMembers()` returns a 404 error (missing group) by removing the group member from the state.

I could validate with [this simple bug reproducer](https://github.com/LoicBer/azuread-groupmember-bug) that this change solves the issue.

Here the output I get when running `terraform plan` when the group ID referenced by the group member has changed:
https://gist.github.com/LoicBer/53a8b974067d0ca0cfacb50f9a9ee911

Terraform wants to remove the member from the state and recreate the member with the new group ID, which is the expected behavior.