### PR TITLE
feat(azuread_service_principals): Support for argument `filter`

### DIFF
--- a/docs/data-sources/service_principals.md
+++ b/docs/data-sources/service_principals.md
@@ -51,6 +51,14 @@ data "azuread_service_principals" "example" {
 }
 ```
 
+*Look up by using a OData filter*
+
+```terraform
+data "azuread_service_principals" "example" {
+  filter = "startswith(displayName, 'myPrincipal')"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -60,6 +68,7 @@ The following arguments are supported:
 * `ignore_missing` - (Optional) Ignore missing service principals and return all service principals that are found. The data source will still fail if no service principals are found. Defaults to false.
 * `object_ids` - (Optional) The object IDs of the service principals.
 * `return_all` - (Optional) When `true`, the data source will return all service principals. Cannot be used with `ignore_missing`. Defaults to false.
+* `filter` - (Optional) Use a OData filter to search for service principals. Cannot be used with `ignore_missing`.
 
 ~> Either `return_all`, or one of `client_ids`, `display_names` or `object_ids` must be specified. These _may_ be specified as an empty list, in which case no results will be returned.
 

--- a/internal/services/serviceprincipals/service_principals_data_source_test.go
+++ b/internal/services/serviceprincipals/service_principals_data_source_test.go
@@ -93,6 +93,19 @@ func TestAccServicePrincipalsDataSource_byObjectIdsWithIgnoreMissing(t *testing.
 	}})
 }
 
+func TestAccServicePrincipalsDataSource_byFilter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_service_principals", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: ServicePrincipalsDataSource{}.byFilter(data),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("display_names.#").HasValue("1"),
+			check.That(data.ResourceName).Key("object_ids.#").HasValue("1"),
+			check.That(data.ResourceName).Key("service_principals.#").HasValue("1"),
+		),
+	}})
+}
+
 func TestAccServicePrincipalsDataSource_noNames(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azuread_service_principals", "test")
 
@@ -221,4 +234,14 @@ data "azuread_service_principals" "test" {
   return_all = true
 }
 `
+}
+
+func (ServicePrincipalsDataSource) byFilter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_service_principals" "test" {
+  filter = "displayName eq '${azuread_service_principal.testA.display_name}'"
+}
+`, ServicePrincipalResource{}.threeServicePrincipalsABC(data))
 }


### PR DESCRIPTION
This adds support for filtering service principals by using a OData filter.

```terraform
data "azuread_service_principals" "example" {
  filter = "startswith(displayName, 'myPrincipal')"
}
```

```terraform
data "azuread_service_principals" "example" {
  filter = "displayName eq 'foo'"
}
```