### PR TITLE
bugfix: azuread_application - delete password block

### DIFF
--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -202,8 +202,6 @@ resource "azuread_application_password" "test" {
 
 func (r ApplicationPasswordResource) passwordsCombined(data acceptance.TestData, renderPassword bool) string {
 	return fmt.Sprintf(`
-#provider "azuread" {}
-
 data "azuread_client_config" "current" {}
 
 resource "azuread_application" "test" {
@@ -218,9 +216,6 @@ resource "azuread_application_password" "test" {
   display_name   = "acctest-application-password-%[2]s"
 }
 
-
-
-
 `, data.RandomInteger, data.RandomString, r.applicationPassword(data.RandomString, renderPassword))
 }
 
@@ -234,5 +229,4 @@ func (r ApplicationPasswordResource) applicationPassword(randomString string, re
 	}
 
 	return ""
-
 }

--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -215,8 +215,10 @@ resource "azuread_application" "test" {
 
 resource "azuread_application_password" "test" {
   application_id = azuread_application.test.id
-  display_name          = "acctest-application-password-%[2]s"
+  display_name   = "acctest-application-password-%[2]s"
 }
+
+
 
 
 `, data.RandomInteger, data.RandomString, r.applicationPassword(data.RandomString, renderPassword))

--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -79,6 +79,50 @@ func TestAccApplicationPassword_relativeEndDate(t *testing.T) {
 	})
 }
 
+func TestAccApplicationPassword_with_ApplicationInlinePassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_application_password", "test")
+	application := "azuread_application.test"
+
+	r := ApplicationPasswordResource{}
+	aR := ApplicationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.passwordsCombined(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("application_id").Exists(),
+				check.That(data.ResourceName).Key("end_date").Exists(),
+				check.That(data.ResourceName).Key("key_id").Exists(),
+				check.That(data.ResourceName).Key("start_date").Exists(),
+				check.That(data.ResourceName).Key("value").Exists(),
+				/* azuread_application */
+				check.That(application).ExistsInAzure(aR),
+				check.That(application).Key("password.#").HasValue("1"),
+				check.That(application).Key("password.0.key_id").Exists(),
+				check.That(application).Key("password.0.value").Exists(),
+				check.That(application).Key("password.0.start_date").Exists(),
+				check.That(application).Key("password.0.end_date").Exists(),
+				check.That(application).Key("password.0.display_name").HasValue(fmt.Sprintf("acctest-appPassword-%s", data.RandomString)),
+			),
+		},
+		{
+			Config: r.passwordsCombined(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(application).ExistsInAzure(aR),
+			),
+		},
+		{
+			RefreshState: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(application).ExistsInAzure(aR),
+				check.That(application).Key("password.#").HasValue("0"),
+			),
+		},
+	})
+}
+
 func (r ApplicationPasswordResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.Applications.ApplicationClient
 
@@ -154,4 +198,39 @@ resource "azuread_application_password" "test" {
   end_date_relative = "8760h"
 }
 `, r.template(data), data.RandomString)
+}
+
+func (r ApplicationPasswordResource) passwordsCombined(data acceptance.TestData, renderPassword bool) string {
+	return fmt.Sprintf(`
+#provider "azuread" {}
+
+data "azuread_client_config" "current" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctest-appPassword-%[1]d"
+  owners       = [data.azuread_client_config.current.object_id]
+
+  %[3]s
+}
+
+resource "azuread_application_password" "test" {
+  application_id = azuread_application.test.id
+  display_name          = "acctest-application-password-%[2]s"
+}
+
+
+`, data.RandomInteger, data.RandomString, r.applicationPassword(data.RandomString, renderPassword))
+}
+
+func (r ApplicationPasswordResource) applicationPassword(randomString string, renderPassword bool) string {
+	if renderPassword {
+		return fmt.Sprintf(`
+  password {
+    display_name = "acctest-appPassword-%[1]s"
+  }
+`, randomString)
+	}
+
+	return ""
+
 }

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -410,7 +410,6 @@ func applicationResource() *pluginsdk.Resource {
 				Description: "App password definition",
 				Type:        pluginsdk.TypeSet,
 				Optional:    true,
-				Computed:    true,
 				MaxItems:    1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{


### PR DESCRIPTION
FIX:
Update function of application resource to update / remove the password when the inline `password` block is removed.
