### PR TITLE
fix: azuread_application resource import example

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -343,5 +343,5 @@ In addition to all arguments above, the following attributes are exported:
 Applications can be imported using their object ID, e.g.
 
 ```shell
-terraform import azuread_application.example 00000000-0000-0000-0000-000000000000
+terraform import azuread_application.example /applications/00000000-0000-0000-0000-000000000000
 ```


### PR DESCRIPTION
Fixes: #1230 

Currently documentation states that the resource should be imported using pattern:
```
terraform import azuread_application.example 00000000-0000-0000-0000-000000000000
```

It should be instead:
```
terraform import azuread_application.example /applications/00000000-0000-0000-0000-000000000000
```