### PR TITLE
bugfix: ensure `sessionControls.isEnabled: true` when specifying `sign_in_frequency_interval = "everyTime"`

### DIFF
--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -220,6 +220,16 @@ func TestAccConditionalAccessPolicy_sessionControls(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.sessionControlsSignInFrequencyAlways(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-CONPOLICY-%d", data.RandomInteger)),
+				check.That(data.ResourceName).Key("state").HasValue("disabled"),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.sessionControlsDisabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -676,6 +686,42 @@ resource "azuread_conditional_access_policy" "test" {
 
   session_controls {
     persistent_browser_mode = "always"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (ConditionalAccessPolicyResource) sessionControlsSignInFrequencyAlways(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_conditional_access_policy" "test" {
+  display_name = "acctest-CONPOLICY-%[1]d"
+  state        = "disabled"
+
+  conditions {
+    client_app_types = ["browser"]
+
+    applications {
+      included_applications = ["All"]
+    }
+
+    locations {
+      included_locations = ["All"]
+    }
+
+    platforms {
+      included_platforms = ["all"]
+    }
+
+    users {
+      included_users = ["All"]
+      excluded_users = ["GuestsOrExternalUsers"]
+    }
+  }
+
+  session_controls {
+    sign_in_frequency_interval = "everyTime"
   }
 }
 `, data.RandomInteger)

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -489,8 +489,13 @@ func expandConditionalAccessSessionControls(in []interface{}) *msgraph.Condition
 	}
 
 	signInFrequency := msgraph.SignInFrequencySessionControl{}
-	if frequencyValue := config["sign_in_frequency"].(int); frequencyValue > 0 {
+	frequencyValue := config["sign_in_frequency"].(int)
+	frequencyInterval := config["sign_in_frequency_interval"].(string)
+	if frequencyValue > 0 || frequencyInterval == msgraph.ConditionalAccessFrequencyIntervalEveryTime {
 		signInFrequency.IsEnabled = pointer.To(true)
+	}
+
+	if frequencyValue > 0 {
 		signInFrequency.Type = pointer.To(config["sign_in_frequency_period"].(string))
 		signInFrequency.Value = pointer.To(int32(frequencyValue))
 
@@ -503,8 +508,8 @@ func expandConditionalAccessSessionControls(in []interface{}) *msgraph.Condition
 		signInFrequency.AuthenticationType = pointer.To(authenticationType.(string))
 	}
 
-	if interval, ok := config["sign_in_frequency_interval"]; ok && interval.(string) != "" {
-		signInFrequency.FrequencyInterval = pointer.To(interval.(string))
+	if frequencyInterval != "" {
+		signInFrequency.FrequencyInterval = pointer.To(frequencyInterval)
 	}
 
 	// API returns 400 error if signInFrequency is set with all default/zero values


### PR DESCRIPTION
This fixes some incorrect logic around enabling session controls when only `sign_in_frequency_interval = "everyTime"` is specified.

Unfortunately this is currently blocked due to a possible API bug - this field doesn't seem to be accepted by the v1.0 API [contrary to documentation](https://learn.microsoft.com/en-us/graph/api/resources/signinfrequencysessioncontrol?view=graph-rest-1.0). Changing the API version in the request to `beta` allows the request to complete.

<img width="1144" alt="Screenshot 2024-06-25 at 23 10 26" src="https://github.com/hashicorp/terraform-provider-azuread/assets/251987/216fdacd-aff8-44c4-b962-d4584de0bf10">
<br><br>
<img width="990" alt="Screenshot 2024-06-25 at 23 11 38" src="https://github.com/hashicorp/terraform-provider-azuread/assets/251987/ab51f92d-7180-4e6a-8d02-a1f204527b4a">

Closes: #1416 