### PR TITLE
Removing references to "hashitown" domain

### DIFF
--- a/docs/resources/application_identifier_uri.md
+++ b/docs/resources/application_identifier_uri.md
@@ -27,7 +27,7 @@ resource "azuread_application_registration" "example" {
 
 resource "azuread_application_identifier_uri" "example" {
   application_id = azuread_application_registration.example.id
-  identifier_uri = "https://app.hashitown.com"
+  identifier_uri = "https://app.example.com"
 }
 ```
 

--- a/docs/resources/application_owner.md
+++ b/docs/resources/application_owner.md
@@ -26,7 +26,7 @@ resource "azuread_application_registration" "example" {
 }
 
 resource "azuread_user" "jane" {
-  user_principal_name = "jane.fischer@hashitown.com"
+  user_principal_name = "jane.fischer@example.com"
   display_name        = "Jane Fischer"
   password            = "Ch@ngeMe"
 }

--- a/docs/resources/application_redirect_uris.md
+++ b/docs/resources/application_redirect_uris.md
@@ -44,8 +44,8 @@ resource "azuread_application_redirect_uris" "example_spa" {
   type           = "SPA"
 
   redirect_uris = [
-    "https://mobile.hashitown.com/",
-    "https://beta.hashitown.com/",
+    "https://mobile.example.com/",
+    "https://beta.example.com/",
   ]
 }
 
@@ -54,8 +54,8 @@ resource "azuread_application_redirect_uris" "example_web" {
   type           = "Web"
 
   redirect_uris = [
-    "https://app.hashitown.com/",
-    "https://classic.hashitown.com/",
+    "https://app.example.com/",
+    "https://classic.example.com/",
     "urn:ietf:wg:oauth:2.0:oob",
   ]
 }

--- a/docs/resources/application_registration.md
+++ b/docs/resources/application_registration.md
@@ -24,12 +24,12 @@ resource "azuread_application_registration" "example" {
   description      = "My example application"
   sign_in_audience = "AzureADMyOrg"
 
-  homepage_url          = "https://app.hashitown.com/"
-  logout_url            = "https://app.hashitown.com/logout"
-  marketing_url         = "https://hashitown.com/"
-  privacy_statement_url = "https://hashitown.com/privacy"
-  support_url           = "https://support.hashitown.com/"
-  terms_of_service_url  = "https://hashitown.com/terms"
+  homepage_url          = "https://app.example.com/"
+  logout_url            = "https://app.example.com/logout"
+  marketing_url         = "https://example.com/"
+  privacy_statement_url = "https://example.com/privacy"
+  support_url           = "https://support.example.com/"
+  terms_of_service_url  = "https://example.com/terms"
 }
 ```
 

--- a/internal/services/applications/application_data_source_test.go
+++ b/internal/services/applications/application_data_source_test.go
@@ -84,8 +84,8 @@ func (ApplicationDataSource) testCheck(data acceptance.TestData) acceptance.Test
 		check.That(data.ResourceName).Key("required_resource_access.#").HasValue("2"),
 		check.That(data.ResourceName).Key("sign_in_audience").HasValue("AzureADandPersonalMicrosoftAccount"),
 		check.That(data.ResourceName).Key("tags.#").HasValue("4"),
-		check.That(data.ResourceName).Key("web.0.homepage_url").HasValue(fmt.Sprintf("https://app.hashitown-%d.com/", data.RandomInteger)),
-		check.That(data.ResourceName).Key("web.0.logout_url").HasValue(fmt.Sprintf("https://app.hashitown-%[1]d.com/logout", data.RandomInteger)),
+		check.That(data.ResourceName).Key("web.0.homepage_url").HasValue(fmt.Sprintf("https://app.hashitown.example.com-%d.com/", data.RandomInteger)),
+		check.That(data.ResourceName).Key("web.0.logout_url").HasValue(fmt.Sprintf("https://app.hashitown.example.com-%[1]d.com/logout", data.RandomInteger)),
 		check.That(data.ResourceName).Key("web.0.redirect_uris.#").HasValue("3"),
 	)
 }

