### PR TITLE
Adjust documentation for group_membership_claims accepted values

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -176,7 +176,7 @@ The following arguments are supported:
 
 -> **Features and Tags** Features are configured for an application using tags, and are provided as a shortcut to set the corresponding magic tag value for each feature. You cannot configure `feature_tags` and `tags` for an application at the same time, so if you need to assign additional custom tags it's recommended to use the `tags` property instead. Tag values also propagate to any linked service principals.
 
-* `group_membership_claims` - (Optional) Configures the `groups` claim issued in a user or OAuth 2.0 access token that the app expects. Possible values are `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup` or `All`.
+* `group_membership_claims` - (Optional) A set of membership claims issued in a user or OAuth 2.0 access token that the app expects. Possible values are `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup` or `All`.
 * `identifier_uris` - (Optional) A set of user-defined URI(s) that uniquely identify an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant.
 * `logo_image` - (Optional) A logo image to upload for the application, as a raw base64-encoded string. The image should be in gif, jpeg or png format. Note that once an image has been uploaded, it is not possible to remove it without replacing it with another image.
 * `marketing_url` - (Optional) URL of the application's marketing page.

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -176,7 +176,7 @@ The following arguments are supported:
 
 -> **Features and Tags** Features are configured for an application using tags, and are provided as a shortcut to set the corresponding magic tag value for each feature. You cannot configure `feature_tags` and `tags` for an application at the same time, so if you need to assign additional custom tags it's recommended to use the `tags` property instead. Tag values also propagate to any linked service principals.
 
-* `group_membership_claims` - (Optional) A set of membership claims issued in a user or OAuth 2.0 access token that the app expects. Possible values are `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup` or `All`.
+* `group_membership_claims` - (Optional) A set of strings containing membership claims issued in a user or OAuth 2.0 access token that the app expects. Possible values are `None`, `SecurityGroup`, `DirectoryRole`, `ApplicationGroup` or `All`.
 * `identifier_uris` - (Optional) A set of user-defined URI(s) that uniquely identify an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant.
 * `logo_image` - (Optional) A logo image to upload for the application, as a raw base64-encoded string. The image should be in gif, jpeg or png format. Note that once an image has been uploaded, it is not possible to remove it without replacing it with another image.
 * `marketing_url` - (Optional) URL of the application's marketing page.


### PR DESCRIPTION
Since version 2.0.0 the `group_membership_claims` are expected to be a set of strings (see https://github.com/hashicorp/terraform-provider-azuread/blob/79f6519777b7676825d2713c26d77e6a6d25d494/CHANGELOG.md?plain=1#L767).

If a string instead of a set of strings is provided, the following error occurs:

```
│ Error: Incorrect attribute value type
│ 
│   on ../../modules/core-infra/aad-app.tf line 79, in resource "azuread_application" "aad-app":
│   79:   group_membership_claims = "SecurityGroup"
│ 
│ Inappropriate value for attribute "group_membership_claims": set of string
│ required.
```

Not sure if any combination of possible values works. Your feedback would be appreciated.