### PR TITLE
bugfix: end_date_relative for application_password

### DIFF
--- a/internal/helpers/credentials.go
+++ b/internal/helpers/credentials.go
@@ -245,16 +245,16 @@ func getEndDateFromResourceData(d *pluginsdk.ResourceData) (*time.Time, error) {
 		}
 		endDate = &expiry
 	} else if v, ok := d.GetOk("end_date_relative"); ok && v.(string) != "" {
-		d, err := time.ParseDuration(v.(string))
+		duration, err := time.ParseDuration(v.(string))
 		if err != nil {
 			return nil, CredentialError{str: fmt.Sprintf("Unable to parse `end_date_relative` (%q) as a duration", v), attr: "end_date_relative"}
 		}
 
 		if startDate == nil {
-			expiry := time.Now().Add(d)
+			expiry := time.Now().Add(duration)
 			endDate = &expiry
 		} else {
-			expiry := startDate.Add(d)
+			expiry := startDate.Add(duration)
 			endDate = &expiry
 		}
 	}

--- a/internal/helpers/credentials.go
+++ b/internal/helpers/credentials.go
@@ -156,9 +156,8 @@ func KeyCredentialForResource(d *pluginsdk.ResourceData) (*msgraph.KeyCredential
 	}
 
 	endDate, err := getEndDateFromResourceData(d)
