### PR TITLE
Fixing some import commands in docs

### DIFF
--- a/docs/resources/administrative_unit.md
+++ b/docs/resources/administrative_unit.md
@@ -58,5 +58,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Administrative units can be imported using their object ID, e.g.
 
 ```shell
-terraform import azuread_administrative_unit.example 00000000-0000-0000-0000-000000000000
+terraform import azuread_administrative_unit.example /directory/administrativeUnits/00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/administrative_unit_member.md
+++ b/docs/resources/administrative_unit_member.md
@@ -62,7 +62,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Administrative unit members can be imported using the object ID of the administrative unit and the object ID of the member, e.g.
 
 ```shell
-terraform import azuread_administrative_unit_member.example 00000000-0000-0000-0000-000000000000/member/11111111-1111-1111-1111-111111111111
+terraform import azuread_administrative_unit_member.example /directory/administrativeUnits/00000000-0000-0000-0000-000000000000/members/11111111-1111-1111-1111-111111111111
 ```
-
--> This ID format is unique to Terraform and is composed of the Administrative Unit Object ID and the target Member Object ID in the format `{AdministrativeUnitObjectID}/member/{MemberObjectID}`.

--- a/docs/resources/administrative_unit_role_member.md
+++ b/docs/resources/administrative_unit_role_member.md
@@ -64,7 +64,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Administrative unit role members can be imported using the object ID of the administrative unit and the unique ID of the role assignment, e.g.
 
 ```shell
-terraform import azuread_administrative_unit_role_member.example 00000000-0000-0000-0000-000000000000/roleMember/zX37MRLyF0uvE-xf2WH4B7x-6CPLfudNnxFGj800htpBXqkxW7bITqGb6Rj4kuTuS
+terraform import azuread_administrative_unit_role_member.example 
+/directory/administrativeUnits/00000000-0000-0000-0000-000000000000/scopedRoleMembers/zX37MRLyF0uvE-xf2WH4B7x-6CPLfudNnxFGj800htpBXqkxW7bITqGb6Rj4kuTuS
 ```
-
--> This ID format is unique to Terraform and is composed of the Administrative Unit Object ID and the role assignment ID in the format `{AdministrativeUnitObjectID}/roleMember/{RoleAssignmentID}`.

--- a/docs/resources/authentication_strength_policy.md
+++ b/docs/resources/authentication_strength_policy.md
@@ -83,5 +83,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Authentication Strength Policies can be imported using the `id`, e.g.
 
 ```shell
-terraform import azuread_authentication_strength_policy.my_policy 00000000-0000-0000-0000-000000000000
+terraform import azuread_authentication_strength_policy.my_policy /policies/authenticationStrengthPolicies/00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/conditional_access_policy.md
+++ b/docs/resources/conditional_access_policy.md
@@ -291,5 +291,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Conditional Access Policies can be imported using the `id`, e.g.
 
 ```shell
-terraform import azuread_conditional_access_policy.my_location 00000000-0000-0000-0000-000000000000
+terraform import azuread_conditional_access_policy.my_location /identity/conditionalAccess/policies/00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/named_location.md
+++ b/docs/resources/named_location.md
@@ -89,5 +89,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Named Locations can be imported using the `id`, e.g.
 
 ```shell
-terraform import azuread_named_location.my_location 00000000-0000-0000-0000-000000000000
+terraform import azuread_named_location.my_location /identity/conditionalAccess/namedLocations/00000000-0000-0000-0000-000000000000
 ```


### PR DESCRIPTION
My goal with this pull request is to improve the documentation for the terraform import commands for some resource types:

- administrative units
- administrative unit members
- administrative unit role member
- authentication strength policies
- conditional access policies
- named locations

As this is my first fork pull request, I hope this way is correct to do it. If not, please let me know so I can improve the pull request.