### PR TITLE
New Resource: `azuread_group_without_members`

### DIFF
--- a/.github/labeler-issue-triage.yaml
+++ b/.github/labeler-issue-triage.yaml
@@ -25,7 +25,7 @@ feature/domains:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azuread_domains((.|\n)*)###'
 
 feature/groups:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azuread_(group\W+|group_member\W+|groups\W+)((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azuread_(group\W+|group_member\W+|group_without_members\W+|groups\W+)((.|\n)*)###'
 
 feature/identity-governance:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azuread_(access_package|privileged_access_group_)((.|\n)*)###'

--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -182,9 +182,9 @@ func groupWithoutMembersResource() *pluginsdk.Resource {
 				Type:        pluginsdk.TypeSet,
 				Optional:    true,
 				Computed:    true,
-				MinItems:    1,
 				MaxItems:    100,
 				Set:         pluginsdk.HashString,
+				ConfigMode:  pluginsdk.SchemaConfigModeAttr,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: validation.IsUUID,

--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -1,0 +1,1308 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package groups
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
+	administrativeunitmemberBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/directory/beta/administrativeunitmember"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/directoryobjects/stable/directoryobject"
+	groupBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/group"
+	memberofBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/memberof"
+	ownerBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/owner"
+	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/consistency"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/validation"
+)
+
+func groupWithoutMembersResource() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		CreateContext: groupWithoutMembersResourceCreate,
+		ReadContext:   groupWithoutMembersResourceReadFunc(false),
+		UpdateContext: groupWithoutMembersResourceUpdate,
+		DeleteContext: groupWithoutMembersResourceDelete,
+
+		CustomizeDiff: groupWithoutMembersResourceCustomizeDiff,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			if _, errs := beta.ValidateGroupID(id, "id"); len(errs) > 0 {
+				out := ""
+				for _, err := range errs {
+					out += err.Error()
+				}
+				return fmt.Errorf(out)
+			}
+			return nil
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"display_name": {
+				Description:  "The display name for the group",
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"administrative_unit_ids": {
+				Description: "The administrative unit IDs in which the group should be. If empty, the group will be created at the tenant level.",
+				Type:        pluginsdk.TypeSet,
+				Optional:    true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.IsUUID,
+				},
+			},
+
+			"assignable_to_role": {
+				Description: "Indicates whether this group can be assigned to an Azure Active Directory role. This property can only be `true` for security-enabled groups.",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
+			"auto_subscribe_new_members": {
+				Description: "Indicates whether new members added to the group will be auto-subscribed to receive email notifications.",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+
+			"behaviors": {
+				Description: "The group behaviours for a Microsoft 365 group",
+				Type:        pluginsdk.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(possibleValuesForGroupResourceBehaviorOptions, false),
+				},
+			},
+
+			"description": {
+				Description: "The description for the group",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"dynamic_membership": {
+				Description: "An optional block to configure dynamic membership for the group.",
+				Type:        pluginsdk.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Required: true,
+						},
+
+						"rule": {
+							Description:  "Rule to determine members for a dynamic group. Required when `group_types` contains 'DynamicMembership'",
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(0, 3072),
+						},
+					},
+				},
+			},
+
+			"external_senders_allowed": {
+				Description: "Indicates whether people external to the organization can send messages to the group.",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+
+			"hide_from_address_lists": {
+				Description: "Indicates whether the group is displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups.",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+
+			"hide_from_outlook_clients": {
+				Description: "Indicates whether the group is displayed in Outlook clients, such as Outlook for Windows and Outlook on the web.",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
+
+			"mail_enabled": {
+				Description:  "Whether the group is a mail enabled, with a shared group mailbox. At least one of `mail_enabled` or `security_enabled` must be specified. A group can be mail enabled _and_ security enabled",
+				Type:         pluginsdk.TypeBool,
+				Optional:     true,
+				AtLeastOneOf: []string{"mail_enabled", "security_enabled"},
+			},
+
+			"mail_nickname": {
+				Description:      "The mail alias for the group, unique in the organisation",
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validation.MailNickname,
+			},
+
+			"onpremises_group_type": {
+				Description:  "Indicates the target on-premise group type the group will be written back as",
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(possibleValuesForOnPremisesGroupType, false),
+			},
+
+			"owners": {
+				Description: "A set of owners who own this group. Supported object types are Users or Service Principals",
+				Type:        pluginsdk.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				MinItems:    1,
+				MaxItems:    100,
+				Set:         pluginsdk.HashString,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.IsUUID,
+				},
+			},
+
+			"prevent_duplicate_names": {
+				Description: "If `true`, will return an error if an existing group is found with the same name",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
+
+			"provisioning_options": {
+				Description: "The group provisioning options for a Microsoft 365 group",
+				Type:        pluginsdk.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(possibleValuesForGroupResourceProvisioningOptions, false),
+				},
+			},
+
+			"security_enabled": {
+				Description:  "Whether the group is a security group for controlling access to in-app resources. At least one of `security_enabled` or `mail_enabled` must be specified. A group can be security enabled _and_ mail enabled",
+				Type:         pluginsdk.TypeBool,
+				Optional:     true,
+				AtLeastOneOf: []string{"mail_enabled", "security_enabled"},
+			},
+
+			"theme": {
+				Description:  "The colour theme for a Microsoft 365 group",
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(possibleValuesForGroupTheme, false),
+			},
+
+			"types": {
+				Description: "A set of group types to configure for the group. `Unified` specifies a Microsoft 365 group. Required when `mail_enabled` is true",
+				Type:        pluginsdk.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice(possibleValuesForGroupType, false),
+				},
+			},
+
+			"visibility": {
+				Description:  "Specifies the group join policy and group content visibility",
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(possibleValuesForGroupVisibility, false),
+			},
+
+			"writeback_enabled": {
+				Description: "Whether this group should be synced from Azure AD to the on-premises directory when Azure AD Connect is used",
+				Type:        pluginsdk.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
+
+			"mail": {
+				Description: "The SMTP address for the group",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"object_id": {
+				Description: "The object ID of the group",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"onpremises_domain_name": {
+				Description: "The on-premises FQDN, also called dnsDomainName, synchronized from the on-premises directory when Azure AD Connect is used",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"onpremises_netbios_name": {
+				Description: "The on-premises NetBIOS name, synchronized from the on-premises directory when Azure AD Connect is used",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"onpremises_sam_account_name": {
+				Description: "The on-premises SAM account name, synchronized from the on-premises directory when Azure AD Connect is used",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"onpremises_security_identifier": {
+				Description: "The on-premises security identifier (SID), synchronized from the on-premises directory when Azure AD Connect is used",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
+
+			"onpremises_sync_enabled": {
+				Description: "Whether this group is synchronized from an on-premises directory (true), no longer synchronized (false), or has never been synchronized (null)",
+				Type:        pluginsdk.TypeBool,
+				Computed:    true,
+			},
+
+			"preferred_language": {
+				Description: "The preferred language for a Microsoft 365 group, in ISO 639-1 notation",
+				Type:        pluginsdk.TypeString,
+				Computed:    true, // API always returns "preferredLanguage should not be set"
+			},
+
+			"proxy_addresses": {
+				Description: "Email addresses for the group that direct to the same group mailbox",
+				Type:        pluginsdk.TypeList,
+				Computed:    true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func groupWithoutMembersResourceCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
+	client := meta.(*clients.Client).Groups.GroupClientBeta
+
+	// Check for duplicate names
+	oldDisplayName, newDisplayName := diff.GetChange("display_name")
+	if pluginsdk.ValueIsNotEmptyOrUnknown(diff.Id()) && diff.Get("prevent_duplicate_names").(bool) && pluginsdk.ValueIsNotEmptyOrUnknown(newDisplayName) &&
+		(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
+		result, err := groupFindByName(ctx, client, newDisplayName.(string))
+		if err != nil {
+			return fmt.Errorf("could not check for existing group(s): %+v", err)
+		}
+		if result != nil && len(*result) > 0 {
+			for _, existingGroup := range *result {
+				if existingGroup.Id == nil {
+					return fmt.Errorf("API error: group returned with nil object ID during duplicate name check")
+				}
+				if diff.Id() == "" || diff.Id() == *existingGroup.Id {
+					return tf.ImportAsDuplicateError("azuread_group", *existingGroup.Id, newDisplayName.(string))
+				}
+			}
+		}
+	}
+
+	mailEnabled := diff.Get("mail_enabled").(bool)
+	securityEnabled := diff.Get("security_enabled").(bool)
+	groupTypes := make([]string, 0)
+	for _, v := range diff.Get("types").(*pluginsdk.Set).List() {
+		groupTypes = append(groupTypes, v.(string))
+	}
+
+	if slices.Contains(groupTypes, GroupTypeDynamicMembership) && diff.Get("dynamic_membership.#").(int) == 0 {
+		return fmt.Errorf("`dynamic_membership` must be specified when `types` contains %q", GroupTypeDynamicMembership)
+	}
+
+	if mailEnabled && !slices.Contains(groupTypes, GroupTypeUnified) {
+		return fmt.Errorf("`types` must contain %q for mail-enabled groups", GroupTypeUnified)
+	}
+
+	if !mailEnabled && slices.Contains(groupTypes, GroupTypeUnified) {
+		return fmt.Errorf("`mail_enabled` must be true for unified groups")
+	}
+
+	if mailNickname := diff.Get("mail_nickname").(string); mailEnabled && mailNickname == "" {
+		return fmt.Errorf("`mail_nickname` is required for mail-enabled groups")
+	}
+
+	if diff.Get("assignable_to_role").(bool) && !securityEnabled {
+		return fmt.Errorf("`assignable_to_role` can only be `true` for security-enabled groups")
+	}
+
+	visibilityOld, visibilityNew := diff.GetChange("visibility")
+
+	if !slices.Contains(groupTypes, GroupTypeUnified) {
+		if autoSubscribeNewMembers, ok := diff.GetOk("auto_subscribe_new_members"); ok && autoSubscribeNewMembers.(bool) {
+			return fmt.Errorf("`auto_subscribe_new_members` is only supported for unified groups")
+		}
+
+		if behaviors, ok := diff.GetOk("behaviors"); ok && len(behaviors.(*pluginsdk.Set).List()) > 0 {
+			return fmt.Errorf("`behaviors` is only supported for unified groups")
+		}
+
+		if allowExternalSenders, ok := diff.GetOk("external_senders_allowed"); ok && allowExternalSenders.(bool) {
+			return fmt.Errorf("`external_senders_allowed` is only supported for unified groups")
+		}
+
+		if hideFromAddressLists, ok := diff.GetOk("hide_from_address_lists"); ok && hideFromAddressLists.(bool) {
+			return fmt.Errorf("`hide_from_address_lists` is only supported for unified groups")
+		}
+
+		if hideFromOutlookClients, ok := diff.GetOk("hide_from_outlook_clients"); ok && hideFromOutlookClients.(bool) {
+			return fmt.Errorf("`hide_from_outlook_clients` is only supported for unified groups")
+		}
+
+		if provisioning, ok := diff.GetOk("provisioning_options"); ok && len(provisioning.(*pluginsdk.Set).List()) > 0 {
+			return fmt.Errorf("`provisioning_options` is only supported for unified groups")
+		}
+
+		if theme := diff.Get("theme"); theme.(string) != "" {
+			return fmt.Errorf("`theme` is only supported for unified groups")
+		}
+
+		if visibilityNew.(string) == GroupVisibilityHiddenMembership {
+			return fmt.Errorf("`visibility` can only be %q for unified groups", GroupVisibilityHiddenMembership)
+		}
+	}
+
+	if (visibilityOld.(string) == GroupVisibilityPrivate || visibilityOld.(string) == GroupVisibilityPublic) &&
+		visibilityNew.(string) == GroupVisibilityHiddenMembership {
+		diff.ForceNew("visibility")
+	}
+
+	return nil
+}
+
+func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	client := meta.(*clients.Client).Groups.GroupClientBeta
+	ownerClient := meta.(*clients.Client).Groups.GroupOwnerClientBeta
+	directoryObjectClient := meta.(*clients.Client).Groups.DirectoryObjectClient
+	administrativeUnitMemberClient := meta.(*clients.Client).Groups.AdministrativeUnitMemberClientBeta
+
+	callerId := meta.(*clients.Client).ObjectID
+	callerODataId := fmt.Sprintf("%s%s", client.Client.BaseUri, beta.NewDirectoryObjectID(callerId).ID())
+
+	displayName := d.Get("display_name").(string)
+
+	// Perform this check at apply time to catch any duplicate names created during the same apply
+	if d.Get("prevent_duplicate_names").(bool) {
+		result, err := groupFindByName(ctx, client, displayName)
+		if err != nil {
+			return tf.ErrorDiagPathF(err, "name", "Could not check for existing groups(s)")
+		}
+		if result != nil && len(*result) > 0 {
+			existingGroup := (*result)[0]
+			if existingGroup.Id == nil {
+				return tf.ErrorDiagF(errors.New("API returned group with nil object ID during duplicate name check"), "Bad API response")
+			}
+			return tf.ImportAsDuplicateDiag("azuread_group", *existingGroup.Id, displayName)
+		}
+	}
+
+	groupTypes := make([]string, 0)
+	for _, v := range d.Get("types").(*pluginsdk.Set).List() {
+		groupTypes = append(groupTypes, v.(string))
+	}
+
+	mailEnabled := d.Get("mail_enabled").(bool)
+	securityEnabled := d.Get("security_enabled").(bool)
+
+	// Mimic the portal and generate a random mailNickname for security groups
+	mailNickname := groupDefaultMailNickname()
+	if v, ok := d.GetOk("mail_nickname"); ok && v.(string) != "" {
+		mailNickname = v.(string)
+	}
+
+	behaviorOptions := make([]string, 0)
+	for _, v := range d.Get("behaviors").(*pluginsdk.Set).List() {
+		behaviorOptions = append(behaviorOptions, v.(string))
+	}
+
+	provisioningOptions := make([]string, 0)
+	for _, v := range d.Get("provisioning_options").(*pluginsdk.Set).List() {
+		provisioningOptions = append(provisioningOptions, v.(string))
+	}
+
+	var writebackConfiguration *beta.GroupWritebackConfiguration
+	if v := d.Get("writeback_enabled").(bool); v {
+		writebackConfiguration = &beta.GroupWritebackConfiguration{
+			IsEnabled:              nullable.Value(d.Get("writeback_enabled").(bool)),
+			OmitDiscriminatedValue: true,
+		}
+		if onPremisesGroupType := d.Get("onpremises_group_type").(string); onPremisesGroupType != "" {
+			writebackConfiguration.OnPremisesGroupType = nullable.Value(onPremisesGroupType)
+		}
+	}
+
+	description := d.Get("description").(string)
+
+	properties := beta.Group{
+		Description:                 nullable.NoZero(description),
+		DisplayName:                 nullable.Value(displayName),
+		GroupTypes:                  &groupTypes,
+		IsAssignableToRole:          nullable.Value(d.Get("assignable_to_role").(bool)),
+		MailEnabled:                 nullable.Value(mailEnabled),
+		MailNickname:                nullable.Value(mailNickname),
+		MembershipRule:              nullable.NoZero(""),
+		ResourceBehaviorOptions:     &behaviorOptions,
+		ResourceProvisioningOptions: &provisioningOptions,
+		SecurityEnabled:             nullable.Value(securityEnabled),
+		WritebackConfiguration:      writebackConfiguration,
+	}
+
+	if v, ok := d.GetOk("dynamic_membership"); ok && len(v.([]interface{})) > 0 {
+		if d.Get("dynamic_membership.0.enabled").(bool) {
+			properties.MembershipRuleProcessingState = nullable.Value("On")
+		} else {
+			properties.MembershipRuleProcessingState = nullable.Value("Paused")
+		}
+
+		properties.MembershipRule = nullable.Value(d.Get("dynamic_membership.0.rule").(string))
+	}
+
+	if theme := d.Get("theme").(string); theme != "" {
+		properties.Theme = nullable.Value(theme)
+	}
+
+	if visibility := d.Get("visibility").(string); visibility != "" {
+		properties.Visibility = nullable.Value(visibility)
+	}
+
+	// Sort the owners into two slices, the first containing up to 20 and the rest overflowing to the second slice
+	var ownersFirst20 []string
+	var ownersExtra []beta.ReferenceCreate
+
+	// Retrieve and set the initial owners, which can be up to 20 in total when creating the group.
+	// First look for the calling principal, then prefer users, followed by service principals, and lastly groups,
+	// to try and avoid ownership-related API validation errors for Microsoft 365 groups, which require that a User
+	// be an explicit owner for new groups.
+	if v, ok := d.GetOk("owners"); ok {
+		owners := v.(*pluginsdk.Set).List()
+		ownerCount := 0
+
+		// First look for the calling principal in the specified owners; when specified it should always be included in
+		// the initial owners to avoid orphaning a group when the caller doesn't have the Groups.ReadWrite.All scope.
+		for _, ownerId := range owners {
+			if strings.EqualFold(ownerId.(string), callerId) {
+				ownersFirst20 = append(ownersFirst20, callerODataId)
+				ownerCount++
+			}
+		}
+
+		// Then look for users, and finally service principals
+		for _, t := range []stable.DirectoryObject{stable.User{}, stable.ServicePrincipal{}, stable.Group{}} {
+			for _, ownerIdRaw := range owners {
+				ownerId := ownerIdRaw.(string)
+
+				// We already added the caller above
+				if strings.EqualFold(ownerId, callerId) {
+					continue
+				}
+
+				resp, err := directoryObjectClient.GetDirectoryObject(ctx, stable.NewDirectoryObjectID(ownerId), directoryobject.DefaultGetDirectoryObjectOperationOptions())
+				if err != nil {
+					return tf.ErrorDiagF(err, "Could not retrieve owner principal object %q", ownerId)
+				}
+
+				ownerObject := resp.Model
+				if ownerObject == nil {
+					return tf.ErrorDiagF(errors.New("ownerObject model was nil"), "Could not retrieve owner principal object %q", ownerId)
+				}
+
+				if reflect.TypeOf(ownerObject) == reflect.TypeOf(t) {
+					if ownerCount < 20 {
+						ownersFirst20 = append(ownersFirst20, fmt.Sprintf("%s%s", client.Client.BaseUri, beta.NewDirectoryObjectID(ownerId).ID()))
+					} else {
+						ownerRef := beta.ReferenceCreate{
+							ODataId: pointer.To(client.Client.BaseUri + beta.NewDirectoryObjectID(ownerId).ID()),
+						}
+						ownersExtra = append(ownersExtra, ownerRef)
+					}
+					ownerCount++
+				}
+			}
+		}
+	}
+
+	if len(ownersFirst20) == 0 {
+		// The calling principal is the default owner if no others are specified. This is the default API behaviour, so
+		// we're being explicit about this in order to minimise confusion and avoid inconsistent API behaviours.
+		ownersFirst20 = []string{fmt.Sprintf("%s%s", client.Client.BaseUri, beta.NewDirectoryObjectID(callerId).ID())}
+	}
+
+	// Set the initial owners, which either be the calling principal, or up to 20 of the owners specified in configuration
+	properties.Owners_ODataBind = &ownersFirst20
+
+	var groupObjectId string
+
+	if v, ok := d.GetOk("administrative_unit_ids"); ok {
+		administrativeUnitIds := tf.ExpandStringSlice(v.(*pluginsdk.Set).List())
+
+		for i, auId := range administrativeUnitIds {
+			administrativeUnitId := beta.NewDirectoryAdministrativeUnitID(auId)
+
+			// Create the group in the first administrative unit, as this requires fewer permissions than creating it at tenant level
+			if i == 0 {
+				resp, err := administrativeUnitMemberClient.CreateAdministrativeUnitMember(ctx, administrativeUnitId, &properties, administrativeunitmemberBeta.DefaultCreateAdministrativeUnitMemberOperationOptions())
+				if err != nil {
+					if response.WasBadRequest(resp.HttpResponse) && regexp.MustCompile(groupDuplicateValueError).MatchString(err.Error()) {
+						// Retry the group creation, without the calling principal as owner
+						ownersWithoutCallingPrincipal := make([]string, 0)
+						for _, o := range *properties.Owners_ODataBind {
+							if o != callerODataId {
+								ownersWithoutCallingPrincipal = append(ownersWithoutCallingPrincipal, o)
+							}
+						}
+
+						// No point in retrying if the caller wasn't specified as an owner
+						if len(ownersWithoutCallingPrincipal) == len(*properties.Owners) {
+							log.Printf("[DEBUG] Not retrying group creation for %q within %s as owner was not specified", displayName, administrativeUnitId)
+							return tf.ErrorDiagF(err, "Creating group in %s", administrativeUnitId)
+						}
+
+						// If the API is refusing the calling principal as owner, it will typically automatically append the caller in the background,
+						// and subsequent GETs for the group will include the calling principal as owner, as if it were specified when creating.
+						log.Printf("[DEBUG] Retrying group creation for %q within %s without calling principal as owner", displayName, administrativeUnitId)
+						if len(ownersWithoutCallingPrincipal) == 0 {
+							properties.Owners_ODataBind = nil
+						} else {
+							properties.Owners_ODataBind = &ownersWithoutCallingPrincipal
+						}
+
+						resp, err = administrativeUnitMemberClient.CreateAdministrativeUnitMember(ctx, administrativeUnitId, &properties, administrativeunitmemberBeta.DefaultCreateAdministrativeUnitMemberOperationOptions())
+						if err != nil {
+							return tf.ErrorDiagF(err, "Creating group in %s", administrativeUnitId)
+						}
+					} else {
+						return tf.ErrorDiagF(err, "Creating group in %s", administrativeUnitId)
+					}
+				}
+
+				if resp.Model == nil {
+					return tf.ErrorDiagF(errors.New("returned model was nil"), "Creating group in %s", administrativeUnitId)
+				}
+
+				// Obtain the new group ID
+				newGroup, ok := resp.Model.(beta.Group)
+				if !ok {
+					return tf.ErrorDiagF(errors.New("returned model was not a group"), "Creating group in %s", administrativeUnitId)
+				}
+				groupObjectId = pointer.From(newGroup.Id)
+
+			} else {
+				ref := beta.ReferenceCreate{
+					ODataId: pointer.To(fmt.Sprintf("%s%s", client.Client.BaseUri, beta.NewDirectoryObjectID(groupObjectId).ID())),
+				}
+				if _, err := administrativeUnitMemberClient.AddAdministrativeUnitMemberRef(ctx, administrativeUnitId, ref, administrativeunitmemberBeta.DefaultAddAdministrativeUnitMemberRefOperationOptions()); err != nil {
+					return tf.ErrorDiagF(err, "Adding group %q to %s", groupObjectId, administrativeUnitId)
+				}
+			}
+		}
+
+	} else {
+		options := groupBeta.CreateGroupOperationOptions{
+			RetryFunc: func(resp *http.Response, o *odata.OData) (bool, error) {
+				if response.WasNotFound(resp) {
+					return true, nil
+				} else if response.WasBadRequest(resp) && o != nil && o.Error != nil {
+					return o.Error.Match("One or more property values specified are invalid") ||
+						o.Error.Match("does not exist or one of its queried reference-property objects are not present"), nil
+				}
+				return false, nil
+			},
+		}
+
+		// Create the group at the tenant level
+		resp, err := client.CreateGroup(ctx, properties, options)
+		if err != nil {
+			if response.WasBadRequest(resp.HttpResponse) && regexp.MustCompile(groupDuplicateValueError).MatchString(err.Error()) {
+				// Retry the group creation, without the calling principal as owner
+				ownersWithoutCallingPrincipal := make([]string, 0)
+				for _, o := range *properties.Owners_ODataBind {
+					if o != callerODataId {
+						ownersWithoutCallingPrincipal = append(ownersWithoutCallingPrincipal, o)
+					}
+				}
+
+				// No point in retrying if the caller wasn't specified as an owner
+				if len(ownersWithoutCallingPrincipal) == len(pointer.From(properties.Owners)) {
+					log.Printf("[DEBUG] Not retrying group creation for %q as owner was not specified", displayName)
+					return tf.ErrorDiagF(err, "Creating group %q", displayName)
+				}
+
+				// If the API is refusing the calling principal as owner, it will typically automatically append the caller in the background,
+				// and subsequent GETs for the group will include the calling principal as owner, as if it were specified when creating.
+				log.Printf("[DEBUG] Retrying group creation for %q without calling principal as owner", displayName)
+				if len(ownersWithoutCallingPrincipal) == 0 {
+					properties.Owners_ODataBind = nil
+				} else {
+					properties.Owners_ODataBind = &ownersWithoutCallingPrincipal
+				}
+
+				resp, err = client.CreateGroup(ctx, properties, groupBeta.DefaultCreateGroupOperationOptions())
+				if err != nil {
+					return tf.ErrorDiagF(err, "Creating group %q", displayName)
+				}
+			} else {
+				return tf.ErrorDiagF(err, "Creating group %q", displayName)
+			}
+		}
+
+		if resp.Model == nil {
+			return tf.ErrorDiagF(errors.New("returned model was nil"), "Creating group %q", displayName)
+		}
+
+		groupObjectId = pointer.From(resp.Model.Id)
+	}
+
+	if groupObjectId == "" {
+		return tf.ErrorDiagF(errors.New("unable to obtain group object ID"), "Creating group %q", displayName)
+	}
+
+	id := beta.NewGroupID(groupObjectId)
+	d.SetId(id.ID())
+
+	// Attempt to patch the newly created group and set the display name, which will tell us whether it exists yet, then set it back to the desired value.
+	// The SDK handles retries for us here in the event of 404, 429 or 5xx, then returns after giving up.
+	uid, err := uuid.GenerateUUID()
+	if err != nil {
+		return tf.ErrorDiagF(err, "Failed to generate a UUID")
+	}
+	tempDisplayName := fmt.Sprintf("TERRAFORM_UPDATE_%s", uid)
+	for _, displayNameToSet := range []string{tempDisplayName, displayName} {
+		updateOptions := groupBeta.UpdateGroupOperationOptions{
+			RetryFunc: func(resp *http.Response, o *odata.OData) (bool, error) {
+				return response.WasNotFound(resp), nil
+			},
+		}
+		resp, err := client.UpdateGroup(ctx, id, beta.Group{
+			DisplayName: nullable.Value(displayNameToSet),
+		}, updateOptions)
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return tf.ErrorDiagF(err, "Timed out whilst waiting for new %s to be replicated in Azure AD", id)
+			}
+			return tf.ErrorDiagF(err, "Failed to patch %s after creating", id)
+		}
+	}
+
+	// Wait for DisplayName to be updated
+	if err := consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+		resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return pointer.To(false), nil
+			}
+			return nil, err
+		}
+		group := resp.Model
+		return pointer.To(group != nil && group.DisplayName.GetOrZero() == displayName), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for update of `display_name` for %s", id)
+	}
+
+	if slices.Contains(groupTypes, GroupTypeUnified) {
+		// Newly created Unified groups now get a description added out-of-band, so we'll wait a couple of minutes to see if this appears and then clear it
+		// See https://github.com/microsoftgraph/msgraph-metadata/issues/331
+		if description == "" {
+			// Ignoring the error result here because the description might not be updated out of band, in which case we skip over this
+			if updated, _ := consistency.WaitForUpdateWithTimeout(ctx, 2*time.Minute, func(ctx context.Context) (*bool, error) {
+				resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
+				if err != nil {
+					return nil, err
+				}
+				group := resp.Model
+				return pointer.To(group != nil && !group.Description.IsNull() && group.Description.GetOrZero() != ""), nil
+			}); updated {
+				updateOptions := groupBeta.UpdateGroupOperationOptions{
+					RetryFunc: func(resp *http.Response, o *odata.OData) (bool, error) {
+						return response.WasNotFound(resp), nil
+					},
+				}
+				resp, err := client.UpdateGroup(ctx, id, beta.Group{
+					Description: nullable.NoZero(""),
+				}, updateOptions)
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return tf.ErrorDiagF(err, "Timed out whilst waiting for new %s to be replicated in Azure AD", id)
+					}
+					return tf.ErrorDiagF(err, "Failed to patch `description` for %s after creating", id)
+				}
+
+				// Wait for Description to be removed
+				if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+					resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
+					if err != nil {
+						return nil, err
+					}
+					group := resp.Model
+					return pointer.To(group != nil && group.Description.IsNull()), nil
+				}); err != nil {
+					return tf.ErrorDiagF(err, "Waiting to remove `description` for %s", id)
+				}
+			}
+		}
+
+		// The following unified group properties in this block only support delegated authentication.
+		// Application-authenticated requests will return a 4xx error, so we only
+		// set these when explicitly configured, as they each default to false anyway
+		// See https://docs.microsoft.com/en-us/graph/known-issues#groups
+
+		// AllowExternalSenders can only be set in its own PATCH request; including other properties returns a 400
+		if allowExternalSenders, ok := d.GetOkExists("external_senders_allowed"); ok { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, id, beta.Group{
+				AllowExternalSenders: nullable.Value(allowExternalSenders.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `external_senders_allowed` for %s", id)
+			}
+
+			// Wait for AllowExternalSenders to be updated
+			if err := consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.AllowExternalSenders.GetOrZero() == allowExternalSenders), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `external_senders_allowed` for %s", id)
+			}
+		}
+
+		// AutoSubscribeNewMembers can only be set in its own PATCH request; including other properties returns a 400
+		if autoSubscribeNewMembers, ok := d.GetOkExists("auto_subscribe_new_members"); ok { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, id, beta.Group{
+				AutoSubscribeNewMembers: nullable.Value(autoSubscribeNewMembers.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `auto_subscribe_new_members` for %s", id)
+			}
+
+			// Wait for AutoSubscribeNewMembers to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.AutoSubscribeNewMembers.GetOrZero() == autoSubscribeNewMembers), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `auto_subscribe_new_members` for %s", id)
+			}
+		}
+
+		// HideFromAddressLists can only be set in its own PATCH request; including other properties returns a 400
+		if hideFromAddressList, ok := d.GetOkExists("hide_from_address_lists"); ok { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, id, beta.Group{
+				HideFromAddressLists: nullable.Value(hideFromAddressList.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `hide_from_address_lists` for %s", id)
+			}
+
+			// Wait for HideFromAddressLists to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.HideFromAddressLists.GetOrZero() == hideFromAddressList), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `hide_from_address_lists` for %s", id)
+			}
+		}
+
+		// HideFromOutlookClients can only be set in its own PATCH request; including other properties returns a 400
+		if hideFromOutlookClients, ok := d.GetOkExists("hide_from_outlook_clients"); ok { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, id, beta.Group{
+				HideFromOutlookClients: nullable.Value(hideFromOutlookClients.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `hide_from_outlook_clients` for %s", id)
+			}
+
+			// Wait for HideFromOutlookClients to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.HideFromOutlookClients.GetOrZero() == hideFromOutlookClients), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `hide_from_outlook_clients` for %s", id)
+			}
+		}
+	}
+
+	// Add any remaining owners after the group is created
+	for _, o := range ownersExtra {
+		if _, err = ownerClient.AddOwnerRef(ctx, id, o, ownerBeta.DefaultAddOwnerRefOperationOptions()); err != nil {
+			return tf.ErrorDiagF(err, "Could not add owners to %s", id)
+		}
+	}
+
+	enableRetries := false
+	if _, ok := d.GetOk("administrative_unit_ids"); ok {
+		// It has been observed that when creating a group within an administrative unit and querying the group with the `/groups` endpoint whilst
+		// specifying `$select=allowExternalSenders,autoSubscribeNewMembers,hideFromAddressLists,hideFromOutlookClients, a 404 is returned for ~11 minutes.
+		enableRetries = true
+	}
+
+	return groupWithoutMembersResourceReadFunc(enableRetries)(ctx, d, meta)
+}
+
+func groupWithoutMembersResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	client := meta.(*clients.Client).Groups.GroupClientBeta
+	ownerClient := meta.(*clients.Client).Groups.GroupOwnerClientBeta
+	memberOfClient := meta.(*clients.Client).Groups.GroupMemberOfClientBeta
+	administrativeUnitMemberClient := meta.(*clients.Client).Groups.AdministrativeUnitMemberClientBeta
+
+	id, err := beta.ParseGroupID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing ID")
+	}
+
+	callerId := meta.(*clients.Client).ObjectID
+	displayName := d.Get("display_name").(string)
+
+	tf.LockByName(groupResourceName, id.GroupId)
+	defer tf.UnlockByName(groupResourceName, id.GroupId)
+
+	// Perform this check at apply time to catch any duplicate names created during the same apply
+	if d.Get("prevent_duplicate_names").(bool) {
+		result, err := groupFindByName(ctx, client, displayName)
+		if err != nil {
+			return tf.ErrorDiagPathF(err, "display_name", "Could not check for existing group(s)")
+		}
+		if result != nil && len(*result) > 0 {
+			for _, existingGroup := range *result {
+				if existingGroup.Id == nil {
+					return tf.ErrorDiagF(errors.New("API returned group with nil object ID during duplicate name check"), "Bad API response")
+				}
+
+				if *existingGroup.Id != id.GroupId {
+					return tf.ImportAsDuplicateDiag("azuread_group", *existingGroup.Id, displayName)
+				}
+			}
+		}
+	}
+
+	group := beta.Group{
+		Description:     nullable.NoZero(d.Get("description").(string)),
+		DisplayName:     nullable.Value(displayName),
+		MailEnabled:     nullable.Value(d.Get("mail_enabled").(bool)),
+		MembershipRule:  nullable.NoZero(""),
+		SecurityEnabled: nullable.Value(d.Get("security_enabled").(bool)),
+	}
+
+	if d.HasChange("writeback_enabled") || d.HasChange("onpremises_group_type") {
+		group.WritebackConfiguration = &beta.GroupWritebackConfiguration{
+			IsEnabled:              nullable.Value(d.Get("writeback_enabled").(bool)),
+			OmitDiscriminatedValue: true,
+		}
+		if onPremisesGroupType := d.Get("onpremises_group_type").(string); onPremisesGroupType != "" {
+			group.WritebackConfiguration.OnPremisesGroupType = nullable.Value(onPremisesGroupType)
+		}
+	}
+
+	if v, ok := d.GetOk("dynamic_membership"); ok && len(v.([]interface{})) > 0 {
+		if d.Get("dynamic_membership.0.enabled").(bool) {
+			group.MembershipRuleProcessingState = nullable.Value("On")
+		} else {
+			group.MembershipRuleProcessingState = nullable.Value("Paused")
+		}
+
+		group.MembershipRule = nullable.Value(d.Get("dynamic_membership.0.rule").(string))
+	}
+
+	if theme := d.Get("theme").(string); theme != "" {
+		group.Theme = nullable.Value(theme)
+	}
+
+	if d.HasChange("visibility") {
+		group.Visibility = nullable.Value(d.Get("visibility").(string))
+	}
+
+	if _, err := client.UpdateGroup(ctx, *id, group, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+		return tf.ErrorDiagF(err, "Updating %s", id)
+	}
+
+	groupTypes := make([]string, 0)
+	for _, v := range d.Get("types").(*pluginsdk.Set).List() {
+		groupTypes = append(groupTypes, v.(string))
+	}
+
+	// The following properties can only be set or unset for Unified groups, other group types will return a 4xx error.
+	if slices.Contains(groupTypes, GroupTypeUnified) {
+		// The unified group properties in this block only support delegated auth
+		// Application-authenticated requests will return a 403 or 404 error, so we
+		// only set these when explicitly configured, and when the value differs.
+		// See https://docs.microsoft.com/en-us/graph/known-issues#groups
+		extra, err := groupGetAdditional(ctx, client, *id)
+		if err != nil {
+			return tf.ErrorDiagF(err, "Retrieving extra fields for %s", id)
+		}
+
+		// AllowExternalSenders can only be set in its own PATCH request; including other properties returns a 400
+		if v, ok := d.GetOkExists("external_senders_allowed"); ok && (extra == nil || extra.AllowExternalSenders.GetOrZero() != v.(bool)) { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, *id, beta.Group{
+				AllowExternalSenders: nullable.Value(v.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `external_senders_allowed` for %s", id)
+			}
+
+			// Wait for AllowExternalSenders to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, *id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.AllowExternalSenders.GetOrZero() == v.(bool)), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `external_senders_allowed` for %s", id)
+			}
+		}
+
+		// AutoSubscribeNewMembers can only be set in its own PATCH request; including other properties returns a 400
+		if v, ok := d.GetOkExists("auto_subscribe_new_members"); ok && (extra == nil || extra.AutoSubscribeNewMembers.GetOrZero() != v.(bool)) { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, *id, beta.Group{
+				AutoSubscribeNewMembers: nullable.Value(v.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `auto_subscribe_new_members` for %s", id)
+			}
+
+			// Wait for AutoSubscribeNewMembers to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, *id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.AutoSubscribeNewMembers.GetOrZero() == v.(bool)), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `auto_subscribe_new_members` for %s", id)
+			}
+		}
+
+		// HideFromAddressLists can only be set in its own PATCH request; including other properties returns a 400
+		if v, ok := d.GetOkExists("hide_from_address_lists"); ok && (extra == nil || extra.HideFromAddressLists.GetOrZero() != v.(bool)) { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, *id, beta.Group{
+				HideFromAddressLists: nullable.Value(v.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `hide_from_address_lists` for %s", id)
+			}
+
+			// Wait for HideFromAddressLists to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, *id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.HideFromAddressLists.GetOrZero() == v.(bool)), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `hide_from_address_lists` for %s", id)
+			}
+		}
+
+		// HideFromOutlookClients can only be set in its own PATCH request; including other properties returns a 400
+		if v, ok := d.GetOkExists("hide_from_outlook_clients"); ok && (extra == nil || extra.HideFromOutlookClients.GetOrZero() != v.(bool)) { //nolint:staticcheck
+			if _, err = client.UpdateGroup(ctx, *id, beta.Group{
+				HideFromOutlookClients: nullable.Value(v.(bool)),
+			}, groupBeta.DefaultUpdateGroupOperationOptions()); err != nil {
+				return tf.CheckDelegatedAuthDiagF(err, "Failed to set `hide_from_outlook_clients` for %s", id)
+			}
+
+			// Wait for HideFromOutlookClients to be updated
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				groupExtra, err := groupGetAdditional(ctx, client, *id)
+				if err != nil {
+					return nil, err
+				}
+				return pointer.To(groupExtra != nil && groupExtra.HideFromOutlookClients.GetOrZero() == v.(bool)), nil
+			}); err != nil {
+				return tf.ErrorDiagF(err, "Waiting for update of `hide_from_outlook_clients` for %s", id)
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("owners"); ok && d.HasChange("owners") {
+		resp, err := ownerClient.ListOwners(ctx, *id, ownerBeta.DefaultListOwnersOperationOptions())
+		if err != nil {
+			return tf.ErrorDiagF(err, "Could not retrieve members for %s", id)
+		}
+
+		// If all owners are removed, restore the calling principal as the sole owner, in order to meet API
+		// restrictions about removing all owners, and maintain consistency with the Create behaviour.
+		// In theory this path should never be reached, since the property is Computed and has MinItems: 1, but we handle it anyway.
+		desiredOwners := tf.ExpandStringSlice(v.(*pluginsdk.Set).List())
+		if len(desiredOwners) == 0 {
+			desiredOwners = []string{callerId}
+		}
+
+		existingOwners := make([]string, 0)
+		if resp.Model != nil {
+			for _, o := range *resp.Model {
+				existingOwners = append(existingOwners, pointer.From(o.DirectoryObject().Id))
+			}
+		}
+
+		ownersForRemoval := tf.Difference(existingOwners, desiredOwners)
+		ownersToAdd := tf.Difference(desiredOwners, existingOwners)
+
+		// Add new owners first to avoid leaving the group without any owners
+		for _, v := range ownersToAdd {
+			ref := beta.ReferenceCreate{
+				ODataId: pointer.To(client.Client.BaseUri + beta.NewDirectoryObjectID(v).ID()),
+			}
+			if _, err = ownerClient.AddOwnerRef(ctx, *id, ref, ownerBeta.DefaultAddOwnerRefOperationOptions()); err != nil {
+				return tf.ErrorDiagF(err, "removing %s", beta.NewGroupIdOwnerID(id.GroupId, v))
+			}
+		}
+
+		for _, v := range ownersForRemoval {
+			ownerId := beta.NewGroupIdOwnerID(id.GroupId, v)
+			if _, err = ownerClient.RemoveOwnerRef(ctx, ownerId, ownerBeta.DefaultRemoveOwnerRefOperationOptions()); err != nil {
+				return tf.ErrorDiagF(err, "removing %s", ownerId)
+			}
+		}
+	}
+
+	if v := d.Get("administrative_unit_ids"); d.HasChange("administrative_unit_ids") {
+		resp, err := memberOfClient.ListMemberOfs(ctx, *id, memberofBeta.DefaultListMemberOfsOperationOptions())
+		if err != nil {
+			return tf.ErrorDiagPathF(err, "administrative_units", "retrieving administrative unit memberships for %s", id)
+		}
+
+		if resp.Model == nil {
+			return tf.ErrorDiagPathF(errors.New("model was nil"), "administrative_units", "retrieving administrative unit memberships for %s", id)
+		}
+
+		var existingAdministrativeUnits []string
+		for _, obj := range *resp.Model {
+			if _, ok := obj.(beta.AdministrativeUnit); ok {
+				existingAdministrativeUnits = append(existingAdministrativeUnits, *obj.DirectoryObject().Id)
+			}
+		}
+
+		desiredAdministrativeUnits := tf.ExpandStringSlice(v.(*pluginsdk.Set).List())
+		administrativeUnitsToLeave := tf.Difference(existingAdministrativeUnits, desiredAdministrativeUnits)
+		administrativeUnitsToJoin := tf.Difference(desiredAdministrativeUnits, existingAdministrativeUnits)
+
+		if len(administrativeUnitsToJoin) > 0 {
+			for _, v := range administrativeUnitsToJoin {
+				newAdministrativeUnitId := beta.NewDirectoryAdministrativeUnitID(v)
+				ref := beta.ReferenceCreate{
+					ODataId: pointer.To(fmt.Sprintf("%s%s", client.Client.BaseUri, beta.NewDirectoryObjectID(id.GroupId).ID())),
+				}
+				if _, err = administrativeUnitMemberClient.AddAdministrativeUnitMemberRef(ctx, newAdministrativeUnitId, ref, administrativeunitmemberBeta.DefaultAddAdministrativeUnitMemberRefOperationOptions()); err != nil {
+					return tf.ErrorDiagF(err, "Could not add %s as member of %s", id, newAdministrativeUnitId)
+				}
+			}
+		}
+
+		if len(administrativeUnitsToLeave) > 0 {
+			for _, v := range administrativeUnitsToLeave {
+				memberId := beta.NewDirectoryAdministrativeUnitIdMemberID(v, id.GroupId)
+				if _, err = administrativeUnitMemberClient.RemoveAdministrativeUnitMemberRef(ctx, memberId, administrativeunitmemberBeta.DefaultRemoveAdministrativeUnitMemberRefOperationOptions()); err != nil {
+					return tf.ErrorDiagF(err, "Could not remove %s", memberId)
+				}
+			}
+		}
+	}
+
+	return groupWithoutMembersResourceReadFunc(false)(ctx, d, meta)
+}
+
+// groupWithoutMembersResourceReadFunc returns a ReadContextFunc with optional retries. This is necessary when creating new groups
+// within administrative units, since some GET requests return a 404 for up to ~11 minutes after the group is created,
+// even if that group has been updated several times.
+func groupWithoutMembersResourceReadFunc(enableRetries bool) pluginsdk.ReadContextFunc {
+	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+		client := meta.(*clients.Client).Groups.GroupClientBeta
+		ownerClient := meta.(*clients.Client).Groups.GroupOwnerClientBeta
+		memberOfClient := meta.(*clients.Client).Groups.GroupMemberOfClientBeta
+
+		id, err := beta.ParseGroupID(d.Id())
+		if err != nil {
+			return tf.ErrorDiagPathF(err, "id", "Parsing ID")
+		}
+
+		options := groupBeta.DefaultGetGroupOperationOptions()
+		if enableRetries {
+			// Keep retrying on 404 for up to 12 minutes to defeat extended replication delays
+			startTimeForRetries := time.Now()
+			options.RetryFunc = func(resp *http.Response, o *odata.OData) (bool, error) {
+				if response.WasNotFound(resp) && time.Since(startTimeForRetries).Minutes() < 12 {
+					return true, nil
+				}
+				return false, nil
+			}
+		}
+
+		resp, err := client.GetGroup(ctx, *id, options)
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				log.Printf("[DEBUG] %s was not found - removing from state", id)
+				d.SetId("")
+				return nil
+			}
+			return tf.ErrorDiagF(err, "Retrieving %s", id)
+		}
+
+		group := resp.Model
+		if group == nil {
+			return tf.ErrorDiagF(errors.New("model was nil"), "Retrieving %s", id)
+		}
+
+		tf.Set(d, "assignable_to_role", group.IsAssignableToRole.GetOrZero())
+		tf.Set(d, "behaviors", tf.FlattenStringSlicePtr(group.ResourceBehaviorOptions))
+		tf.Set(d, "description", group.Description.GetOrZero())
+		tf.Set(d, "display_name", group.DisplayName.GetOrZero())
+		tf.Set(d, "mail_enabled", group.MailEnabled.GetOrZero())
+		tf.Set(d, "mail", group.Mail.GetOrZero())
+		tf.Set(d, "mail_nickname", group.MailNickname.GetOrZero())
+		tf.Set(d, "object_id", pointer.From(group.Id))
+		tf.Set(d, "onpremises_domain_name", group.OnPremisesDomainName.GetOrZero())
+		tf.Set(d, "onpremises_netbios_name", group.OnPremisesNetBiosName.GetOrZero())
+		tf.Set(d, "onpremises_sam_account_name", group.OnPremisesSamAccountName.GetOrZero())
+		tf.Set(d, "onpremises_security_identifier", group.OnPremisesSecurityIdentifier.GetOrZero())
+		tf.Set(d, "onpremises_sync_enabled", group.OnPremisesSyncEnabled.GetOrZero())
+		tf.Set(d, "preferred_language", group.PreferredLanguage.GetOrZero())
+		tf.Set(d, "provisioning_options", tf.FlattenStringSlicePtr(group.ResourceProvisioningOptions))
+		tf.Set(d, "proxy_addresses", tf.FlattenStringSlicePtr(group.ProxyAddresses))
+		tf.Set(d, "security_enabled", group.SecurityEnabled.GetOrZero())
+		tf.Set(d, "theme", group.Theme.GetOrZero())
+		tf.Set(d, "types", tf.FlattenStringSlicePtr(group.GroupTypes))
+		tf.Set(d, "visibility", group.Visibility.GetOrZero())
+
+		dynamicMembership := make([]interface{}, 0)
+		if !group.MembershipRule.IsNull() {
+			enabled := true
+			if group.MembershipRuleProcessingState.GetOrZero() == "Paused" {
+				enabled = false
+			}
+			dynamicMembership = append(dynamicMembership, map[string]interface{}{
+				"enabled": enabled,
+				"rule":    group.MembershipRule.GetOrZero(),
+			})
+		}
+		tf.Set(d, "dynamic_membership", dynamicMembership)
+
+		if group.WritebackConfiguration != nil {
+			tf.Set(d, "writeback_enabled", group.WritebackConfiguration.IsEnabled.GetOrZero())
+			tf.Set(d, "onpremises_group_type", group.WritebackConfiguration.OnPremisesGroupType.GetOrZero())
+		}
+
+		var allowExternalSenders, autoSubscribeNewMembers, hideFromAddressLists, hideFromOutlookClients bool
+		if group.GroupTypes != nil && slices.Contains(*group.GroupTypes, GroupTypeUnified) {
+			// Retrieve these properties in a separate request to sidestep API bugs
+			groupExtra, err := groupGetAdditional(ctx, client, *id)
+			if err != nil {
+				return tf.ErrorDiagF(err, "Could not retrieve group with object UID %q", d.Id())
+			}
+
+			if groupExtra != nil {
+				allowExternalSenders = groupExtra.AllowExternalSenders.GetOrZero()
+				autoSubscribeNewMembers = groupExtra.AutoSubscribeNewMembers.GetOrZero()
+				hideFromAddressLists = groupExtra.HideFromAddressLists.GetOrZero()
+				hideFromOutlookClients = groupExtra.HideFromOutlookClients.GetOrZero()
+			}
+		}
+
+		tf.Set(d, "auto_subscribe_new_members", autoSubscribeNewMembers)
+		tf.Set(d, "external_senders_allowed", allowExternalSenders)
+		tf.Set(d, "hide_from_address_lists", hideFromAddressLists)
+		tf.Set(d, "hide_from_outlook_clients", hideFromOutlookClients)
+
+		owners := make([]string, 0)
+		if resp, err := ownerClient.ListOwners(ctx, *id, ownerBeta.DefaultListOwnersOperationOptions()); err != nil {
+			return tf.ErrorDiagPathF(err, "owners", "Could not retrieve owners for %s", id)
+		} else if resp.Model != nil {
+			for _, o := range *resp.Model {
+				owners = append(owners, pointer.From(o.DirectoryObject().Id))
+			}
+		}
+		tf.Set(d, "owners", owners)
+
+		administrativeUnitIds := make([]string, 0)
+		if resp, err := memberOfClient.ListMemberOfs(ctx, *id, memberofBeta.DefaultListMemberOfsOperationOptions()); err != nil {
+			return tf.ErrorDiagPathF(err, "members", "Could not retrieve members for %s", id)
+		} else if resp.Model != nil {
+			for _, obj := range *resp.Model {
+				if _, ok := obj.(beta.AdministrativeUnit); ok {
+					administrativeUnitIds = append(administrativeUnitIds, *obj.DirectoryObject().Id)
+				}
+			}
+		}
+		tf.Set(d, "administrative_unit_ids", administrativeUnitIds)
+
+		preventDuplicates := false
+		if v := d.Get("prevent_duplicate_names").(bool); v {
+			preventDuplicates = v
+		}
+		tf.Set(d, "prevent_duplicate_names", preventDuplicates)
+
+		return nil
+	}
+}
+
+func groupWithoutMembersResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	client := meta.(*clients.Client).Groups.GroupClientBeta
+
+	id, err := beta.ParseGroupID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing ID")
+	}
+
+	// Get the group before attempting deletion
+	resp, err := client.GetGroup(ctx, *id, groupBeta.DefaultGetGroupOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return tf.ErrorDiagPathF(errors.New("group was not found"), "id", "Retrieving %s", id)
+		}
+		return tf.ErrorDiagPathF(err, "id", "Retrieving %s", id)
+	}
+
+	if _, err = client.DeleteGroup(ctx, *id, groupBeta.DefaultDeleteGroupOperationOptions()); err != nil {
+		return tf.ErrorDiagF(err, "Deleting %s", id)
+	}
+
+	// Wait for group object to be deleted
+	if err := consistency.WaitForDeletion(ctx, func(ctx context.Context) (*bool, error) {
+		if resp, err := client.GetGroup(ctx, *id, groupBeta.DefaultGetGroupOperationOptions()); err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return pointer.To(false), nil
+			}
+			return nil, err
+		}
+		return pointer.To(true), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for deletion of %s", id)
+	}
+
+	return nil
+}

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -145,20 +145,6 @@ func TestAccGroupWithoutMembers_dynamicMembership(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.unified(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.dynamicMembership(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -540,7 +526,7 @@ func (GroupWithoutMembersResource) removeOwners(data acceptance.TestData) string
 resource "azuread_group_without_members" "test" {
   display_name     = "acctestGroup-%[1]d"
   security_enabled = true
-  owners = []
+  owners           = []
 }
 `, data.RandomInteger)
 }

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -1,0 +1,868 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package groups_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+	groupBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/group"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+)
+
+type GroupWithoutMembersResource struct{}
+
+func TestAccGroupWithoutMembers_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_basicUnified(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test_unified")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicUnified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_completeUnified(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeUnified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_updateUnified(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicUnified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeUnified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_assignableToRole(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.assignableToRole(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_behaviors(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.behaviors(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_dynamicMembership(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dynamicMembership(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unified(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dynamicMembership(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_callerOwner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withCallerAsOwner(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_owners(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withOneOwner(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withThreeOwners(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withOneOwner(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withServicePrincipalOwner(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withDiverseOwners(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("owners.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_preventDuplicateNamesPass(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.preventDuplicateNamesPass(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep("prevent_duplicate_names"),
+	})
+}
+
+func TestAccGroupWithoutMembers_preventDuplicateNamesForceNew(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.preventDuplicateNamesForceNew(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep("prevent_duplicate_names"),
+	})
+}
+
+func TestAccGroupWithoutMembers_provisioning(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.provisioning(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_unifiedExtraSettings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.unifiedWithExtraSettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unifiedAsUser(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unifiedWithExtraSettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_preventDuplicateNamesFail(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		data.RequiresImportErrorStep(r.preventDuplicateNamesFail(data)),
+	})
+}
+
+func TestAccGroupWithoutMembers_visibility(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.visibility(data, "Private"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.visibility(data, "Public"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_administrativeUnit(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.administrativeUnits(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("administrative_unit_ids.#").HasValue("2"),
+			),
+		},
+		data.ImportStep("administrative_unit_ids"),
+		{
+			Config: r.administrativeUnitsWithoutAssociation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("administrative_unit_ids.#").HasValue("0"),
+			),
+		},
+		data.ImportStep("administrative_unit_ids"),
+		{
+			Config: r.administrativeUnits(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("administrative_unit_ids.#").HasValue("2"),
+			),
+		},
+		data.ImportStep("administrative_unit_ids"),
+	})
+}
+
+func TestAccGroupWithoutMembers_writeback(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withWriteback(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalSecurityGroup"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_writebackUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withWriteback(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalSecurityGroup"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccGroupWithoutMembers_writebackUnified(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
+	r := GroupWithoutMembersResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.unifiedWithWriteback(data, "UniversalDistributionGroup"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalDistributionGroup"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.unifiedWithWriteback(data, "UniversalMailEnabledSecurityGroup"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalMailEnabledSecurityGroup"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r GroupWithoutMembersResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	client := clients.Groups.GroupClientBeta
+
+	id, err := beta.ParseGroupID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetGroup(ctx, *id, groupBeta.DefaultGetGroupOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("failed to retrieve %s: %v", id, err)
+	}
+	return pointer.To(true), nil
+}
+
+func (GroupWithoutMembersResource) templateDiverseDirectoryObjects(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_application" "test" {
+  display_name = "acctestGroup-%[1]d"
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+resource "azuread_user" "test" {
+  user_principal_name = "acctestGroup.%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestGroup-%[1]d"
+  password            = "%[2]s"
+}
+
+resource "azuread_group_without_members" "member" {
+  display_name     = "acctestGroup-%[1]d-Member"
+  security_enabled = true
+}
+`, data.RandomInteger, data.RandomPassword)
+}
+
+func (GroupWithoutMembersResource) templateThreeUsers(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "testA" {
+  user_principal_name = "acctestGroup.%[1]d.A@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestGroup-%[1]d-A"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testB" {
+  user_principal_name = "acctestGroup.%[1]d.B@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestGroup-%[1]d-B"
+  mail_nickname       = "acctestGroup-%[1]d-B"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testC" {
+  user_principal_name = "acctestGroup.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestGroup-%[1]d-C"
+  password            = "%[2]s"
+}
+`, data.RandomInteger, data.RandomPassword)
+}
+
+func (GroupWithoutMembersResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) basicUnified(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test_unified" {
+  display_name     = "acctestGroup-%[1]d"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctestGroup-%[1]d"
+  security_enabled = false
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) unified(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  description      = "Please delete me as this is a.test.AD group!"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = true
+  theme            = "Pink"
+}
+`, data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) unifiedAsUser(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {
+  client_id           = ""
+  client_id_file_path = ""
+  use_cli             = true
+}
+
+%[1]s
+`, r.unified(data))
+}
+
+func (GroupWithoutMembersResource) unifiedWithExtraSettings(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {
+  client_id           = ""
+  client_id_file_path = ""
+  use_cli             = true
+}
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  description      = "Please delete me as this is a.test.AD group!"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = true
+  theme            = "Pink"
+
+  auto_subscribe_new_members = true
+  external_senders_allowed   = true
+  hide_from_address_lists    = true
+  hide_from_outlook_clients  = true
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) unifiedWithWriteback(data acceptance.TestData, onPremisesGroupType string) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  description      = "Please delete me as this is a.test.AD group!"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = true
+  theme            = "Pink"
+
+  writeback_enabled     = true
+  onpremises_group_type = %[2]q
+}
+`, data.RandomInteger, onPremisesGroupType)
+}
+
+func (GroupWithoutMembersResource) completeUnified(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+data "azuread_client_config" "test" {}
+
+resource "azuread_user" "test" {
+  user_principal_name = "acctestGroup.%[1]d@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestGroup-%[1]d"
+  password            = "%[2]s"
+}
+
+resource "azuread_group_without_members" "test" {
+  description      = "Please delete me as this is a.test.AD group!"
+  display_name     = "acctestGroup-complete-%[1]d"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = true
+  owners           = [azuread_user.test.object_id]
+  theme            = "Purple"
+}
+`, data.RandomInteger, data.RandomPassword)
+}
+
+func (GroupWithoutMembersResource) assignableToRole(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  assignable_to_role = true
+  display_name       = "acctestGroup-assignableToRole-%[1]d"
+  security_enabled   = true
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) behaviors(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name  = "acctestGroup-behaviors-%[1]d"
+  mail_enabled  = true
+  mail_nickname = "acctestGroup-behaviors-%[1]d"
+  types         = ["Unified"]
+
+  behaviors = [
+    "AllowOnlyMembersToPost",
+    "HideGroupInOutlook",
+    "SubscribeNewGroupMembers",
+    "WelcomeEmailDisabled"
+  ]
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) dynamicMembership(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  description      = "Please delete me as this is a.test.AD group!"
+  types            = ["DynamicMembership", "Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = true
+
+  dynamic_membership {
+    enabled = true
+    rule    = "user.department -eq \"Sales\""
+  }
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) provisioning(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name  = "acctestGroup-behaviors-%[1]d"
+  mail_enabled  = true
+  mail_nickname = "acctestGroup-behaviors-%[1]d"
+  types         = ["Unified"]
+
+  provisioning_options = ["Team"]
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) visibility(data acceptance.TestData, visibility string) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name  = "acctestGroup-visibility-%[1]d"
+  mail_enabled  = true
+  mail_nickname = "acctestGroup-visibility-%[1]d"
+  types         = ["Unified"]
+  visibility    = "%[2]s"
+}
+`, data.RandomInteger, visibility)
+}
+
+func (r GroupWithoutMembersResource) withOneOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[2]d"
+  security_enabled = true
+  owners           = [azuread_user.testA.object_id]
+}
+`, r.templateThreeUsers(data), data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) withCallerAsOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azuread_client_config" "test" {}
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+  owners           = [data.azuread_client_config.test.object_id]
+}
+`, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) withServicePrincipalOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_application" "test" {
+  display_name = "acctestGroup-%[1]d"
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+  owners           = [azuread_service_principal.test.object_id]
+}
+`, data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) withDiverseOwners(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[2]d"
+  security_enabled = true
+  owners = [
+    azuread_service_principal.test.object_id,
+    azuread_user.test.object_id,
+  ]
+}
+`, r.templateDiverseDirectoryObjects(data), data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) withThreeOwners(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[2]d"
+  security_enabled = true
+  owners = [
+    azuread_user.testA.object_id,
+    azuread_user.testB.object_id,
+    azuread_user.testC.object_id
+  ]
+}
+`, r.templateThreeUsers(data), data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) preventDuplicateNamesPass(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name            = "acctestGroup-%[1]d"
+  security_enabled        = true
+  prevent_duplicate_names = true
+}
+`, data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) preventDuplicateNamesFail(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_group_without_members" "duplicate" {
+  display_name            = azuread_group_without_members.test.display_name
+  security_enabled        = true
+  prevent_duplicate_names = true
+}
+`, r.basic(data))
+}
+
+func (GroupWithoutMembersResource) preventDuplicateNamesForceNew(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name            = "acctestGroup-%[1]d"
+  security_enabled        = true
+  prevent_duplicate_names = true
+
+  assignable_to_role = true
+}
+`, data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) administrativeUnits(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_administrative_unit" "test" {
+  display_name = "acctestGroup-administrative-unit-%[1]d"
+}
+
+resource "azuread_administrative_unit" "test2" {
+  display_name = "acctestGroup-administrative-unit-%[1]d"
+}
+
+resource "azuread_group_without_members" "test" {
+  display_name            = "acctestGroup-%[1]d"
+  security_enabled        = true
+  administrative_unit_ids = [azuread_administrative_unit.test.id, azuread_administrative_unit.test2.id]
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (r GroupWithoutMembersResource) administrativeUnitsWithoutAssociation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_administrative_unit" "test" {
+  display_name = "acctestGroup-administrative-unit-%[1]d"
+}
+
+resource "azuread_administrative_unit" "test2" {
+  display_name = "acctestGroup-administrative-unit-%[1]d"
+}
+
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (GroupWithoutMembersResource) withWriteback(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+
+  writeback_enabled     = true
+  onpremises_group_type = "UniversalSecurityGroup"
+}
+`, data.RandomInteger)
+}

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -37,7 +37,7 @@ func TestAccGroupWithoutMembers_basic(t *testing.T) {
 }
 
 func TestAccGroupWithoutMembers_basicUnified(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test_unified")
+	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
 	r := GroupWithoutMembersResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -231,10 +231,10 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data),
+			Config: r.removeOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("owners.#").HasValue("2"),
+				check.That(data.ResourceName).Key("owners.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -260,7 +260,7 @@ func TestAccGroupWithoutMembers_preventDuplicateNamesForceNew(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_group_without_members", "test")
 	r := GroupWithoutMembersResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -535,9 +535,19 @@ resource "azuread_group_without_members" "test" {
 `, data.RandomInteger)
 }
 
