### PR TITLE
use single runner label for custom-linux-large

### DIFF
--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   gencheck:
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1

--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -31,7 +31,7 @@ jobs:
           fi
 
   provider-tests:
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     needs: [secrets-check]
     if: needs.secrets-check.outputs.available == 'true'
     steps:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1


### PR DESCRIPTION
👋 Greetings! 

To align with Github’s removal of [custom labels on larger runners](https://github.blog/changelog/2023-02-15-github-actions-removal-of-additional-label-option-for-github-hosted-larger-runners/), this PR is updating the labels defined in your Github Action jobs. Moving forward, only one label (the name of GH runner type)  will be needed to ensure an appropriate runner is used for your GHA job.

Please review for accuracy and merge before May 27, 2024. Thank you!

