### PR TITLE
azuread_access_package_resource_catalog_association: allow originId containing `/`, e.g. URIs

### DIFF
--- a/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
@@ -27,7 +27,7 @@ func NewAccessPackageResourceCatalogAssociationID(catalogId, originId string) Ac
 }
 
 func AccessPackageResourceCatalogAssociationID(idString string) (*AccessPackageResourceCatalogAssociationId, error) {
-	parts := strings.Split(idString, "/")
+	parts := strings.SplitN(idString, "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("ID should be in the format {catalogId}/{originId} - but got %q", idString)
 	}


### PR DESCRIPTION
Fixes: #1576