### PR TITLE
update azuread_group to allow SkipExchangeInstantOn in behaviors

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -119,7 +119,7 @@ The following arguments are supported:
 
 ~> **Known Permissions Issue** The `auto_subscribe_new_members` property can only be set when authenticating as a Member user of the tenant and _not_ when authenticating as a Guest user or as a service principal. Please see the [Microsoft Graph Known Issues](https://docs.microsoft.com/en-us/graph/known-issues#groups) documentation.
 
-* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
+* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `CalendarMemberReadOnly`, `ConnectorsDisabled`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
 * `description` - (Optional) The description for the group.
 * `display_name` - (Required) The display name for the group.
 * `dynamic_membership` - (Optional) A `dynamic_membership` block as documented below. Required when `types` contains `DynamicMembership`. Cannot be used with the `members` property.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -119,7 +119,7 @@ The following arguments are supported:
 
 ~> **Known Permissions Issue** The `auto_subscribe_new_members` property can only be set when authenticating as a Member user of the tenant and _not_ when authenticating as a Guest user or as a service principal. Please see the [Microsoft Graph Known Issues](https://docs.microsoft.com/en-us/graph/known-issues#groups) documentation.
 
-* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `HideGroupInOutlook`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
+* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
 * `description` - (Optional) The description for the group.
 * `display_name` - (Required) The display name for the group.
 * `dynamic_membership` - (Optional) A `dynamic_membership` block as documented below. Required when `types` contains `DynamicMembership`. Cannot be used with the `members` property.

--- a/examples/application/main.tf
+++ b/examples/application/main.tf
@@ -45,7 +45,7 @@ resource "azuread_application" "widgets_app" {
 
     resource_access {
       # User.Read
-      id = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
       type = "Scope"
     }
   }
@@ -53,7 +53,7 @@ resource "azuread_application" "widgets_app" {
   required_resource_access {
     resource_app_id = azuread_application.widgets_service.application_id
 
-    dynamic resource_access {
+    dynamic "resource_access" {
       for_each = azuread_application.widgets_service.api.0.oauth2_permission_scope
       iterator = scope
 

--- a/examples/create-for-rbac/outputs.tf
+++ b/examples/create-for-rbac/outputs.tf
@@ -14,7 +14,7 @@ output "client_certificate" {
 }
 
 output "client_key" {
-  value = tls_private_key.example.private_key_pem
+  value     = tls_private_key.example.private_key_pem
   sensitive = true
 }
 

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -96,6 +96,7 @@ func groupResource() *pluginsdk.Resource {
 						msgraph.GroupResourceBehaviorOptionCalendarMemberReadOnly,
 						msgraph.GroupResourceBehaviorOptionConnectorsDisabled,
 						msgraph.GroupResourceBehaviorOptionHideGroupInOutlook,
+						msgraph.GroupResourceBehaviorOptionSkipExchangeInstantOn,
 						msgraph.GroupResourceBehaviorOptionSubscribeMembersToCalendarEventsDisabled,
 						msgraph.GroupResourceBehaviorOptionSubscribeNewGroupMembers,
 						msgraph.GroupResourceBehaviorOptionWelcomeEmailDisabled,

--- a/vendor/github.com/manicminer/hamilton/msgraph/valuetypes.go
+++ b/vendor/github.com/manicminer/hamilton/msgraph/valuetypes.go
@@ -604,6 +604,7 @@ const (
 	GroupResourceBehaviorOptionCalendarMemberReadOnly                   GroupResourceBehaviorOption = "CalendarMemberReadOnly"
 	GroupResourceBehaviorOptionConnectorsDisabled                       GroupResourceBehaviorOption = "ConnectorsDisabled"
 	GroupResourceBehaviorOptionHideGroupInOutlook                       GroupResourceBehaviorOption = "HideGroupInOutlook"
+	GroupResourceBehaviorOptionSkipExchangeInstantOn                    GroupResourceBehaviorOption = "SkipExchangeInstantOn"
 	GroupResourceBehaviorOptionSubscribeMembersToCalendarEventsDisabled GroupResourceBehaviorOption = "SubscribeMembersToCalendarEventsDisabled"
 	GroupResourceBehaviorOptionSubscribeNewGroupMembers                 GroupResourceBehaviorOption = "SubscribeNewGroupMembers"
 	GroupResourceBehaviorOptionWelcomeEmailDisabled                     GroupResourceBehaviorOption = "WelcomeEmailDisabled"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azuread/issues/1315

Adds ability to set `SkipExchangeInstantOn` on `behaviors` parameter for resource `azuread_group`.

Updates documentation to include all allowed settings to the `behaviors` parameter.

A few formatting issues fixed by `terraform fmt`.
