### PR TITLE
docs: add to resource_app_id description and fix typos in service_principals.md

### DIFF
--- a/docs/data-sources/service_principals.md
+++ b/docs/data-sources/service_principals.md
@@ -27,7 +27,7 @@ data "azuread_service_principals" "example" {
 }
 ```
 
-*Look up by application IDs (client IDs*
+*Look up by application IDs (client IDs)
 
 ```terraform
 data "azuread_service_principals" "example" {

--- a/docs/data-sources/service_principals.md
+++ b/docs/data-sources/service_principals.md
@@ -27,7 +27,7 @@ data "azuread_service_principals" "example" {
 }
 ```
 
-*Look up by application IDs (client IDs)
+*Look up by application IDs (client IDs)*
 
 ```terraform
 data "azuread_service_principals" "example" {

--- a/internal/services/applications/application_data_source.go
+++ b/internal/services/applications/application_data_source.go
@@ -374,7 +374,7 @@ func applicationDataSource() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"resource_app_id": {
-							Description: "The unique identifier for the resource that the application requires access to. This is the Application ID of the target application",
+							Description: "The unique identifier for the resource that the application requires access to. This is the Client ID (also called Application ID) of the target application",
 							Type:        pluginsdk.TypeString,
 							Computed:    true,
 						},


### PR DESCRIPTION
# docs: add to resource_app_id description and fix typos in service_principals.md

I was recently using this provider and had some confusion from my side as I was unaware client id and application id were synonomous for one another, I use the terraform provider docs religiously and I believe that because application id is a property that is now deperecated this description should be changed to match what the provider expects, which from what I can tell is client id