### PR TITLE
azuread_conditional_access_policy: Implement support for the `insider_risk_levels` parameter

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -163,13 +163,13 @@ The following arguments are supported:
 * `client_app_types` - (Required) A list of client application types included in the policy. Possible values are: `all`, `browser`, `mobileAppsAndDesktopClients`, `exchangeActiveSync`, `easSupported` and `other`.
 * `client_applications` - (Optional) An `client_applications` block as documented below, which specifies service principals included in and excluded from the policy.
 * `devices` - (Optional) A `devices` block as documented below, which describes devices to be included in and excluded from the policy. A `devices` block can be added to an existing policy, but removing the `devices` block forces a new resource to be created.
+* `insider_risk_levels` - (Optional) The insider risk level in the policy. Possible values are: `minor`, `moderate`, `elevated`, `unknownFutureValue`.
 * `locations` - (Optional) A `locations` block as documented below, which specifies locations included in and excluded from the policy.
 * `platforms` - (Optional) A `platforms` block as documented below, which specifies platforms included in and excluded from the policy.
 * `service_principal_risk_levels` - (Optional) A list of service principal sign-in risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `none`, `unknownFutureValue`.
 * `sign_in_risk_levels` - (Optional) A list of user sign-in risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
 * `user_risk_levels` - (Optional) A list of user risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
 * `users` - (Required) A `users` block as documented below, which specifies users, groups, and roles included in and excluded from the policy.
-* `insider_risk_levels` - (Optional) The insider risk level in the policy. Possible values are: `minor`, `moderate`, `elevated`, `unknownFutureValue`.
 
 ---
 

--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -169,6 +169,7 @@ The following arguments are supported:
 * `sign_in_risk_levels` - (Optional) A list of user sign-in risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
 * `user_risk_levels` - (Optional) A list of user risk levels included in the policy. Possible values are: `low`, `medium`, `high`, `hidden`, `none`, `unknownFutureValue`.
 * `users` - (Required) A `users` block as documented below, which specifies users, groups, and roles included in and excluded from the policy.
+* `insider_risk_levels` - (Optional) The insider risk level in the policy. Possible values are: `minor`, `moderate`, `elevated`, `unknownFutureValue`.
 
 ---
 

--- a/docs/resources/named_location.md
+++ b/docs/resources/named_location.md
@@ -57,8 +57,8 @@ The following arguments are supported:
 `country` block supports the following:
 
 * `countries_and_regions` - (Required) List of countries and/or regions in two-letter format specified by ISO 3166-2. 
-* `include_unknown_countries_and_regions` - (Optional) Whether IP addresses that don't map to a country or region should be included in the named location. Defaults to `false`.
 * `country_lookup_method` - (Optional) Method of detecting country the user is located in. Possible values are `clientIpAddress` for IP-based location and `authenticatorAppGps` for Authenticator app GPS-based location.  Defaults to `clientIpAddress`.
+* `include_unknown_countries_and_regions` - (Optional) Whether IP addresses that don't map to a country or region should be included in the named location. Defaults to `false`.
 
 ---
 

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -408,6 +408,13 @@ func conditionalAccessPolicyResource() *pluginsdk.Resource {
 								ValidateFunc: validation.StringInSlice(stable.PossibleValuesForRiskLevel(), false),
 							},
 						},
+
+						"insider_risk_levels": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(stable.PossibleValuesForConditionalAccessInsiderRiskLevels(), false),
+						},
 					},
 				},
 			},

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -37,6 +37,11 @@ func flattenConditionalAccessConditionSet(in *stable.ConditionalAccessConditionS
 		userRiskLevels = append(userRiskLevels, string(v))
 	}
 
+	insiderRiskLevels := ""
+	if in.InsiderRiskLevels != nil {
+		insiderRiskLevels = string(pointer.From(in.InsiderRiskLevels))
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"applications":                  flattenConditionalAccessApplications(in.Applications),
@@ -49,6 +54,7 @@ func flattenConditionalAccessConditionSet(in *stable.ConditionalAccessConditionS
 			"service_principal_risk_levels": servicePrincipalRiskLevels,
 			"sign_in_risk_levels":           signInRiskLevels,
 			"user_risk_levels":              userRiskLevels,
+			"insider_risk_levels":           insiderRiskLevels,
 		},
 	}
 }
@@ -365,6 +371,10 @@ func expandConditionalAccessConditionSet(in []interface{}) *stable.ConditionalAc
 	userRiskLevels := make([]stable.RiskLevel, 0)
 	for _, elem := range config["user_risk_levels"].([]interface{}) {
 		userRiskLevels = append(userRiskLevels, stable.RiskLevel(elem.(string)))
+	}
+
+	if insiderRiskLevel, ok := config["insider_risk_levels"]; ok && insiderRiskLevel.(string) != "" {
+		result.InsiderRiskLevels = pointer.To(stable.ConditionalAccessInsiderRiskLevels(insiderRiskLevel.(string)))
 	}
 
 	result.Applications = expandConditionalAccessApplications(applications)

--- a/internal/services/conditionalaccess/migrations/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/migrations/conditional_access_policy_resource.go
@@ -330,6 +330,11 @@ func ResourceConditionalAccessPolicyInstanceResourceV0() *pluginsdk.Resource {
 								Type: pluginsdk.TypeString,
 							},
 						},
+
+						"insider_risk_levels": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/internal/services/conditionalaccess/migrations/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/migrations/conditional_access_policy_resource.go
@@ -330,11 +330,6 @@ func ResourceConditionalAccessPolicyInstanceResourceV0() *pluginsdk.Resource {
 								Type: pluginsdk.TypeString,
 							},
 						},
-
-						"insider_risk_levels": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-						},
 					},
 				},
 			},

--- a/internal/services/conditionalaccess/named_location_resource_test.go
+++ b/internal/services/conditionalaccess/named_location_resource_test.go
@@ -251,13 +251,13 @@ func (NamedLocationResource) completeCountry(data acceptance.TestData) string {
 resource "azuread_named_location" "test" {
   display_name = "acctestNLC-%[1]d"
   country {
+    country_lookup_method = "clientIpAddress"
     countries_and_regions = [
       "GB",
       "US",
       "JP",
     ]
     include_unknown_countries_and_regions = true
-    country_lookup_method = "clientIpAddress"
   }
 }
 `, data.RandomInteger)
@@ -268,13 +268,13 @@ func (NamedLocationResource) completeCountryByGps(data acceptance.TestData) stri
 resource "azuread_named_location" "test" {
   display_name = "acctestNLC-%[1]d"
   country {
+    country_lookup_method = "authenticatorAppGps"
     countries_and_regions = [
       "GB",
       "US",
       "JP",
     ]
     include_unknown_countries_and_regions = true
-    country_lookup_method = "authenticatorAppGps"
   }
 }
 `, data.RandomInteger)


### PR DESCRIPTION
In `azuread_conditional_access_policy` add support for insider risk parameter `insider_risk_levels`. This allows specifying insider risk level with Conditional Access policies.

Graph API Documentation: https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessconditionset?view=graph-rest-1.0

Fix #1521 