### PR TITLE
Fix azuread_privileged_access_group_eligibility_schedule resource update functionality 

### DIFF
--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
@@ -228,7 +228,7 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Update() sdk.ResourceF
 				AccessId:      stable.PrivilegedAccessGroupRelationships(resourceId.Relationship),
 				PrincipalId:   nullable.Value(model.PrincipalId),
 				GroupId:       nullable.Value(resourceId.GroupId),
-				Action:        pointer.To(stable.ScheduleRequestActions_AdminAssign),
+				Action:        pointer.To(stable.ScheduleRequestActions_AdminUpdate),
 				Justification: nullable.NoZero(model.Justification),
 				ScheduleInfo:  schedule,
 			}

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -34,6 +34,9 @@ func TestPrivilegedAccessGroupEligibilitySchedule_member(t *testing.T) {
 			Config: r.member(data, endTime),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				// There is a minimum life of 5 minutes for a schedule request to exist.
+				// Attempting to delete the request within this time frame will result in
+				// a 400 error on destroy, which we can't trap.
 				helpers.SleepCheck(5*time.Minute+15*time.Second),
 			),
 		},

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -34,9 +34,6 @@ func TestPrivilegedAccessGroupEligibilitySchedule_member(t *testing.T) {
 			Config: r.member(data, endTime),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				// There is a minimum life of 5 minutes for a schedule request to exist.
-				// Attempting to delete the request within this time frame will result in
-				// a 400 error on destroy, which we can't trap.
 				helpers.SleepCheck(5*time.Minute+15*time.Second),
 			),
 		},
@@ -50,7 +47,18 @@ func TestPrivilegedAccessGroupEligibilitySchedule_owner(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.owner(data),
+			Config: r.owner(data, "P30D", "required"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				// There is a minimum life of 5 minutes for a schedule request to exist.
+				// Attempting to delete the request within this time frame will result in
+				// a 400 error on destroy, which we can't trap.
+				helpers.SleepCheck(5*time.Minute+15*time.Second),
+			),
+		},
+		{
+
+			Config: r.owner(data, "P45D", "updated justification"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				// There is a minimum life of 5 minutes for a schedule request to exist.
@@ -114,7 +122,7 @@ resource "azuread_privileged_access_group_eligibility_schedule" "member" {
 `, data.RandomString, data.RandomPassword, endTime.Format(time.RFC3339))
 }
 
-func (PrivilegedAccessGroupEligibilityScheduleResource) owner(data acceptance.TestData) string {
+func (PrivilegedAccessGroupEligibilityScheduleResource) owner(data acceptance.TestData, duration, justification string) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -146,13 +154,12 @@ resource "azuread_user" "eligibile_owner" {
   password            = "%[2]s"
 }
 
-
 resource "azuread_privileged_access_group_eligibility_schedule" "owner" {
   group_id        = azuread_group.pam.id
   principal_id    = azuread_user.eligibile_owner.id
   assignment_type = "owner"
-  duration        = "P30D"
-  justification   = "required"
+  duration        = "%[3]s"
+  justification   = "%[4]s"
 }
-`, data.RandomString, data.RandomPassword)
+`, data.RandomString, data.RandomPassword, duration, justification)
 }


### PR DESCRIPTION
My goal with this pull request is to improve the azuread_privileged_access_group_eligibility_schedule resource. 

Updating the 'Update' functionality to use the `adminUpdate` instead of `adminAssign` [As per Microsoft graph documentation ](https://learn.microsoft.com/en-us/graph/api/privilegedaccessgroup-post-eligibilityschedulerequests?view=graph-rest-1.0&tabs=http#request-body)

> `adminUpdate`: For administrators to change existing eligible assignments. instead of `adminAssign`: For administrators to assign group membership or ownership eligibility to principals.

I found this issue in relation to this problem: https://github.com/hashicorp/terraform-provider-azuread/issues/1412

As this is my first fork pull request, I hope this way is correct to do it. If not, please let me know so I can improve the pull request.