--- a/internal/services/applications/application_federated_identity_credential_resource_test.go
+++ b/internal/services/applications/application_federated_identity_credential_resource_test.go
@@ -120,9 +120,9 @@ func (r ApplicationFederatedIdentityCredentialResource) basic(data acceptance.Te
 
 resource "azuread_application_federated_identity_credential" "test" {
   application_id = azuread_application.test.id
-  display_name   = "hashitown-%[2]s"
+  display_name   = "hashitown.example.com-%[2]s"
   audiences      = ["api://HashiTownLikesAzureAD"]
-  issuer         = "https://tokens.hashitown.net"
+  issuer         = "https://tokens.hashitown.example.com.net"
   subject        = "%[3]s"
 }
 `, r.template(data), data.RandomString, data.RandomID)
@@ -134,10 +134,10 @@ func (r ApplicationFederatedIdentityCredentialResource) complete(data acceptance
 
 resource "azuread_application_federated_identity_credential" "test" {
   application_id = azuread_application.test.id
-  display_name   = "hashitown-%[2]s"
+  display_name   = "hashitown.example.com-%[2]s"
   description    = "Funtime tokens for HashiTown"
   audiences      = ["api://HashiTownLikesAzureAD"]
-  issuer         = "https://vending.hashitown.net"
+  issuer         = "https://vending.hashitown.example.com.net"
   subject        = "%[3]s"
 }
 `, r.template(data), data.RandomString, data.UUID())

--- a/internal/services/applications/application_redirect_uris_resource_test.go
+++ b/internal/services/applications/application_redirect_uris_resource_test.go
@@ -188,8 +188,8 @@ resource "azuread_application_redirect_uris" "test" {
   type           = "SPA"
 
   redirect_uris = [
-    "https://mobile.hashitown-%[1]d.com/",
-    "https://beta.hashitown-%[1]d.com/",
+    "https://mobile.hashitown.example.com-%[1]d.com/",
+    "https://beta.hashitown.example.com-%[1]d.com/",
   ]
 }
 `, data.RandomInteger)
@@ -208,8 +208,8 @@ resource "azuread_application_redirect_uris" "test" {
   type           = "Web"
 
   redirect_uris = [
-    "https://app.hashitown-%[1]d.com/",
-    "https://classic.hashitown-%[1]d.com/",
+    "https://app.hashitown.example.com-%[1]d.com/",
+    "https://classic.hashitown.example.com-%[1]d.com/",
     "urn:ietf:wg:oauth:2.0:oob",
   ]
 }
@@ -243,8 +243,8 @@ resource "azuread_application_redirect_uris" "test_spa" {
   type           = "SPA"
 
   redirect_uris = [
-    "https://mobile.hashitown-%[1]d.com/",
-    "https://beta.hashitown-%[1]d.com/",
+    "https://mobile.hashitown.example.com-%[1]d.com/",
+    "https://beta.hashitown.example.com-%[1]d.com/",
   ]
 }
 
@@ -253,8 +253,8 @@ resource "azuread_application_redirect_uris" "test_web" {
   type           = "Web"
 
   redirect_uris = [
-    "https://app.hashitown-%[1]d.com/",
-    "https://classic.hashitown-%[1]d.com/",
+    "https://app.hashitown.example.com-%[1]d.com/",
+    "https://classic.hashitown.example.com-%[1]d.com/",
     "urn:ietf:wg:oauth:2.0:oob",
   ]
 }

--- a/internal/services/applications/application_registration_resource_test.go
+++ b/internal/services/applications/application_registration_resource_test.go
@@ -135,12 +135,12 @@ resource "azuread_application_registration" "test" {
   notes                        = "Testing application"
   service_management_reference = "app-for-testing"
 
-  homepage_url          = "https://app.hashitown-%[1]d.com/"
-  logout_url            = "https://app.hashitown-%[1]d.com/logout"
-  marketing_url         = "https://hashitown-%[1]d.com/"
-  privacy_statement_url = "https://hashitown-%[1]d.com/privacy"
-  support_url           = "https://support.hashitown-%[1]d.com/"
-  terms_of_service_url  = "https://hashitown-%[1]d.com/terms"
+  homepage_url          = "https://app.hashitown.example.com-%[1]d.com/"
+  logout_url            = "https://app.hashitown.example.com-%[1]d.com/logout"
+  marketing_url         = "https://hashitown.example.com-%[1]d.com/"
+  privacy_statement_url = "https://hashitown.example.com-%[1]d.com/privacy"
+  support_url           = "https://support.hashitown.example.com-%[1]d.com/"
+  terms_of_service_url  = "https://hashitown.example.com-%[1]d.com/terms"
 }
 `, data.RandomInteger)
 }

