### PR TITLE
docs: Fix formatting of directory_object

### DIFF
--- a/docs/data-sources/directory_object.md
+++ b/docs/data-sources/directory_object.md
@@ -37,8 +37,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-*`object_id` - The object ID of the directory object.
-*`type` - The shortened OData type of the directory object. Possible values include: `Group`, `User` or `ServicePrincipal`.
+* `object_id` - The object ID of the directory object.
+* `type` - The shortened OData type of the directory object. Possible values include: `Group`, `User` or `ServicePrincipal`.
 
 ## Timeouts
 


### PR DESCRIPTION
Fix formatting of attribute references in docs

<img width="736" alt="Screenshot 2024-10-03 at 23 59 13" src="https://github.com/user-attachments/assets/ea68042c-1bd9-460a-995a-50e7e5547fde">
