### PR TITLE
docs: update oauth2_permission_scope documentation

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -265,7 +265,7 @@ The following arguments are supported:
 * `type` - (Optional) Whether this delegated permission should be considered safe for non-admin users to consent to on behalf of themselves, or whether an administrator should be required for consent to the permissions. Defaults to `User`. Possible values are `User` or `Admin`.
 * `user_consent_description` - (Optional) Delegated permission description that appears in the end user consent experience, intended to be read by a user consenting on their own behalf.
 * `user_consent_display_name` - (Optional) Display name for the delegated permission that appears in the end user consent experience.
-* `value` - (Optional) The value that is used for the `scp` claim in OAuth 2.0 access tokens.
+* `value` - (Required) The value that is used for the `scp` claim in OAuth 2.0 access tokens.
 
 ~> **Default `user_impersonation` Scope** Unlike the Azure Portal, applications created with the Terraform AzureAD provider do not get assigned a default `user_impersonation` scope. You will need to include a block for the `user_impersonation` scope if you need it for your application.
 


### PR DESCRIPTION
Fix field marked as optional that is in fact required. When trying to create this resource without the field the following error gets returned:
```
16:47:34.579 STDERR terraform: │ Error: Could not update application with object ID: "<redacted>"
16:47:34.579 STDERR terraform: │
16:47:34.579 STDERR terraform: │   with module.<redacted>.azuread_application.this,
16:47:34.579 STDERR terraform: │   on ../../../../../../modules/<redacted>/main.tf line 16, in resource "azuread_application" "this":
16:47:34.579 STDERR terraform: │   16: resource "azuread_application" "this" {
16:47:34.579 STDERR terraform: │
16:47:34.579 STDERR terraform: │ unexpected status 400 (400 Bad Request) with error: ValueRequired: Property
16:47:34.579 STDERR terraform: │ value is required but is empty or missing.
16:47:34.580 STDERR terraform: ╵
16:47:34.660 ERROR  terraform invocation failed in .
```

Once the field is provided the error no longer occurs. The field is also required in the UI as can be seen in the below screenshot

![image](https://github.com/user-attachments/assets/37f44bf3-c1d7-4cf7-8e63-a9f310022a09)
