### PR TITLE
regression: `azuread_application` - don't populate the `password` block unless specified in config

### DIFF
--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1626,15 +1626,15 @@ func applicationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, met
 		if len(currentPassword) == 1 {
 			keyIdToMatch = currentPassword[0].(map[string]interface{})["key_id"].(string)
 			existingValue = currentPassword[0].(map[string]interface{})["value"].(string)
-		}
 
-		for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) {
-			// Match against the known key ID, or select the first returned password if not present in state
-			if keyIdToMatch == "" || credential["key_id"] == keyIdToMatch {
-				// Retain the value from state, if known
-				credential["value"] = existingValue
-				passwordToSave = append(passwordToSave, credential)
-				break
+			for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) {
+				// Match against the known key ID, or select the first returned password if not present in state
+				if credential["key_id"] == keyIdToMatch {
+					// Retain the value from state, if known
+					credential["value"] = existingValue
+					passwordToSave = append(passwordToSave, credential)
+					break
+				}
 			}
 		}
 

--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -651,6 +651,27 @@ func TestAccApplication_passwordUpdate(t *testing.T) {
 	})
 }
 
+func TestAccApplication_passwordNotSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_application", "test")
+	r := ApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: ApplicationPasswordResource{}.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			RefreshState: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("password.#").HasValue("0"),
+			),
+		},
+	})
+}
+
 func (r ApplicationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationsClientBeta
 	client.BaseClient.DisableRetries = true


### PR DESCRIPTION
Avoids marking all attributes as sensitive if the entire resource is used for an output variable

Fixes: #1421