-
 	if err != nil {
-		return nil, CredentialError{str: fmt.Sprintf("Unable to parse the provided end date: %+v", err), attr: "end_date"}
+		return nil, err
 	}
 
 	if endDate != nil {
@@ -218,7 +217,7 @@ func PasswordCredentialForResource(d *pluginsdk.ResourceData) (*msgraph.Password
 
 	endDate, err := getEndDateFromResourceData(d)
 	if err != nil {
-		return nil, CredentialError{str: fmt.Sprintf("Unable to parse the provided end date: %+v", err), attr: "end_date"}
+		return nil, err
 	}
 
 	if endDate != nil {
@@ -233,7 +232,7 @@ func getEndDateFromResourceData(d *pluginsdk.ResourceData) (*time.Time, error) {
 	if v, ok := d.GetOk("start_date"); ok && v.(string) != "" {
 		start_date, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse the provided start date %q: %+v", v, err)
+			return nil, CredentialError{str: fmt.Sprintf("Unable to parse the provided start date %q: %+v", v, err), attr: "start_date"}
 		}
 		startDate = &start_date
 	}
@@ -242,13 +241,13 @@ func getEndDateFromResourceData(d *pluginsdk.ResourceData) (*time.Time, error) {
 	if v, ok := d.GetOk("end_date"); ok && v.(string) != "" {
 		expiry, err := time.Parse(time.RFC3339, v.(string))
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse the provided end date %q: %+v", v, err)
+			return nil, CredentialError{str: fmt.Sprintf("Unable to parse the provided end date %q: %+v", v, err), attr: "end_date"}
 		}
 		endDate = &expiry
 	} else if v, ok := d.GetOk("end_date_relative"); ok && v.(string) != "" {
 		d, err := time.ParseDuration(v.(string))
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse `end_date_relative` (%q) as a duration", v)
+			return nil, CredentialError{str: fmt.Sprintf("Unable to parse `end_date_relative` (%q) as a duration", v), attr: "end_date_relative"}
 		}
 
 		if startDate == nil {

--- a/internal/helpers/credentials_test.go
+++ b/internal/helpers/credentials_test.go
@@ -1,0 +1,154 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// To create test certificates:
+// openssl req -subj '/CN=hashicorptest/O=HashiCorp, Inc./ST=CA/C=US' -new -newkey rsa:2048 -sha256 -days 3650 -nodes -x509 -keyout server.key -out server.crt
+// grep -v \\----- server.crt >server.b64
+// cat server.b64 | base64 -d | xxd -p
+
+const applicationCertificatePem string = `-----BEGIN CERTIFICATE-----
+MIIDFDCCAfwCCQCvHp+vopfOOTANBgkqhkiG9w0BAQsFADBMMRYwFAYDVQQDDA1o
+YXNoaWNvcnB0ZXN0MRgwFgYDVQQKDA9IYXNoaUNvcnAsIEluYy4xCzAJBgNVBAgM
+AkNBMQswCQYDVQQGEwJVUzAeFw0yMTAzMDkxMTAyMTNaFw0zMTAzMDcxMTAyMTNa
+MEwxFjAUBgNVBAMMDWhhc2hpY29ycHRlc3QxGDAWBgNVBAoMD0hhc2hpQ29ycCwg
+SW5jLjELMAkGA1UECAwCQ0ExCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAlVmb5pmoASvZ5pxD6CEBiPYqADb7teCHV54RRwv1aJjS
+eiPUW/1WNQooIQF0M0yzFdHmwx3HSoxCkQwwxVMAPsuqFJVabs/eAr41NpxQCncb
+i+vKlbmaAWbaIdidxeUe1jXB2N0YXRCg7Ps8IGA0UochvRGypfciy4k6/xEfrrQP
+FlrPeDeaurNUjJ4IotTBLzWNAX9nT1HKzvljYNg4A0PwuzPNOmgxUSpAeiPbDoQo
+D/YcQUKWzBlW8qt9ZnuRMGNi6V2fnQeTLblfsheaavXyP11syJ9owz6mDffZELHd
+SYC7j2EOqG+Pndd55MLOac8cF4D9Y91PkLKKjNIrWwIDAQABMA0GCSqGSIb3DQEB
+CwUAA4IBAQBlVJLn17BFmigbqS8JIx0/RTbGokRoLKdg7SZAQJWn20jDtunSo+sp
+ZzuZ4uS8WbgZ+SFD1rrQy3s0F9HssZFBwDGyn31z/sGjkwWpoAP65v1DCaNzmAsz
+xMNijhYlShv61g2IEO9Q98bgBW9LNwmJRGnGxz0ufzeZuUr9IV9EjeoJCKPIbwJC
+lab0Ty/kRC13JgNhHtNFwYVwK6NDt46IRsjxqWQ6bVakrEROlfuoY8sxUjunj+hB
+2vZTkZKaPc0sFvUQjNHxHX4jMeTwCopQCo+qF3lPde+G7C1MNf30kDZlks++GLNs
+0/0Ayfjh6JllWqW482dIIqMErl6s5DuK
+-----END CERTIFICATE-----`
+
+func getKeyCredentialSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"value": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"encoding": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"start_date": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"end_date": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"end_date_relative": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func TestKeyCredentialForResource_withEndDate(t *testing.T) {
+
+	// Arrange
+	d := schema.TestResourceDataRaw(t, getKeyCredentialSchema(), nil)
+	d.Set("type", "AsymmetricX509Cert")
+	d.Set("value", applicationCertificatePem)
+	d.Set("encoding", "pem")
+
+	now := time.Now()
+	d.Set("end_date", now.Format(time.RFC3339))
+
+	// Act
+	keyCredential, err := KeyCredentialForResource(d)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := keyCredential.EndDateTime
+	expected := now
+
+	// In order to compare the time.Time objects, we need to truncate the time.
+	// 3 minutes is a reasonable amount of time to allow for the time it takes to run the test.
+	trunc := 3 * time.Minute
+	if actual.Truncate(trunc).Equal(expected.Truncate(trunc)) == false {
+		t.Fatalf("expected end date to be %v, got %v", expected, actual)
+	}
+}
+
+func TestKeyCredentialForResource_withEndDateRelative(t *testing.T) {
+
+	// Arrange
+	d := schema.TestResourceDataRaw(t, getKeyCredentialSchema(), nil)
+	d.Set("type", "AsymmetricX509Cert")
+	d.Set("value", applicationCertificatePem)
+	d.Set("encoding", "pem")
+
+	d.Set("end_date_relative", "240h") // 10 days
+
+	// Act
+	keyCredential, err := KeyCredentialForResource(d)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := keyCredential.EndDateTime
+	expected := time.Now().Add(time.Hour * 240) // 10 days
+
+	// In order to compare the time.Time objects, we need to truncate the time.
+	// 3 minutes is a reasonable amount of time to allow for the time it takes to run the test.
+	trunc := 3 * time.Minute
+	if actual.Truncate(trunc).Equal(expected.Truncate(trunc)) == false {
+		t.Fatalf("expected end date to be 10 days from now, got %v", actual)
+	}
+}
+
+func TestKeyCredentialForResource_withStartDateAndEndDateRelative(t *testing.T) {
+
+	// Arrange
+	d := schema.TestResourceDataRaw(t, getKeyCredentialSchema(), nil)
+	d.Set("type", "AsymmetricX509Cert")
+	d.Set("value", applicationCertificatePem)
+	d.Set("encoding", "pem")
+
+	start_date := time.Now().Add(time.Hour * 984)
+	d.Set("start_date", start_date.Format(time.RFC3339)) // 41 days
+	d.Set("end_date_relative", "240h")                   // 10 days
+
+	// Act
+	keyCredential, err := KeyCredentialForResource(d)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actual := keyCredential.EndDateTime
+	expected := start_date.Add(time.Hour * 240) // 10 days
+
+	// In order to compare the time.Time objects, we need to truncate the time.
+	// 3 minutes is a reasonable amount of time to allow for the time it takes to run the test.
+	trunc := 3 * time.Minute
+	if actual.Truncate(trunc).Equal(expected.Truncate(trunc)) == false {
+		t.Fatalf("expected end date to be 10 days from %v, got %v", start_date, actual)
+	}
+
+}


### PR DESCRIPTION
This fix supports `end_date_relative` for azuread_application_password.  See https://github.com/hashicorp/terraform-provider-azuread/issues/843 and https://github.com/hashicorp/terraform-provider-azuread/issues/1424 for more details.

## Terraform version

Terraform v1.9.1
on darwin_amd64 

## Provider version

2.53.1

## Terraform Configuration Files

```terraform
data "azuread_client_config" "current" {}

resource "azuread_application" "example" {
  display_name = "example"
  owners       = [data.azuread_client_config.current.object_id]
}

resource "azuread_application_password" "application_password" {
  application_id = azuread_application.example.id
  end_date_relative = "360h" # 15 days
}
```

## Expected Behavior

The expiration of the client secret in Microsoft Entra ID is calculated based on the `end_date_relative` argument.  

## Actual Behavior

`end_date_relative` is ignored and the expiration of the client secret in Microsoft Entra ID is set to the default of 2 years.

## Steps to Reproduce

```
terraform apply
```

## Sample

https://github.com/nickdala/azure-app-registration

Fixed #1424