### PR TITLE
feat: allow data.azuread_application lookup using identifier_uri

### DIFF
--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `client_id` - (Optional) Specifies the Client ID of the application.
 * `display_name` - (Optional) Specifies the display name of the application.
 * `object_id` - (Optional) Specifies the Object ID of the application.
-* `identifier_uri` - (Optional) Specifies a identifying URI of the application. This should only be used for lookups, `identifier_uris` should be used to read identifier URIs.
+* `identifier_uri` - (Optional) Specifies any identifier URI of the application. See also the `identifier_uris` attribute which contains a list of all identifier URIs for the application.
 
 ~> One of `client_id`, `display_name`, `object_id`, or `identifier_uri` must be specified.
 

--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -33,8 +33,9 @@ The following arguments are supported:
 * `client_id` - (Optional) Specifies the Client ID of the application.
 * `display_name` - (Optional) Specifies the display name of the application.
 * `object_id` - (Optional) Specifies the Object ID of the application.
+* `identifier_uris` - (Optional) Specifies a list containing one identifying URI of the application.
 
-~> One of `client_id`, `display_name`, or `object_id` must be specified.
+~> One of `client_id`, `display_name`, `object_id`, or `identifier_uris` must be specified.
 
 ## Attributes Reference
 

--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -33,9 +33,9 @@ The following arguments are supported:
 * `client_id` - (Optional) Specifies the Client ID of the application.
 * `display_name` - (Optional) Specifies the display name of the application.
 * `object_id` - (Optional) Specifies the Object ID of the application.
-* `identifier_uris` - (Optional) Specifies a list containing one identifying URI of the application.
+* `identifier_uri` - (Optional) Specifies a identifying URI of the application. This should only be used for lookups, `identifier_uris` should be used to read identifier URIs.
 
-~> One of `client_id`, `display_name`, `object_id`, or `identifier_uris` must be specified.
+~> One of `client_id`, `display_name`, `object_id`, or `identifier_uri` must be specified.
 
 ## Attributes Reference
 

--- a/internal/services/applications/application_data_source_test.go
+++ b/internal/services/applications/application_data_source_test.go
@@ -61,6 +61,18 @@ func TestAccApplicationDataSource_byDisplayName(t *testing.T) {
 	})
 }
 
+func TestAccApplicationDataSource_byIdentifierUris(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_application", "test")
+	r := ApplicationDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.identifierUris(data),
+			Check:  r.testCheck(data),
+		},
+	})
+}
+
 func (ApplicationDataSource) testCheck(data acceptance.TestData) acceptance.TestCheckFunc {
 	return acceptance.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("application_id").IsUuid(),
@@ -127,6 +139,16 @@ func (ApplicationDataSource) displayName(data acceptance.TestData) string {
 
 data "azuread_application" "test" {
   display_name = upper(azuread_application.test.display_name)
+}
+`, ApplicationResource{}.complete(data))
+}
+
+func (ApplicationDataSource) identifierUris(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_application" "test" {
+  identifier_uris = [tolist(azuread_application.test.identifier_uris)[0]]
 }
 `, ApplicationResource{}.complete(data))
 }

--- a/internal/services/applications/application_data_source_test.go
+++ b/internal/services/applications/application_data_source_test.go
@@ -61,13 +61,13 @@ func TestAccApplicationDataSource_byDisplayName(t *testing.T) {
 	})
 }
 
-func TestAccApplicationDataSource_byIdentifierUris(t *testing.T) {
+func TestAccApplicationDataSource_byIdentifierUri(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azuread_application", "test")
 	r := ApplicationDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.identifierUris(data),
+			Config: r.identifierUri(data),
 			Check:  r.testCheck(data),
 		},
 	})
@@ -143,12 +143,12 @@ data "azuread_application" "test" {
 `, ApplicationResource{}.complete(data))
 }
 
-func (ApplicationDataSource) identifierUris(data acceptance.TestData) string {
+func (ApplicationDataSource) identifierUri(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "azuread_application" "test" {
-  identifier_uris = [tolist(azuread_application.test.identifier_uris)[0]]
+  identifier_uri = tolist(azuread_application.test.identifier_uris)[0]
 }
 `, ApplicationResource{}.complete(data))
 }


### PR DESCRIPTION
This PR introduces a small feature to the `azuread_application` data source that allows us to get the application based on an identifying URI. This is a feature we would really like to use. It looks like this:

```terraform
data "azuread_application" "example" {
  identifier_uris  = [
    "api://example-app",
  ]
}
```

I've implemented it in a way where you can provide a list of one element to the `identifier_uris` field, instead of introducing another field called `identifier_uri` that is just a string, as I thought it might be easy to mix up the two fields, but would love some input on this. I added an error if more than one element is provided in `identifier_uris`.