### PR TITLE
Add support for AadApplication and SharepointOnline in resource `azuread_access_package_resource_package_association`

### DIFF
--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -48,7 +48,7 @@ resource "azuread_access_package_resource_package_association" "example" {
 ## Argument Reference
 
 * `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
+* `access_type` - (Required) The role of access type to the specified resource. For `AadGroup` valid values are `Member`, or `Owner`, For `AadApplication` this it must be a the UUID of an app role and for `SharePointOnline` it should be a URL. Changing this forces a new resource to be created.
 * `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -59,9 +59,8 @@ func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 			"access_type": {
 				Description: "The role of access type to the specified resource - for `AadGroup` valid values are `Member` and `Owner`, for `AadApplication` it must be a UUID and for `SharePointOnline` it must be a URL",
 				Type:        pluginsdk.TypeString,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    true,
-				Default:     "Member",
 				ValidateFunc: validation.Any(validation.StringInSlice([]string{
 					"Member",
 					"Owner",

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -57,15 +57,15 @@ func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 			},
 
 			"access_type": {
-				Description: "The role of access type to the specified resource, valid values are `Member` and `Owner`",
+				Description: "The role of access type to the specified resource - for `AadGroup` valid values are `Member` and `Owner`, for `AadApplication` it must be a UUID and for `SharePointOnline` it must be a URL",
 				Type:        pluginsdk.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Default:     "Member",
-				ValidateFunc: validation.StringInSlice([]string{
+				ValidateFunc: validation.Any(validation.StringInSlice([]string{
 					"Member",
 					"Owner",
-				}, false),
+				}, false), validation.IsUUID, validation.IsURLWithHTTPorHTTPS),
 			},
 		},
 	}
@@ -99,10 +99,25 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 
 	resource := pointer.To((*resourceResp.Model)[0])
 
+	var originId string
+	var displayName string
+	switch resource.OriginSystem.GetOrZero() {
+	case "AadGroup":
+		originId = fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId)
+		displayName = accessType
+		break
+	case "AadApplication":
+	case "SharePointOnline":
+		originId = accessType
+		break
+	default:
+		return tf.ErrorDiagF(errors.New("unknown origin system"), "Retrieving origin id")
+	}
+
 	properties := beta.AccessPackageResourceRoleScope{
 		AccessPackageResourceRole: &beta.AccessPackageResourceRole{
-			DisplayName:  nullable.NoZero(accessType),
-			OriginId:     nullable.Value(fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId)),
+			DisplayName:  nullable.NoZero(displayName),
+			OriginId:     nullable.Value(originId),
 			OriginSystem: resource.OriginSystem,
 			AccessPackageResource: &beta.AccessPackageResource{
 				Id:           resource.Id,


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

[The previous work](https://github.com/hashicorp/terraform-provider-azuread/pull/903) to implement adding resources to access packages only supported groups (though this isn't mentioned anywhere).

The change to allow both applications and Sharepoint Online though aren't massive, and largely require allowing different IDs as the origin ID.

This PR aims to allow for these two as well, by allowing the `access_type` to also be a UUID (ID format for app roles) or a URL (seemingly the ID for Sharepoint Online).

Currently, this is a breaking change as it changes the `access_type` to be required. If we really want this could be avoided, but would mean we keep it defaulting to a value of "Member" which only makes sense for groups.

## PR Checklist

- [ ] ~I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).~
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [ ] ~My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)~

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

**Resources changed**
* `azuread_access_package_resource_package_association` - support for Applications and SharePointOnline, change field `access_type` to be required and accept UUIDs and URLs.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #1066 