### PR TITLE
`applications`: URI parsing bugfixes

### DIFF
--- a/internal/helpers/tf/validation/uri.go
+++ b/internal/helpers/tf/validation/uri.go
@@ -36,15 +36,9 @@ func IsLogoutUrl(i interface{}, k string) (warnings []string, errors []error) {
 	return
 }
 
-func IsRedirectUriFunc(urnAllowed bool, allowAllSchemes bool) pluginsdk.SchemaValidateFunc {
+func IsRedirectUriFunc(urnAllowed bool) pluginsdk.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
-		// See https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-user-flows?pivots=b2c-custom-policy#register-the-proxyidentityexperienceframework-application
-		var allowedSchemes []string
-		if !allowAllSchemes {
-			allowedSchemes = []string{"http", "https", "ms-appx-web"}
-		}
-
-		warnings, errors = IsUriFunc(allowedSchemes, urnAllowed, true, true)(i, k)
+		warnings, errors = IsUriFunc([]string{}, urnAllowed, true, true)(i, k)
 		if len(errors) > 0 {
 			return
 		}

--- a/internal/services/applications/application_redirect_uris_resource.go
+++ b/internal/services/applications/application_redirect_uris_resource.go
@@ -65,7 +65,7 @@ func (r ApplicationRedirectUrisResource) Arguments() map[string]*pluginsdk.Schem
 			Required:    true,
 			Elem: &pluginsdk.Schema{
 				Type:         pluginsdk.TypeString,
-				ValidateFunc: validation.IsRedirectUriFunc(true, true),
+				ValidateFunc: validation.IsRedirectUriFunc(true),
 			},
 		},
 	}

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -471,7 +471,7 @@ func applicationResource() *pluginsdk.Resource {
 							MaxItems:    256,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.IsRedirectUriFunc(true, true),
+								ValidateFunc: validation.IsRedirectUriFunc(true),
 							},
 						},
 					},
@@ -543,7 +543,7 @@ func applicationResource() *pluginsdk.Resource {
 							MaxItems:    256,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.IsRedirectUriFunc(false, false),
+								ValidateFunc: validation.IsRedirectUriFunc(false),
 							},
 						},
 					},
@@ -611,7 +611,7 @@ func applicationResource() *pluginsdk.Resource {
 							MaxItems:    256,
 							Elem: &pluginsdk.Schema{
 								Type:         pluginsdk.TypeString,
-								ValidateFunc: validation.IsRedirectUriFunc(true, false),
+								ValidateFunc: validation.IsRedirectUriFunc(true),
 							},
 						},
 

--- a/internal/services/applications/migrations/application_identifier_uri_resource.go
+++ b/internal/services/applications/migrations/application_identifier_uri_resource.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package migrations
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications/parse"
+)
+
+type ResourceApplicationIdentifierUriStateUpgradeV0 struct{}
+
+func (ResourceApplicationIdentifierUriStateUpgradeV0) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"application_object_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"key_id": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"value": {
+			Type:      pluginsdk.TypeString,
+			Required:  true,
+			ForceNew:  true,
+			Sensitive: true,
+		},
+
+		"start_date": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"end_date": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"end_date_relative"},
+		},
+
+		"end_date_relative": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ExactlyOneOf: []string{"end_date"},
+		},
+	}
+}
+
+func (ResourceApplicationIdentifierUriStateUpgradeV0) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+		log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+		id, err := parse.ParseIdentifierUriID(rawState["id"].(string))
+		if err != nil {
+			return rawState, fmt.Errorf("generating new ID: %s", err)
+		}
+
+		uriFromIdSegment, err := base64.StdEncoding.DecodeString(id.IdentifierUri)
+		if err != nil {
+			return rawState, fmt.Errorf("failed to decode identifierUri from resource ID: %+v", err)
+		}
+
+		id.IdentifierUri = base64.URLEncoding.EncodeToString(uriFromIdSegment)
+		rawState["id"] = id.String()
+
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
* Fix encoding of `application_identifier_uri` IDs to avoid injecting forward slashes into the base64 slug (closes: #1401)
* Loosen URI schema restrictions for application redirect URIs as the number of supported schemes has expanded and their documentation is not consolidated, making it difficult for the provider to keep up (closes: #1600)

### Changelog

* `azuread_application` - allow more URL schemes for `redirect_uris` properties
* `azuread_application_identifier_uri` - fix an encoding bug that could generate invalid resource IDs
* `azuread_application_redirect_uris` - allow more URL schemes for `redirect_uris` properties
