### PR TITLE
azuread_application: support `ignore_changes` lifecycle argument

### DIFF
--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -648,6 +648,16 @@ resource "azuread_application" "test" {
       value                      = "user_impersonation"
     }
   }
+
+  app_role {
+    allowed_member_types = [
+      "User",
+    ]
+    description  = "msiam_access"
+    display_name = "msiam_access"
+    enabled      = true
+    id           = "dfd0e7dd-26fb-4b2c-98d2-e444486c1e37"
+  }
 }
 `, data.RandomInteger, testApplicationTemplateId, data.UUID())
 }

--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -635,8 +635,21 @@ resource "azuread_application" "test" {
   display_name = "acctest-APP-%[1]d"
   owners       = [data.azuread_client_config.test.object_id]
   template_id  = "%[2]s"
+
+  api {
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access acctest-APP-%[1]d on behalf of the signed-in user."
+      admin_consent_display_name = "Access acctest-APP-%[1]d"
+      enabled                    = true
+      id                         = "%[3]s"
+      type                       = "User"
+      user_consent_description   = "Allow the application to access acctest-APP-%[1]d on your behalf."
+      user_consent_display_name  = "Access acctest-APP-%[1]d"
+      value                      = "user_impersonation"
+    }
+  }
 }
-`, data.RandomInteger, testApplicationTemplateId)
+`, data.RandomInteger, testApplicationTemplateId, data.UUID())
 }
 
 func (ApplicationResource) withGroupMembershipClaims(data acceptance.TestData) string {


### PR DESCRIPTION
Support `ignore_changes` lifecycle argument for `app_role`, `oauth2_permission_scope`, `identifier_uris`, `optional_claims`, and `required_resource_access`

Fixes: #1344

<img width="522" alt="Screenshot 2024-06-10 at 19 10 03" src="https://github.com/hashicorp/terraform-provider-azuread/assets/251987/4ca81b1e-579d-4bbf-93f1-10bd79991f45">
