### PR TITLE
Update azuread_service_principal_password documentation to correct azuread_service_principal example

### DIFF
--- a/docs/resources/service_principal_password.md
+++ b/docs/resources/service_principal_password.md
@@ -26,7 +26,7 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_service_principal" "example" {
-  application_id = azuread_application.example.application_id
+  client_id = azuread_application.example.client_id
 }
 
 resource "azuread_service_principal_password" "example" {
@@ -42,7 +42,7 @@ resource "azuread_application" "example" {
 }
 
 resource "azuread_service_principal" "example" {
-  application_id = azuread_application.example.application_id
+  client_id = azuread_application.example.client_id
 }
 
 resource "time_rotating" "example" {


### PR DESCRIPTION
The example is incorrect - azuread_service_principal only allows you to specify client_id not application_id