### PR TITLE
`azuread_application`: work around very buggy API when instantiating from template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,3 +63,5 @@ require (
 )
 
 go 1.21.3
+
+replace github.com/manicminer/hamilton => github.com/MarkDordoy/hamilton v0.17.1-0.20240611151114-899c6ce169f6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/MarkDordoy/hamilton v0.17.1-0.20240611151114-899c6ce169f6 h1:yRxIRrSebI7v7BspqjteIZKrnNQDWhRA68NVeU8cTmI=
+github.com/MarkDordoy/hamilton v0.17.1-0.20240611151114-899c6ce169f6/go.mod h1:u80g9rPtJpCG7EC0iayttt8UfeAp6jknClixgZGE950=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 h1:kkhsdkhsCvIsutKu5zLMgWtgh9YxGCNAw8Ad8hjwfYg=
@@ -111,8 +113,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/manicminer/hamilton v0.70.0 h1:XMgVcwVtUGq2aBXqVAynaUDZdPXCXC8/rd7D5Zsg3UM=
-github.com/manicminer/hamilton v0.70.0/go.mod h1:u80g9rPtJpCG7EC0iayttt8UfeAp6jknClixgZGE950=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/internal/services/applications/application_redirect_uris_resource.go
+++ b/internal/services/applications/application_redirect_uris_resource.go
@@ -199,7 +199,7 @@ func (r ApplicationRedirectUrisResource) Update() sdk.ResourceFunc {
 			applicationId := parse.NewApplicationID(id.ApplicationId)
 
 			var model ApplicationRedirectUrisModel
-			if err := metadata.Decode(&model); err != nil {
+			if err = metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 

--- a/internal/services/applications/application_registration_resource.go
+++ b/internal/services/applications/application_registration_resource.go
@@ -353,6 +353,9 @@ func (r ApplicationRegistrationResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
+			tf.LockByName(applicationResourceName, id.ApplicationId)
+			defer tf.UnlockByName(applicationResourceName, id.ApplicationId)
+
 			properties := msgraph.Application{
 				DirectoryObject: msgraph.DirectoryObject{
 					Id: &id.ApplicationId,

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1106,7 +1106,7 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 	// See https://github.com/hashicorp/terraform-provider-azuread/issues/914
 	if acceptMappedClaims != nil {
 		api.AcceptMappedClaims = acceptMappedClaims
-		if _, err := client.Update(ctx, msgraph.Application{
+		if _, err = client.Update(ctx, msgraph.Application{
 			DirectoryObject: msgraph.DirectoryObject{
 				Id: app.Id,
 			},
@@ -1119,7 +1119,7 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 	if len(ownersExtra) > 0 {
 		// Add any remaining owners after the application is created
 		app.Owners = &ownersExtra
-		if _, err := client.AddOwners(ctx, app); err != nil {
+		if _, err = client.AddOwners(ctx, app); err != nil {
 			return tf.ErrorDiagF(err, "Could not add owners to application with object ID: %q", id.ApplicationId)
 		}
 	}
@@ -1133,7 +1133,7 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 
 	// Upload the application image
 	if imageContentType != "" && len(imageData) > 0 {
-		_, err := client.UploadLogo(ctx, id.ApplicationId, imageContentType, imageData)
+		_, err = client.UploadLogo(ctx, id.ApplicationId, imageContentType, imageData)
 		if err != nil {
 			return tf.ErrorDiagF(err, "Could not upload logo image for application with object ID: %q", id.ApplicationId)
 		}
@@ -1150,6 +1150,9 @@ func applicationResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData, m
 	if err != nil {
 		return tf.ErrorDiagPathF(err, "id", "Parsing ID")
 	}
+
+	tf.LockByName(applicationResourceName, id.ApplicationId)
+	defer tf.UnlockByName(applicationResourceName, id.ApplicationId)
 
 	displayName := d.Get("display_name").(string)
 

--- a/internal/services/applications/client/client.go
+++ b/internal/services/applications/client/client.go
@@ -13,6 +13,7 @@ type Client struct {
 	ApplicationsClientBeta     *msgraph.ApplicationsClient
 	ApplicationTemplatesClient *msgraph.ApplicationTemplatesClient
 	DirectoryObjectsClient     *msgraph.DirectoryObjectsClient
+	ServicePrincipalsClient    *msgraph.ServicePrincipalsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -31,10 +32,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	directoryObjectsClient := msgraph.NewDirectoryObjectsClient()
 	o.ConfigureClient(&directoryObjectsClient.BaseClient)
 
+	servicePrincipalsClient := msgraph.NewServicePrincipalsClient()
+	o.ConfigureClient(&servicePrincipalsClient.BaseClient)
+
 	return &Client{
 		ApplicationsClient:         applicationsClient,
 		ApplicationsClientBeta:     applicationsClientBeta,
 		ApplicationTemplatesClient: applicationTemplatesClient,
 		DirectoryObjectsClient:     directoryObjectsClient,
+		ServicePrincipalsClient:    servicePrincipalsClient,
 	}
 }

--- a/vendor/github.com/manicminer/hamilton/msgraph/application_templates.go
+++ b/vendor/github.com/manicminer/hamilton/msgraph/application_templates.go
@@ -95,9 +95,8 @@ func (c *ApplicationTemplatesClient) Instantiate(ctx context.Context, applicatio
 	}
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		Body:                   body,
-		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
-		ValidStatusCodes:       []int{http.StatusCreated},
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
 		Uri: Uri{
 			Entity: fmt.Sprintf("/applicationTemplates/%s/instantiate", *applicationTemplate.ID),
 		},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.1.1
 ## explicit; go 1.15
 github.com/hashicorp/yamux
-# github.com/manicminer/hamilton v0.70.0
+# github.com/manicminer/hamilton v0.70.0 => github.com/MarkDordoy/hamilton v0.17.1-0.20240611151114-899c6ce169f6
 ## explicit; go 1.21
 github.com/manicminer/hamilton/errors
 github.com/manicminer/hamilton/internal/utils
@@ -428,3 +428,4 @@ google.golang.org/protobuf/types/known/timestamppb
 ## explicit; go 1.19
 software.sslmate.com/src/go-pkcs12
 software.sslmate.com/src/go-pkcs12/internal/rc2
+# github.com/manicminer/hamilton => github.com/MarkDordoy/hamilton v0.17.1-0.20240611151114-899c6ce169f6


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on https://github.com/manicminer/hamilton/pull/285, requires rebase prior to merging

The `/instantiate` operation can return a 404 whlst also processing the request completely normally. This leads to orphaned objects in the directory, and a resource that cannot successfully Create.

Work around this by polling for the application and service principal that you'd expect to see created out-of-band, whenever a 404 is received. Also set a temporary `displayName` for the application, as this is the only means we have to identify the resulting object is the one we are looking for.

Unfortunately this means that this workaround cannot be implemented for the `azuread_application_from_template` resource, since that resource intentionally avoids changing the implicitly created `user_impersonation` scope - this will get created with nonsensical display names / descriptions in the consent flow. Since the whole point of the standalone resource is to inherit scopes (and other fields) from the template, this makes it infeasible to add this workaround there.

Tested locally by intercepting the response to `POST /v1.0/applicationTemplates/4601ed45-8ff3-4599-8377-b6649007e876/instantiate` and sending a 404 back to the provider.

<img width="1490" alt="Screenshot 2024-06-11 at 18 23 59" src="https://github.com/hashicorp/terraform-provider-azuread/assets/251987/8553f0fe-df5c-4174-b710-789b913dd5b8">
  <br>
  <br>

**Test results:**

<img width="530" alt="Screenshot 2024-06-11 at 18 19 26" src="https://github.com/hashicorp/terraform-provider-azuread/assets/251987/3169b0e8-fee3-47ef-8342-8184ca63d013">
