### PR TITLE
bugfix: run d.Partial() to avoid setting invalid password to state when a user update fails

### DIFF
--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -576,6 +576,11 @@ func userResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta int
 	}
 
 	if _, err := client.Update(ctx, properties); err != nil {
+		// Flag the state as 'partial' to avoid setting `password` from the current config. Since the config is the
+		// only source for this property, if the update fails due to a bad password, the current password will be forgotten
+		// and Terraform will not offer a diff in the next plan.
+		d.Partial(true) //lintignore:R007
+
 		return tf.ErrorDiagF(err, "Could not update user with ID: %q", d.Id())
 	}
 


### PR DESCRIPTION
Resolves #1308