### PR TITLE
azuread_conditional_access_policy: Authentication strength policies hard-coded values path

### DIFF
--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -245,7 +245,7 @@ The following arguments are supported:
 
 `grant_controls` block supports the following:
 
-* `authentication_strength_policy_id` - (Optional) ID of an Authentication Strength Policy to use in this policy.
+* `authentication_strength_policy_id` - (Optional) ID of an Authentication Strength Policy to use in this policy. When using a hard-coded ID, the UUID value should be prefixed with: `/policies/authenticationStrengthPolicies/`.
 * `built_in_controls` - (Optional) List of built-in controls required by the policy. Possible values are: `block`, `mfa`, `approvedApplication`, `compliantApplication`, `compliantDevice`, `domainJoinedDevice`, `passwordChange` or `unknownFutureValue`.
 * `custom_authentication_factors` - (Optional) List of custom controls IDs required by the policy.
 * `operator` - (Required) Defines the relationship of the grant controls. Possible values are: `AND`, `OR`.


### PR DESCRIPTION
Improve documentation to make the authentication strength policy better defined. Add a test case to authentication strength policy with hard-coded values, such as the _Phishing resistant MFA_ policy. This patch does not change the ID handling introduced in #1499 and keeps backwards compatibility, but the add test will fail if the behavior changes again.

Fix #1547