### PR TITLE
azuread_named_location: Implement support for the country_lookup_method parameter

### DIFF
--- a/docs/resources/named_location.md
+++ b/docs/resources/named_location.md
@@ -58,6 +58,7 @@ The following arguments are supported:
 
 * `countries_and_regions` - (Required) List of countries and/or regions in two-letter format specified by ISO 3166-2. 
 * `include_unknown_countries_and_regions` - (Optional) Whether IP addresses that don't map to a country or region should be included in the named location. Defaults to `false`.
+* `country_lookup_method` - (Optional) Method of detecting country the user is located in. Possible values are `clientIpAddress` for IP-based location and `authenticatorAppGps` for Authenticator app GPS-based location.  Defaults to `clientIpAddress`.
 
 ---
 

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -278,10 +278,16 @@ func flattenCountryNamedLocation(in *stable.CountryNamedLocation) []interface{} 
 		includeUnknown = *in.IncludeUnknownCountriesAndRegions
 	}
 
+	countryLookupMethod := stable.CountryLookupMethodType_ClientIPAddress
+	if in.CountryLookupMethod != nil {
+		countryLookupMethod = *in.CountryLookupMethod
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"countries_and_regions":                 tf.FlattenStringSlice(in.CountriesAndRegions),
 			"include_unknown_countries_and_regions": includeUnknown,
+			"country_lookup_method":                 countryLookupMethod,
 		},
 	}
 }
@@ -658,6 +664,10 @@ func expandCountryNamedLocation(in []interface{}) *stable.CountryNamedLocation {
 
 	result.CountriesAndRegions = tf.ExpandStringSlice(countriesAndRegions)
 	result.IncludeUnknownCountriesAndRegions = pointer.To(includeUnknown.(bool))
+
+	if countryLookupMethodType, ok := config["country_lookup_method"]; ok && countryLookupMethodType.(string) != "" {
+		result.CountryLookupMethod = pointer.To(stable.CountryLookupMethodType(countryLookupMethodType.(string)))
+	}
 
 	return &result
 }

--- a/internal/services/conditionalaccess/named_location_data_source.go
+++ b/internal/services/conditionalaccess/named_location_data_source.go
@@ -73,6 +73,11 @@ func namedLocationDataSource() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Computed: true,
 						},
+
+						"country_lookup_method": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/services/conditionalaccess/named_location_data_source_test.go
+++ b/internal/services/conditionalaccess/named_location_data_source_test.go
@@ -23,6 +23,23 @@ func TestAccNamedLocationDataSource_country(t *testing.T) {
 				check.That(data.ResourceName).Key("country.#").HasValue("1"),
 				check.That(data.ResourceName).Key("country.0.countries_and_regions.#").HasValue("3"),
 				check.That(data.ResourceName).Key("country.0.include_unknown_countries_and_regions").HasValue("true"),
+				check.That(data.ResourceName).Key("country.0.country_lookup_method").HasValue("clientIpAddress"),
+			),
+		},
+	})
+}
+
+func TestAccNamedLocationDataSource_countryByGps(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_named_location", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: NamedLocationDataSource{}.countryByGps(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("country.#").HasValue("1"),
+				check.That(data.ResourceName).Key("country.0.countries_and_regions.#").HasValue("3"),
+				check.That(data.ResourceName).Key("country.0.include_unknown_countries_and_regions").HasValue("true"),
+				check.That(data.ResourceName).Key("country.0.country_lookup_method").HasValue("authenticatorAppGps"),
 			),
 		},
 	})
@@ -51,6 +68,16 @@ data "azuread_named_location" "test" {
   display_name = azuread_named_location.test.display_name
 }
 `, NamedLocationResource{}.completeCountry(data))
+}
+
+func (NamedLocationDataSource) countryByGps(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_named_location" "test" {
+  display_name = azuread_named_location.test.display_name
+}
+`, NamedLocationResource{}.completeCountryByGps(data))
 }
 
 func (NamedLocationDataSource) ip(data acceptance.TestData) string {

--- a/internal/services/conditionalaccess/named_location_resource.go
+++ b/internal/services/conditionalaccess/named_location_resource.go
@@ -110,6 +110,13 @@ func namedLocationResource() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 						},
+
+						"country_lookup_method": {
+							Type:         pluginsdk.TypeString,
+							Default:      stable.CountryLookupMethodType_ClientIPAddress,
+							ValidateFunc: validation.StringInSlice(stable.PossibleValuesForCountryLookupMethodType(), false),
+							Optional:     true,
+						},
 					},
 				},
 			},

--- a/internal/services/conditionalaccess/named_location_resource_test.go
+++ b/internal/services/conditionalaccess/named_location_resource_test.go
@@ -138,6 +138,50 @@ func TestAccNamedLocation_updateCountry(t *testing.T) {
 	})
 }
 
+func TestAccNamedLocation_completeCountryByGps(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_named_location", "test")
+	r := NamedLocationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeCountryByGps(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccNamedLocation_updateCountryByGps(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_named_location", "test")
+	r := NamedLocationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicCountry(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeCountryByGps(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicCountry(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r NamedLocationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.ConditionalAccess.NamedLocationClient
 
@@ -213,6 +257,24 @@ resource "azuread_named_location" "test" {
       "JP",
     ]
     include_unknown_countries_and_regions = true
+    country_lookup_method = "clientIpAddress"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (NamedLocationResource) completeCountryByGps(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_named_location" "test" {
+  display_name = "acctestNLC-%[1]d"
+  country {
+    countries_and_regions = [
+      "GB",
+      "US",
+      "JP",
+    ]
+    include_unknown_countries_and_regions = true
+    country_lookup_method = "authenticatorAppGps"
   }
 }
 `, data.RandomInteger)


### PR DESCRIPTION
In `azuread_named_location` add support for the `country_lookup_method` parameter. This specifies method of detecting country the user is located in. Possible values are `clientIpAddress` for IP-based location and `authenticatorAppGps` for Authenticator app GPS-based location.  Defaults to `clientIpAddress`.

Graph API documentation: https://learn.microsoft.com/en-us/graph/api/resources/countrynamedlocation?view=graph-rest-1.0 

Fix #1427 