### PR TITLE
docs: correct `identity` snippet in doc

### DIFF
--- a/docs/guides/managed_service_identity.md
+++ b/docs/guides/managed_service_identity.md
@@ -43,7 +43,7 @@ resource "azurerm_linux_virtual_machine" "management_host" {
 
   # ...
 
-  identity = {
+  identity {
     type = "SystemAssigned"
   }
 }


### PR DESCRIPTION
The `identity` in `azurerm_linux_virtual_machine` resource should be a nested block, so the `=` is incorrect.