### PR TITLE
docs: update import statement for app_role_assignment

### DIFF
--- a/docs/resources/app_role_assignment.md
+++ b/docs/resources/app_role_assignment.md
@@ -199,7 +199,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 App role assignments can be imported using the object ID of the service principal representing the resource and the ID of the app role assignment (note: _not_ the ID of the app role), e.g.
 
 ```shell
-terraform import azuread_app_role_assignment.example 00000000-0000-0000-0000-000000000000/appRoleAssignment/aaBBcDDeFG6h5JKLMN2PQrrssTTUUvWWxxxxxyyyzzz
+terraform import azuread_app_role_assignment.example /servicePrincipals/00000000-0000-0000-0000-000000000000/appRoleAssignedTo/aaBBcDDeFG6h5JKLMN2PQrrssTTUUvWWxxxxxyyyzzz
 ```
 
--> This ID format is unique to Terraform and is composed of the Resource Service Principal Object ID and the ID of the App Role Assignment in the format `{ResourcePrincipalID}/appRoleAssignment/{AppRoleAssignmentID}`.
+-> This ID format is unique to Terraform and is composed of the Resource Service Principal Object ID and the ID of the App Role Assignment in the format `/servicePrincipals/{ResourcePrincipalID}/appRoleAssignedTo/{AppRoleAssignmentID}`.


### PR DESCRIPTION
This small PR updates the import statement for the azuread_app_role_assignment.
I noted a change when recently using it.

```
Error: parsing "d00*****-****-****-****-*****39b503c/appRoleAssignment/Jno_******************************NWf5jBrA4": parsing the ServicePrincipalIdAppRoleAssignedTo ID: the number of segments didn't match
│ 
│ Expected a ServicePrincipalIdAppRoleAssignedTo ID that matched (containing 4 segments):
│ 
│ > /servicePrincipals/servicePrincipalId/appRoleAssignedTo/appRoleAssignmentId
│ 
│ However this value was provided (which was parsed into 0 segments):
│ 
│ > d00*****-****-****-****-*****39b503c/appRoleAssignment/Jno_******************************NWf5jBrA4
│ 
│ The following Segments are expected:
│ 
│ * Segment 0 - this should be the literal value "servicePrincipals"
│ * Segment 1 - this should be the user specified value for this servicePrincipalId [for example "servicePrincipalId"]
│ * Segment 2 - this should be the literal value "appRoleAssignedTo"
│ * Segment 3 - this should be the user specified value for this appRoleAssignmentId [for example "appRoleAssignmentId"]
│ 
│ The following Segments were parsed:
│ 
│ * Segment 0 - not found
│ * Segment 1 - not found
│ * Segment 2 - not found
│ * Segment 3 - not found
```