### PR TITLE
Relaxed validation for identifier_uri attribute in azuread_application_identifier_uri resource

### DIFF
--- a/internal/services/applications/application_identifier_uri_resource.go
+++ b/internal/services/applications/application_identifier_uri_resource.go
@@ -51,10 +51,12 @@ func (r ApplicationIdentifierUriResource) Arguments() map[string]*pluginsdk.Sche
 		},
 
 		"identifier_uri": {
-			Description:  "The user-defined URI or URI-like string that uniquely identifies an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant",
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
+			Description: "The user-defined URI or URI-like string that uniquely identifies an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant",
+			Type:        pluginsdk.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			// Extensive validation is intentionally avoided here, as the accepted values are undocumented, vary wildly and are
+			// different for each user depending on the tenant domain configuration, whether the application is used for SSO etc
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}

--- a/internal/services/applications/application_identifier_uri_resource.go
+++ b/internal/services/applications/application_identifier_uri_resource.go
@@ -51,11 +51,11 @@ func (r ApplicationIdentifierUriResource) Arguments() map[string]*pluginsdk.Sche
 		},
 
 		"identifier_uri": {
-			Description:  "The user-defined URI that uniquely identifies an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant",
+			Description:  "The user-defined URI or URI-like string that uniquely identifies an application within its Azure AD tenant, or within a verified custom domain if the application is multi-tenant",
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.IsAppUri,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -341,8 +341,10 @@ func applicationResource() *pluginsdk.Resource {
 				Type:        pluginsdk.TypeSet,
 				Optional:    true,
 				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: validation.IsAppUri,
+					Type: pluginsdk.TypeString,
+					// Extensive validation is intentionally avoided here, as the accepted values are undocumented, vary wildly and are
+					// different for each user depending on the tenant domain configuration, whether the application is used for SSO etc
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 


### PR DESCRIPTION
Fix #1342
Related #951

I have tried to call API using various patterns.

Test case|`IsAppUri()`|Actual API|Trail
---|---|---|---
(empty string)|Invalid|Invalid|<img width="1029" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/d458b35e-e475-485d-90cd-1df8498db2a1">
`www.example.com?query=param`|Invalid|Invalid|<img width="1023" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/746dbf8e-6251-4243-89ae-be6757d3c6f1">
`this is invalid a url for app with patch!`|Invalid|Invalid|<img width="1033" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/7d0e7223-b50f-46cc-8c51-8909c04c3d0c">
`arn:aws:iam::123456789012:user/johndoe`|Invalid|**Valid**|<img width="1024" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/f977c296-156f-486c-a9aa-e3c212a3e76e">
`valid-url_with-patch`|Invalid|**Valid**|<img width="1031" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/d0d10554-dc8f-450e-a423-29f519e3ecd5">
`this is valid a url for app with patch`|Invalid|**Valid**|<img width="1033" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/c1134e6d-f6b1-4c1c-a54d-d3644799bac5">
`www.example.com`|Invalid|**Valid**|<img width="1029" alt="trail" src="https://github.com/hashicorp/terraform-provider-azuread/assets/1155067/c6ad2630-dcac-409f-8e93-6c812abab70c">


Based on these results, I found it difficult to define custom validation rules. 
Ultimately, since errors will occur in the API, I concluded that rigorous validation should be abandoned.

Therefore, I made changes to simplify the validation.
