### PR TITLE
New resource `azuread_privileged_access_group_eligibility_schedule_request`

### DIFF
--- a/docs/resources/privileged_access_group_eligibility_schedule_request.md
+++ b/docs/resources/privileged_access_group_eligibility_schedule_request.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Identity Governance"
+---
+
+# Resource: azuread_privileged_access_group_eligibility_schedule_request
+
+Manages an eligible assignment to a privileged access group.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the `PrivilegedEligibilitySchedule.ReadWrite.AzureADGroup` Microsoft Graph API permissions.
+
+When authenticated with a user principal, this resource requires `Global Administrator` directory role, or the `Privileged Role Administrator` role in Identity Governance.
+
+## Example Usage
+
+```terraform
+resource "azuread_group" "example" {
+  display_name     = "group-name"
+  security_enabled = true
+}
+
+resource "azuread_user" "member" {
+  user_principal_name = "jdoe@hashicorp.com"
+  display_name        = "J. Doe"
+  mail_nickname       = "jdoe"
+  password            = "SecretP@sswd99!"
+}
+
+resource "azuread_privileged_access_group_eligibility_schedule_request" "example" {
+  group_id        = azuread_group.pim.id
+  principal_id    = azuread_user.member.id
+  assignment_type = "member"
+  duration        = "P30D"
+  justification   = "as requested"
+}
+```
+
+## Argument Reference
+
+- `group_id` (Required) The Object ID of the Azure AD group to which the principal will be assigned.
+- `principal_id` (Required) The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
+- `assignment_type` (Required) The type of assignment to the group. Can be either `member` or `owner`.
+- `justification` (Optional) The justification for this assignment. May be required by the role policy.
+- `ticket_number` (Optional) The ticket number in the ticket system approving this assignment. May be required by the role policy.
+- `ticket_system` (Optional) The ticket system containing the ticket number approving this assignment. May be required by the role policy.
+- `start_date` (Optional) The date from which this assignment is valid, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z). If not provided, the assignment is immediately valid.
+- `expiration_date` (Optional) The date that this assignment expires, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z).
+- `duration` (Optional) The duration that this assignment is valid for, formatted as an ISO8601 duration (e.g. P30D for 30 days, PT3H for three hours).
+- `permanent_assignment` (Optional) Is this assigment permanently valid.
+
+At least one of `expiration_date`, `duration`, or `permanent_assignment` must be supplied. The role policy may limit the maximum duration which can be supplied.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` (String) The ID of this request.
+- `status` (String) The provisioning status of this request.
+- `target_schedule_id` (String) The ID of this schedule created by this request.
+
+## Import
+
+An assignment schedule can be imported using the ID, e.g.
+
+```shell
+terraform import azuread_privileged_access_group_eligibility_schedule_request.example 00000000-0000-0000-0000-000000000000
+```

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -29,6 +29,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		applications.Registration{},
 		directoryroles.Registration{},
 		domains.Registration{},
+		identitygovernance.Registration{},
 		serviceprincipals.Registration{},
 	}
 }

--- a/internal/services/identitygovernance/client/client.go
+++ b/internal/services/identitygovernance/client/client.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Client struct {
-	AccessPackageAssignmentPolicyClient       *msgraph.AccessPackageAssignmentPolicyClient
-	AccessPackageCatalogClient                *msgraph.AccessPackageCatalogClient
-	AccessPackageCatalogRoleAssignmentsClient *msgraph.EntitlementRoleAssignmentsClient
-	AccessPackageCatalogRoleClient            *msgraph.EntitlementRoleDefinitionsClient
-	AccessPackageClient                       *msgraph.AccessPackageClient
-	AccessPackageResourceClient               *msgraph.AccessPackageResourceClient
-	AccessPackageResourceRequestClient        *msgraph.AccessPackageResourceRequestClient
-	AccessPackageResourceRoleScopeClient      *msgraph.AccessPackageResourceRoleScopeClient
+	AccessPackageAssignmentPolicyClient                   *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageCatalogClient                            *msgraph.AccessPackageCatalogClient
+	AccessPackageCatalogRoleAssignmentsClient             *msgraph.EntitlementRoleAssignmentsClient
+	AccessPackageCatalogRoleClient                        *msgraph.EntitlementRoleDefinitionsClient
+	AccessPackageClient                                   *msgraph.AccessPackageClient
+	AccessPackageResourceClient                           *msgraph.AccessPackageResourceClient
+	AccessPackageResourceRequestClient                    *msgraph.AccessPackageResourceRequestClient
+	AccessPackageResourceRoleScopeClient                  *msgraph.AccessPackageResourceRoleScopeClient
+	PrivilegedAccessGroupEligibilityScheduleRequestClient *msgraph.PrivilegedAccessGroupEligibilityScheduleRequestClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -54,14 +55,18 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&accessPackageResourceRoleScopeClient.BaseClient)
 	accessPackageResourceRoleScopeClient.BaseClient.ApiVersion = msgraph.VersionBeta
 
+	privilegedAccessGroupEligibilityScheduleRequestsClient := msgraph.NewPrivilegedAccessGroupEligibilityScheduleRequestClient()
+	o.ConfigureClient(&privilegedAccessGroupEligibilityScheduleRequestsClient.BaseClient)
+
 	return &Client{
-		AccessPackageAssignmentPolicyClient:       accessPackageAssignmentPolicyClient,
-		AccessPackageCatalogClient:                accessPackageCatalogClient,
-		AccessPackageCatalogRoleAssignmentsClient: accessPackageCatalogRoleAssignmentsClient,
-		AccessPackageCatalogRoleClient:            accessPackageCatalogRoleClient,
-		AccessPackageClient:                       accessPackageClient,
-		AccessPackageResourceClient:               accessPackageResourceClient,
-		AccessPackageResourceRequestClient:        accessPackageResourceRequestClient,
-		AccessPackageResourceRoleScopeClient:      accessPackageResourceRoleScopeClient,
+		AccessPackageAssignmentPolicyClient:                   accessPackageAssignmentPolicyClient,
+		AccessPackageCatalogClient:                            accessPackageCatalogClient,
+		AccessPackageCatalogRoleAssignmentsClient:             accessPackageCatalogRoleAssignmentsClient,
+		AccessPackageCatalogRoleClient:                        accessPackageCatalogRoleClient,
+		AccessPackageClient:                                   accessPackageClient,
+		AccessPackageResourceClient:                           accessPackageResourceClient,
+		AccessPackageResourceRequestClient:                    accessPackageResourceRequestClient,
+		AccessPackageResourceRoleScopeClient:                  accessPackageResourceRoleScopeClient,
+		PrivilegedAccessGroupEligibilityScheduleRequestClient: privilegedAccessGroupEligibilityScheduleRequestsClient,
 	}
 }

--- a/internal/services/identitygovernance/parse/privileged_access_group_eligibility_schedule_request.go
+++ b/internal/services/identitygovernance/parse/privileged_access_group_eligibility_schedule_request.go
@@ -1,0 +1,35 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/validation"
+)
+
+type PrivilegedAccessGroupEligibilityScheduleRequestId struct {
+	RequestId string
+}
+
+func NewPrivilegedAccessGroupEligibilityScheduleRequestID(requestId string) *PrivilegedAccessGroupEligibilityScheduleRequestId {
+	return &PrivilegedAccessGroupEligibilityScheduleRequestId{
+		RequestId: requestId,
+	}
+}
+
+func ParsePrivilegedAccessGroupEligibilityScheduleRequestID(idString string) (*PrivilegedAccessGroupEligibilityScheduleRequestId, error) {
+	if _, err := validation.IsUUID(idString, "RequestId"); len(err) > 0 {
+		return nil, fmt.Errorf("parsing RequestId: %+v", err)
+	}
+
+	return &PrivilegedAccessGroupEligibilityScheduleRequestId{
+		RequestId: idString,
+	}, nil
+}
+
+func (id *PrivilegedAccessGroupEligibilityScheduleRequestId) ID() string {
+	return id.RequestId
+}
+
+func (id *PrivilegedAccessGroupEligibilityScheduleRequestId) String() string {
+	return fmt.Sprintf("Privileged Access Group Assigment Schedule Request ID: %q", id.RequestId)
+}

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_request.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_request.go
@@ -1,0 +1,377 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identitygovernance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/parse"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/validation"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type PrivilegedAccessGroupEligibilityScheduleRequestModel struct {
+	AssignmentType      string `tfschema:"assignment_type"`
+	Duration            string `tfschema:"duration"`
+	ExpirationDate      string `tfschema:"expiration_date"`
+	GroupId             string `tfschema:"group_id"`
+	Justification       string `tfschema:"justification"`
+	PermanentAssignment bool   `tfschema:"permanent_assignment"`
+	PrincipalId         string `tfschema:"principal_id"`
+	StartDate           string `tfschema:"start_date"`
+	Status              string `tfschema:"status"`
+	TargetScheduleId    string `tfschema:"target_schedule_id"`
+	TicketNumber        string `tfschema:"ticket_number"`
+	TicketSystem        string `tfschema:"ticket_system"`
+}
+
+type PrivilegedAccessGroupEligibilityScheduleRequestResource struct{}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validation.IsUUID
+}
+
+var _ sdk.Resource = PrivilegedAccessGroupEligibilityScheduleRequestResource{}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) ResourceType() string {
+	return "azuread_privileged_access_group_eligibility_schedule_request"
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) ModelObject() interface{} {
+	return &PrivilegedAccessGroupEligibilityScheduleRequestModel{}
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"group_id": {
+			Description:      "The ID of the Group representing the scope of the assignment",
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			ValidateDiagFunc: validation.ValidateDiag(validation.IsUUID),
+		},
+
+		"principal_id": {
+			Description:      "The ID of the Principal assigned to the schedule",
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ForceNew:         true,
+			ValidateDiagFunc: validation.ValidateDiag(validation.IsUUID),
+		},
+
+		"assignment_type": {
+			Description: "The ID of the assignment to the group",
+			Type:        pluginsdk.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			ValidateFunc: validation.StringInSlice([]string{
+				msgraph.PrivilegedAccessGroupRelationshipMember,
+				msgraph.PrivilegedAccessGroupRelationshipOwner,
+				msgraph.PrivilegedAccessGroupRelationshipUnknown,
+			}, false),
+		},
+
+		"start_date": {
+			Description:  "The date that this assignment starts, formatted as an RFC3339 date string in UTC (e.g. 2018-01-01T01:02:03Z)",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Computed:     true,
+			ValidateFunc: validation.IsRFC3339Time,
+		},
+
+		"expiration_date": {
+			Description:   "The date that this assignment expires, formatted as an RFC3339 date string in UTC (e.g. 2018-01-01T01:02:03Z)",
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"duration", "permanent_assignment"},
+			ValidateFunc:  validation.IsRFC3339Time,
+		},
+
+		"duration": {
+			Description:   "The duration of the assignment, formatted as an ISO8601 duration string (e.g. P3D for 3 days)",
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"expiration_date", "permanent_assignment"},
+			ValidateFunc:  validation.StringIsNotEmpty,
+		},
+
+		"permanent_assignment": {
+			Description:   "Is the assignment permanent",
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			ForceNew:      true,
+			Computed:      true,
+			ConflictsWith: []string{"expiration_date", "duration"},
+		},
+
+		"justification": {
+			Description:  "The justification for the assignment",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"ticket_number": {
+			Description:  "The ticket number authorising the assignment",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			RequiredWith: []string{"ticket_system"},
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"ticket_system": {
+			Description:  "The ticket system authorising the assignment",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			RequiredWith: []string{"ticket_number"},
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"status": {
+			Description: "The status of the Schedule Request",
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+		},
+
+		"target_schedule_id": {
+			Description: "The ID of the Schedule targeted by the request",
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+		},
+	}
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+
+			var model PrivilegedAccessGroupEligibilityScheduleRequestModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			schedule := msgraph.RequestSchedule{}
+			schedule.Expiration = &msgraph.ExpirationPattern{}
+
+			if model.ExpirationDate != "" || model.Duration != "" {
+				if model.Duration != "" {
+					schedule.Expiration.Duration = &model.Duration
+					schedule.Expiration.Type = msgraph.ExpirationPatternTypeAfterDuration
+				}
+
+				if model.ExpirationDate != "" {
+					endDate, err := time.Parse(time.RFC3339, model.ExpirationDate)
+					if err != nil {
+						return fmt.Errorf("parsing %s: %+v", model.StartDate, err)
+					}
+					schedule.Expiration.EndDateTime = &endDate
+					schedule.Expiration.Type = msgraph.ExpirationPatternTypeAfterDateTime
+				}
+			} else if model.PermanentAssignment {
+				schedule.Expiration.Type = msgraph.ExpirationPatternTypeNoExpiration
+			} else {
+				schedule.Expiration.Type = msgraph.ExpirationPatternTypeNotSpecified
+			}
+
+			if model.StartDate != "" {
+				startDate, err := time.Parse(time.RFC3339, model.StartDate)
+				if err != nil {
+					return fmt.Errorf("parsing %s: %+v", model.StartDate, err)
+				}
+				schedule.StartDateTime = &startDate
+			} else {
+				now := time.Now()
+				schedule.StartDateTime = &now
+			}
+
+			properties := msgraph.PrivilegedAccessGroupEligibilityScheduleRequest{
+				AccessId:      model.AssignmentType,
+				PrincipalId:   &model.PrincipalId,
+				GroupId:       &model.GroupId,
+				Action:        msgraph.PrivilegedAccessGroupActionAdminAssign,
+				Justification: &model.Justification,
+				ScheduleInfo:  &schedule,
+				TicketInfo: &msgraph.TicketInfo{
+					TicketNumber: &model.TicketNumber,
+					TicketSystem: &model.TicketSystem,
+				},
+			}
+
+			req, _, err := client.Create(ctx, properties)
+			if err != nil {
+				return fmt.Errorf("Could not create assignment schedule request, %+v", err)
+			}
+
+			if req.ID == nil || *req.ID == "" {
+				return fmt.Errorf("ID returned for assignment schedule request is nil/empty")
+			}
+
+			if req.Status == msgraph.PrivilegedAccessGroupEligibilityStatusFailed {
+				return fmt.Errorf("Assignment schedule request is in a failed state")
+			}
+
+			id := parse.NewPrivilegedAccessGroupEligibilityScheduleRequestID(*req.ID)
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+
+			id, err := parse.ParsePrivilegedAccessGroupEligibilityScheduleRequestID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model PrivilegedAccessGroupEligibilityScheduleRequestModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			result, status, err := client.Get(ctx, id.ID())
+			if err != nil {
+				if status == http.StatusNotFound {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+			if result == nil {
+				return fmt.Errorf("retrieving %s: API error, result was nil", id)
+			}
+
+			if slices.Contains([]string{
+				msgraph.PrivilegedAccessGroupEligibilityStatusCanceled,
+				msgraph.PrivilegedAccessGroupEligibilityStatusRevoked,
+			}, result.Status) {
+				metadata.MarkAsGone(id)
+			}
+
+			model.AssignmentType = result.AccessId
+			model.GroupId = *result.GroupId
+			model.Justification = *result.Justification
+			model.PermanentAssignment = result.ScheduleInfo.Expiration.Type == msgraph.ExpirationPatternTypeNoExpiration
+			model.PrincipalId = *result.PrincipalId
+			model.StartDate = result.ScheduleInfo.StartDateTime.Format(time.RFC3339)
+			model.Status = result.Status
+			model.TargetScheduleId = *result.TargetScheduleId
+
+			if result.ScheduleInfo.Expiration.EndDateTime != nil {
+				model.ExpirationDate = result.ScheduleInfo.Expiration.EndDateTime.Format(time.RFC3339)
+			}
+			if result.ScheduleInfo.Expiration.Duration != nil {
+				model.Duration = *result.ScheduleInfo.Expiration.Duration
+			}
+
+			if result.TicketInfo.TicketNumber != nil {
+				model.TicketNumber = *result.TicketInfo.TicketNumber
+			}
+			if result.TicketInfo.TicketSystem != nil {
+				model.TicketSystem = *result.TicketInfo.TicketSystem
+			}
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r PrivilegedAccessGroupEligibilityScheduleRequestResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+
+			id, err := parse.ParsePrivilegedAccessGroupEligibilityScheduleRequestID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model PrivilegedAccessGroupEligibilityScheduleRequestModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			switch model.Status {
+			case msgraph.PrivilegedAccessGroupEligibilityStatusDenied:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusFailed:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusGranted:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusPendingAdminDecision:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusPendingApproval:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusPendingProvisioning:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusPendingScheduledCreation:
+				return cancelRequest(ctx, metadata, client, id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusProvisioned:
+				return revokeRequest(ctx, metadata, client, id, &model)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusScheduleCreated:
+				return revokeRequest(ctx, metadata, client, id, &model)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusCanceled:
+				return metadata.MarkAsGone(id)
+			case msgraph.PrivilegedAccessGroupEligibilityStatusRevoked:
+				return metadata.MarkAsGone(id)
+			}
+
+			return fmt.Errorf("unknown status: %s", model.Status)
+		},
+	}
+}
+
+func cancelRequest(ctx context.Context, metadata sdk.ResourceMetaData, client *msgraph.PrivilegedAccessGroupEligibilityScheduleRequestClient, id *parse.PrivilegedAccessGroupEligibilityScheduleRequestId) error {
+	status, err := client.Cancel(ctx, id.RequestId)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return metadata.MarkAsGone(id)
+		}
+		return fmt.Errorf("cancelling %s: %+v", id, err)
+	}
+	return metadata.MarkAsGone(id)
+}
+
+func revokeRequest(ctx context.Context, metadata sdk.ResourceMetaData, client *msgraph.PrivilegedAccessGroupEligibilityScheduleRequestClient, id *parse.PrivilegedAccessGroupEligibilityScheduleRequestId, model *PrivilegedAccessGroupEligibilityScheduleRequestModel) error {
+	result, status, err := client.Create(ctx, msgraph.PrivilegedAccessGroupEligibilityScheduleRequest{
+		ID:          &id.RequestId,
+		AccessId:    model.AssignmentType,
+		PrincipalId: &model.PrincipalId,
+		GroupId:     &model.GroupId,
+		Action:      msgraph.PrivilegedAccessGroupActionAdminRemove,
+	})
+	if err != nil {
+		if status == http.StatusNotFound {
+			return metadata.MarkAsGone(id)
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	if result == nil {
+		return fmt.Errorf("retrieving %s: API error, result was nil", id)
+	}
+	return metadata.MarkAsGone(id)
+}

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_request_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_request_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package identitygovernance_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+type PrivilegedAccessGroupEligiblityScheduleRequestResource struct{}
+
+func TestPrivilegedAccessGroupEligiblityScheduleRequest_member(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_privileged_access_group_eligibility_schedule_request", "member")
+	r := PrivilegedAccessGroupEligiblityScheduleRequestResource{}
+
+	endTime := time.Now().AddDate(0, 2, 0).UTC()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.member(data, endTime),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				// There is a minimum life of 5 minutes for a schedule request to exist.
+				// Attempting to delete the request within this time frame will result in
+				// a 400 error on destroy, which we can't trap.
+				sleepCheck(5*time.Minute+1*time.Second),
+			),
+		},
+	})
+}
+
+func TestPrivilegedAccessGroupEligiblityScheduleRequest_owner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_privileged_access_group_eligibility_schedule_request", "owner")
+	r := PrivilegedAccessGroupEligiblityScheduleRequestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.owner(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				// There is a minimum life of 5 minutes for a schedule request to exist.
+				// Attempting to delete the request within this time frame will result in
+				// a 400 error on destroy, which we can't trap.
+				sleepCheck(5*time.Minute+1*time.Second),
+			),
+		},
+	})
+
+}
+
+func (PrivilegedAccessGroupEligiblityScheduleRequestResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+	client.BaseClient.DisableRetries = true
+	defer func() { client.BaseClient.DisableRetries = false }()
+
+	request, status, err := client.Get(ctx, state.ID)
+	if err != nil {
+		if status == http.StatusNotFound {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("failed to retrieve privileged group assignment schedule request with ID %q: %+v", state.ID, err)
+	}
+
+	// Requests are not deleted, but marked as canceled or revoked.
+	if slices.Contains([]string{
+		msgraph.PrivilegedAccessGroupEligibilityStatusCanceled,
+		msgraph.PrivilegedAccessGroupEligibilityStatusRevoked,
+	}, request.Status) {
+		return pointer.To(false), nil
+	} else {
+		return pointer.To(true), nil
+	}
+}
+
+func (PrivilegedAccessGroupEligiblityScheduleRequestResource) member(data acceptance.TestData, endTime time.Time) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "pam" {
+  display_name     = "Privileged Eligibility %[1]s"
+  mail_enabled     = false
+  security_enabled = true
+}
+
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "member" {
+  user_principal_name = "pam-member-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "PAM Member %[1]s"
+  password            = "%[2]s"
+}
+
+resource "azuread_privileged_access_group_eligibility_schedule_request" "member" {
+  group_id        = azuread_group.pam.id
+  principal_id    = azuread_user.member.id
+  assignment_type = "member"
+  expiration_date = "%[3]s"
+  justification   = "required"
+}
+`, data.RandomString, data.RandomPassword, endTime.Format(time.RFC3339))
+}
+
+func (PrivilegedAccessGroupEligiblityScheduleRequestResource) owner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "manual_owner" {
+  user_principal_name = "pam-eligible-owner-manual-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "PAM Owner (Manual) %[1]s"
+  password            = "%[2]s"
+}
+
+resource "azuread_group" "pam" {
+  display_name     = "Privileged Eligibility %[1]s"
+  mail_enabled     = false
+  security_enabled = true
+
+	owners = [azuread_user.manual_owner.object_id]
+
+	lifecycle {
+		ignore_changes = [owners]
+	}
+}
+
+resource "azuread_user" "eligibile_owner" {
+  user_principal_name = "pam-eligible-owner-eligibile-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "PAM Owner (Eligibile) %[1]s"
+  password            = "%[2]s"
+}
+
+
+resource "azuread_privileged_access_group_eligibility_schedule_request" "owner" {
+  group_id        = azuread_group.pam.id
+  principal_id    = azuread_user.eligibile_owner.id
+  assignment_type = "owner"
+  duration        = "P30D"
+  justification   = "required"
+}
+`, data.RandomString, data.RandomPassword)
+}
+
+func sleepCheck(d time.Duration) acceptance.TestCheckFunc {
+	return func(s *terraform.State) error {
+		time.Sleep(d)
+		return nil
+	}
+}

--- a/internal/services/identitygovernance/registration.go
+++ b/internal/services/identitygovernance/registration.go
@@ -57,5 +57,6 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		PrivilegedAccessGroupAssignmentScheduleRequestResource{},
+		PrivilegedAccessGroupEligibilityScheduleRequestResource{},
 	}
 }

--- a/internal/services/identitygovernance/registration.go
+++ b/internal/services/identitygovernance/registration.go
@@ -3,7 +3,10 @@
 
 package identitygovernance
 
-import "github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"
+import (
+	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/tf/pluginsdk"
+)
 
 type Registration struct{}
 
@@ -42,5 +45,17 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azuread_access_package_catalog_role_assignment":      accessPackageCatalogRoleAssignmentResource(),
 		"azuread_access_package_resource_catalog_association": accessPackageResourceCatalogAssociationResource(),
 		"azuread_access_package_resource_package_association": accessPackageResourcePackageAssociationResource(),
+	}
+}
+
+// DataSources returns the typed DataSources supported by this service
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+// Resources returns the typed Resources supported by this service
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		PrivilegedAccessGroupAssignmentScheduleRequestResource{},
 	}
 }


### PR DESCRIPTION
Partially implements requests in #68, #1257. Closes #1164.
Depends on manicminer/hamilton#254.

Related to #1320, #1322.
With these three PRs most of the requests for management of Privileged Access Group management should be done.