--- a/internal/services/applications/application_resource_test.go
+++ b/internal/services/applications/application_resource_test.go
@@ -781,10 +781,10 @@ resource "azuread_application" "test" {
   notes                        = "Testing application"
   service_management_reference = "app-for-testing"
 
-  marketing_url         = "https://hashitown-%[1]d.com/"
-  privacy_statement_url = "https://hashitown-%[1]d.com/privacy"
-  support_url           = "https://support.hashitown-%[1]d.com/"
-  terms_of_service_url  = "https://hashitown-%[1]d.com/terms"
+  marketing_url         = "https://hashitown.example.com-%[1]d.com/"
+  privacy_statement_url = "https://hashitown.example.com-%[1]d.com/privacy"
+  support_url           = "https://support.hashitown.example.com-%[1]d.com/"
+  terms_of_service_url  = "https://hashitown.example.com-%[1]d.com/terms"
 
   api {
     mapped_claims_enabled          = true
@@ -896,7 +896,7 @@ resource "azuread_application" "test" {
 
   single_page_application {
     redirect_uris = [
-      "https://beta.hashitown-%[1]d.com/",
+      "https://beta.hashitown.example.com-%[1]d.com/",
     ]
   }
 
@@ -908,12 +908,12 @@ resource "azuread_application" "test" {
   ]
 
   web {
-    homepage_url = "https://app.hashitown-%[1]d.com/"
-    logout_url   = "https://app.hashitown-%[1]d.com/logout"
+    homepage_url = "https://app.hashitown.example.com-%[1]d.com/"
+    logout_url   = "https://app.hashitown.example.com-%[1]d.com/logout"
 
     redirect_uris = [
-      "https://app.hashitown-%[1]d.com/",
-      "https://classic.hashitown-%[1]d.com/",
+      "https://app.hashitown.example.com-%[1]d.com/",
+      "https://classic.hashitown.example.com-%[1]d.com/",
       "urn:ietf:wg:oauth:2.0:oob",
     ]
 

--- a/internal/services/serviceprincipals/service_principal_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_resource_test.go
@@ -431,8 +431,8 @@ resource "azuread_service_principal" "test" {
   preferred_single_sign_on_mode = "saml"
 
   notification_email_addresses = [
-    "alerts.internal@hashitown.net",
-    "cto@hashitown.net",
+    "alerts.internal@hashitown.example.com.net",
+    "cto@hashitown.example.com.net",
   ]
 
   saml_single_sign_on {
@@ -472,8 +472,8 @@ resource "azuread_service_principal" "test" {
   }
 
   notification_email_addresses = [
-    "alerts.internal@hashitown.net",
-    "cto@hashitown.net",
+    "alerts.internal@hashitown.example.com.net",
+    "cto@hashitown.example.com.net",
   ]
 
   saml_single_sign_on {
@@ -506,8 +506,8 @@ resource "azuread_service_principal" "test" {
   }
 
   notification_email_addresses = [
-    "alerts.internal@hashitown.net",
-    "cto@hashitown.net",
+    "alerts.internal@hashitown.example.com.net",
+    "cto@hashitown.example.com.net",
   ]
 }
 `, r.templateComplete(data), data.RandomInteger)


### PR DESCRIPTION
Parts of our documentation and code reference a (previously) unregistered domain - `hashitown.[com|net]`. To prevent confusion, domain squatting, etc, this change replaces all references with the iana official example domain: `example.com`

First commit only changes docs. Second commit changes references in code (only tests)

Commands were roughly:
`ag -l hashitown | xargs sed -i "" 's/hashitown.com/example.com/g'`
 `ag -l hashitown | xargs sed -i "" 's/hashitown/hashitown.example.com/g'`