+func (GroupWithoutMembersResource) removeOwners(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_group_without_members" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  security_enabled = true
+  owners = []
+}
+`, data.RandomInteger)
+}
+
 func (GroupWithoutMembersResource) basicUnified(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-resource "azuread_group_without_members" "test_unified" {
+resource "azuread_group_without_members" "test" {
   display_name     = "acctestGroup-%[1]d"
   types            = ["Unified"]
   mail_enabled     = true
@@ -833,7 +843,7 @@ resource "azuread_administrative_unit" "test2" {
 resource "azuread_group_without_members" "test" {
   display_name            = "acctestGroup-%[1]d"
   security_enabled        = true
-  administrative_unit_ids = [azuread_administrative_unit.test.id, azuread_administrative_unit.test2.id]
+  administrative_unit_ids = [azuread_administrative_unit.test.object_id, azuread_administrative_unit.test2.object_id]
 }
 `, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/groups/registration.go
+++ b/internal/services/groups/registration.go
@@ -35,7 +35,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azuread_group":        groupResource(),
-		"azuread_group_member": groupMemberResource(),
+		"azuread_group":                 groupResource(),
+		"azuread_group_without_members": groupWithoutMembersResource(),
+		"azuread_group_member":          groupMemberResource(),
 	}
 }


### PR DESCRIPTION
This PR introduces a Group resource that omits management and exposure of group members. This resource is intended for use cases where a Group needs to be managed via terraform, but the members of the group are not of concern, typically where the members list is sufficiently large that performance problems are encountered, and/or members are managed by other means.

closes #954 - Since there is no current way to improve the linear performance problem with the List() call, the `azuread_group` resource cannot be changed to satisfy a performance improvement.