### PR TITLE
Applications: DiffSuppressFunc for `application_object_id`

### DIFF
--- a/internal/services/applications/application_federated_identity_credential_resource.go
+++ b/internal/services/applications/application_federated_identity_credential_resource.go
@@ -62,6 +62,20 @@ func applicationFederatedIdentityCredentialResource() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"application_id", "application_object_id"},
 				Deprecated:   "The `application_object_id` property has been replaced with the `application_id` property and will be removed in version 3.0 of the AzureAD provider",
 				ValidateFunc: validation.Any(validation.IsUUID, parse.ValidateApplicationID),
+				DiffSuppressFunc: func(_, oldValue, newValue string, _ *pluginsdk.ResourceData) bool {
+					// Where oldValue is a UUID (i.e. the bare object ID), and newValue is a properly formed application
+					// resource ID, we'll ignore a diff where these point to the same application resource.
+					// This maintains compatibility with configurations mixing the ID attributes, e.g.
+					//     application_object_id = azuread_application.example.id
+					if _, err := uuid.ParseUUID(oldValue); err == nil {
+						if applicationId, err := parse.ParseApplicationID(newValue); err == nil {
+							if applicationId.ApplicationId == oldValue {
+								return true
+							}
+						}
+					}
+					return false
+				},
 			},
 
 			"audiences": {

--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -66,6 +66,20 @@ func applicationPasswordResource() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"application_id", "application_object_id"},
 				Deprecated:   "The `application_object_id` property has been replaced with the `application_id` property and will be removed in version 3.0 of the AzureAD provider",
 				ValidateFunc: validation.Any(validation.IsUUID, parse.ValidateApplicationID),
+				DiffSuppressFunc: func(_, oldValue, newValue string, _ *pluginsdk.ResourceData) bool {
+					// Where oldValue is a UUID (i.e. the bare object ID), and newValue is a properly formed application
+					// resource ID, we'll ignore a diff where these point to the same application resource.
+					// This maintains compatibility with configurations mixing the ID attributes, e.g.
+					//     application_object_id = azuread_application.example.id
+					if _, err := uuid.ParseUUID(oldValue); err == nil {
+						if applicationId, err := parse.ParseApplicationID(newValue); err == nil {
+							if applicationId.ApplicationId == oldValue {
+								return true
+							}
+						}
+					}
+					return false
+				},
 			},
 
 			"display_name": {

--- a/internal/services/applications/application_pre_authorized_resource.go
+++ b/internal/services/applications/application_pre_authorized_resource.go
@@ -62,6 +62,20 @@ func applicationPreAuthorizedResource() *pluginsdk.Resource {
 				ExactlyOneOf: []string{"application_id", "application_object_id"},
 				Deprecated:   "The `application_object_id` property has been replaced with the `application_id` property and will be removed in version 3.0 of the AzureAD provider",
 				ValidateFunc: validation.Any(validation.IsUUID, parse.ValidateApplicationID),
+				DiffSuppressFunc: func(_, oldValue, newValue string, _ *pluginsdk.ResourceData) bool {
+					// Where oldValue is a UUID (i.e. the bare object ID), and newValue is a properly formed application
+					// resource ID, we'll ignore a diff where these point to the same application resource.
+					// This maintains compatibility with configurations mixing the ID attributes, e.g.
+					//     application_object_id = azuread_application.example.id
+					if _, err := uuid.ParseUUID(oldValue); err == nil {
+						if applicationId, err := parse.ParseApplicationID(newValue); err == nil {
+							if applicationId.ApplicationId == oldValue {
+								return true
+							}
+						}
+					}
+					return false
+				},
 			},
 
 			"authorized_app_id": {


### PR DESCRIPTION
This works around some existing configurations where a diff may arise as a result of the recent state migration to update the resource ID for `azuread_application` to use a typed ID.

Where an existing configuration mistakenly references the `id` attribute for an `azuread_application` resource, expecting it to contain a bare object ID, this avoids a subsequent diff where the existing bare UUID and the prospective ID point to the same application.

Fixes: #1218