### PR TITLE
dependencies: update go-azure-sdk to v0.20250131.1134653

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,8 +120,9 @@ More information on [how to configure a Service Principal using a Client Secret 
 
 When authenticating as a Service Principal using Open ID Connect, the following fields can be set:
 
-* `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_TOKEN` Environment Variables.
-* `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL` or `ACTIONS_ID_TOKEN_REQUEST_TOKEN` Environment Variables.
+* `oidc_request_token` - (Optional) The bearer token for the request to the OIDC provider. This can also be sourced from the `ARM_OIDC_REQUEST_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN` or `SYSTEM_ACCESSTOKEN` Environment Variables. The provider will look for values in this order and use the first it finds configured.
+* `oidc_request_url` - (Optional) The URL for the OIDC provider from which to request an ID token. This can also be sourced from the `ARM_OIDC_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_URL` or `SYSTEM_OIDCREQUESTURI` Environment Variables. The provider will look for values in this order and use the first it finds configured.
+* `ado_pipeline_service_connection_id` - (Optional) The Azure DevOps Pipeline Service Connection ID. This can also be sourced from the `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` Environment Variables. The provider will look for values in this order and use the first it finds configured.
 * `oidc_token` - (Optional) The ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN` Environment Variable.
 * `oidc_token_file_path` - (Optional) The path to a file containing an ID token when authenticating using OpenID Connect (OIDC). This can also be sourced from the `ARM_OIDC_TOKEN_FILE_PATH` Environment Variable.
 * `use_oidc` - (Optional) Should OIDC be used for Authentication? This can also be sourced from the `ARM_USE_OIDC` Environment Variable. Defaults to `false`.

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/hashicorp/terraform-provider-azuread
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-azure-helpers v0.71.0
-	github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20240927.1005214
-	github.com/hashicorp/go-azure-sdk/sdk v0.20240927.1005214
+	github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20250131.1134653
+	github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -49,10 +49,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.71.0 h1:ra3aIRzg01g6MLKQ+yABcb6WJtrqRUDDgyuPLmyZ9lY=
 github.com/hashicorp/go-azure-helpers v0.71.0/go.mod h1:BmbF4JDYXK5sEmFeU5hcn8Br21uElcqLfdQxjatwQKw=
-github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20240927.1005214 h1:m6VCE8gYOJI3XtkVpxEtMp1HwtsYUrL8tvROINe1Q9A=
-github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20240927.1005214/go.mod h1:O2eTEWXTgwu1AISomfd1JIv0r6uh3/fY5BA0yC0/tFA=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240927.1005214 h1:nhYBErlMEkQIoG50GY2OZattC4+WBI/8xgZkwx/CsvY=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240927.1005214/go.mod h1:dMKF6bXrgGmy1d3pLzkmBpG2JIHgSAV2/OMSCEgyMwE=
+github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20250131.1134653 h1:kOOdD198ZdmDCGvjKNmNyhWj4OesFDxy6nTSNaLs2ho=
+github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20250131.1134653/go.mod h1:mi0HWaLQw9CiBLJb3gDy5H1ckVb2NM3IEhLNFjJDUkw=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653 h1:Bd+glHUD1mdal1zn0NgoS4wDFhUB8Qfw61j0nZEnC5A=
+github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653/go.mod h1:oI5R0fTbBx3K/sJBK5R/OlEy8ozdQjvctxVU9v3EDkc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -332,9 +332,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			ClientCertificatePath:     d.Get("client_certificate_path").(string),
 			ClientSecret:              *clientSecret,
 
-			OIDCAssertionToken:          *idToken,
-			GitHubOIDCTokenRequestURL:   d.Get("oidc_request_url").(string),
-			GitHubOIDCTokenRequestToken: d.Get("oidc_request_token").(string),
+			OIDCAssertionToken:    *idToken,
+			OIDCTokenRequestURL:   d.Get("oidc_request_url").(string),
+			OIDCTokenRequestToken: d.Get("oidc_request_token").(string),
 
 			CustomManagedIdentityEndpoint: d.Get("msi_endpoint").(string),
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -189,17 +189,24 @@ func AzureADProvider() *schema.Provider {
 				Description: "The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
+			"ado_pipeline_service_connection_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID", "ARM_OIDC_AZURE_SERVICE_CONNECTION_ID"}, nil),
+				Description: "The Azure DevOps Pipeline Service Connection ID.",
+			},
+
 			"oidc_request_token": {
 				Type:        pluginsdk.TypeString,
 				Optional:    true,
-				DefaultFunc: pluginsdk.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}, ""),
+				DefaultFunc: pluginsdk.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "SYSTEM_ACCESSTOKEN"}, ""),
 				Description: "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
 			"oidc_request_url": {
 				Type:        pluginsdk.TypeString,
 				Optional:    true,
-				DefaultFunc: pluginsdk.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}, ""),
+				DefaultFunc: pluginsdk.MultiEnvDefaultFunc([]string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL", "SYSTEM_OIDCREQUESTURI"}, ""),
 				Description: "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.",
 			},
 
@@ -332,9 +339,10 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			ClientCertificatePath:     d.Get("client_certificate_path").(string),
 			ClientSecret:              *clientSecret,
 
-			OIDCAssertionToken:    *idToken,
-			OIDCTokenRequestURL:   d.Get("oidc_request_url").(string),
-			OIDCTokenRequestToken: d.Get("oidc_request_token").(string),
+			OIDCAssertionToken:             *idToken,
+			OIDCTokenRequestURL:            d.Get("oidc_request_url").(string),
+			OIDCTokenRequestToken:          d.Get("oidc_request_token").(string),
+			ADOPipelineServiceConnectionID: d.Get("ado_pipeline_service_connection_id").(string),
 
 			CustomManagedIdentityEndpoint: d.Get("msi_endpoint").(string),
 
@@ -343,6 +351,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			EnableAuthenticatingUsingClientSecret:      true,
 			EnableAuthenticatingUsingManagedIdentity:   enableManagedIdentity,
 			EnableAuthenticationUsingGitHubOIDC:        enableOidc,
+			EnableAuthenticationUsingADOPipelineOIDC:   enableOidc,
 			EnableAuthenticationUsingOIDC:              enableOidc,
 		}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -476,9 +476,69 @@ func TestAccProvider_githubOidcAuth(t *testing.T) {
 			Environment:                         *env,
 			TenantID:                            *tenantId,
 			ClientID:                            *clientId,
-			GitHubOIDCTokenRequestToken:         d.Get("oidc_request_token").(string),
-			GitHubOIDCTokenRequestURL:           d.Get("oidc_request_url").(string),
+			OIDCTokenRequestToken:               d.Get("oidc_request_token").(string),
+			OIDCTokenRequestURL:                 d.Get("oidc_request_url").(string),
 			EnableAuthenticationUsingGitHubOIDC: true,
+		}
+
+		return buildClient(ctx, provider, authConfig, "")
+	}
+
+	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
+	if d != nil && d.HasError() {
+		t.Fatalf("err: %+v", d)
+	}
+
+	if errs := testCheckProvider(provider); len(errs) > 0 {
+		for _, err := range errs {
+			t.Error(err)
+		}
+	}
+}
+
+func TestAccProvider_adoOidcAuth(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+	if os.Getenv("SYSTEM_ACCESSTOKEN") == "" {
+		t.Skip("SYSTEM_ACCESSTOKEN not set")
+	}
+	if os.Getenv("SYSTEM_OIDCREQUESTURI") == "" {
+		t.Skip("SYSTEM_OIDCREQUESTURI not set")
+	}
+	if os.Getenv("ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID") == "" {
+		t.Skip("ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID")
+	}
+
+	provider := AzureADProvider()
+	ctx := context.Background()
+
+	// Support only oidc authentication
+	provider.ConfigureContextFunc = func(ctx context.Context, d *pluginsdk.ResourceData) (interface{}, pluginsdk.Diagnostics) {
+		envName := d.Get("environment").(string)
+		env, err := environments.FromName(envName)
+		if err != nil {
+			t.Fatalf("configuring environment %q: %v", envName, err)
+		}
+
+		clientId, err := getClientId(d)
+		if err != nil {
+			return nil, pluginsdk.DiagFromErr(err)
+		}
+
+		tenantId, err := getTenantId(d)
+		if err != nil {
+			return nil, pluginsdk.DiagFromErr(err)
+		}
+
+		authConfig := &auth.Credentials{
+			Environment:                              *env,
+			TenantID:                                 *tenantId,
+			ClientID:                                 *clientId,
+			OIDCTokenRequestToken:                    d.Get("oidc_request_token").(string),
+			OIDCTokenRequestURL:                      d.Get("oidc_request_url").(string),
+			ADOPipelineServiceConnectionID:           d.Get("ado_pipeline_service_connection_id").(string),
+			EnableAuthenticationUsingADOPipelineOIDC: true,
 		}
 
 		return buildClient(ctx, provider, authConfig, "")

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/README.md
@@ -130,8 +130,39 @@ func main() {
 	credentials := auth.Credentials{
 		Environment:                         environment,
 		EnableAuthenticationUsingGitHubOIDC: true,
-		GitHubOIDCTokenRequestURL:           os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
-		GitHubOIDCTokenRequestToken:         os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+		OIDCTokenRequestURL:                 os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"),
+		OIDCTokenRequestToken:               os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN"),
+	}
+	authorizer, err := auth.NewAuthorizerFromCredentials(context.TODO(), credentials, environment.MSGraph)
+	if err != nil {
+		log.Fatalf("building authorizer from credentials: %+v", err)
+	}
+	// ..
+}
+```
+
+## Example: Authenticating using ADO Pipeline OIDC
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+func main() {
+	environment := environments.Public
+	credentials := auth.Credentials{
+		Environment:                              environment,
+		EnableAuthenticationUsingADOPipelineOIDC: true,
+		OIDCTokenRequestURL:                      os.Getenv("SYSTEM_OIDCREQUESTURI"),
+		OIDCTokenRequestToken:                    os.Getenv("SYSTEM_ACCESSTOKEN"),
+		ADOPipelineServiceConnectionID:           "<Service Connection ID>",
 	}
 	authorizer, err := auth.NewAuthorizerFromCredentials(context.TODO(), credentials, environment.MSGraph)
 	if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/ado_pipeline_oidc_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/ado_pipeline_oidc_authorizer.go
@@ -1,0 +1,212 @@
+// Copyright (c) HashiCorp Inc. All rights reserved.
+// Licensed under the MPL-2.0 License. See NOTICE.txt in the project root for license information.
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"golang.org/x/oauth2"
+)
+
+const (
+	adoPipelineOIDCAPIVersion = "7.1"
+)
+
+type ADOPipelineOIDCAuthorizerOptions struct {
+	// Api describes the Azure API being used
+	Api environments.Api
+
+	// ClientId is the client ID used when authenticating
+	ClientId string
+
+	// ServiceConnectionId is the ADO service connection ID used when authenticating
+	ServiceConnectionId string
+
+	// Environment is the Azure environment/cloud being targeted
+	Environment environments.Environment
+
+	// TenantId is the tenant to authenticate against
+	TenantId string
+
+	// AuxiliaryTenantIds lists additional tenants to authenticate against, currently only
+	// used for Resource Manager when auxiliary tenants are needed.
+	// e.g. https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant
+	AuxiliaryTenantIds []string
+
+	// IdTokenRequestUrl is the URL for the OIDC provider from which to request an ID token.
+	// Usually exposed via the SYSTEM_OIDCREQUESTURI environment variable when running in ADO Pipelines
+	IdTokenRequestUrl string
+
+	// IdTokenRequestToken is the bearer token for the request to the OIDC provider.
+	// Usually exposed via the SYSTEM_ACCESSTOKEN environment variable when running in ADO Pipelines
+	IdTokenRequestToken string
+}
+
+// NewADOPipelineOIDCAuthorizer returns an authorizer which acquires a client assertion from a ADO endpoint, then uses client assertion authentication to obtain an access token.
+func NewADOPipelineOIDCAuthorizer(ctx context.Context, options ADOPipelineOIDCAuthorizerOptions) (Authorizer, error) {
+	scope, err := environments.Scope(options.Api)
+	if err != nil {
+		return nil, fmt.Errorf("determining scope for %q: %+v", options.Api.Name(), err)
+	}
+
+	conf := adoPipelineOIDCConfig{
+		Environment:         options.Environment,
+		TenantID:            options.TenantId,
+		AuxiliaryTenantIDs:  options.AuxiliaryTenantIds,
+		ClientID:            options.ClientId,
+		ServiceConnectionID: options.ServiceConnectionId,
+		IDTokenRequestURL:   options.IdTokenRequestUrl,
+		IDTokenRequestToken: options.IdTokenRequestToken,
+		Scopes: []string{
+			*scope,
+		},
+	}
+
+	return conf.TokenSource(ctx)
+}
+
+var _ Authorizer = &ADOPipelineOIDCAuthorizer{}
+
+type ADOPipelineOIDCAuthorizer struct {
+	conf *adoPipelineOIDCConfig
+}
+
+func (a *ADOPipelineOIDCAuthorizer) adoPipelineAssertion(ctx context.Context, _ *http.Request) (*string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.conf.IDTokenRequestURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("adoPipelineAssertion: failed to build request: %+v", err)
+	}
+
+	query, err := url.ParseQuery(req.URL.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("adoPipelineAssertion: cannot parse URL query")
+	}
+	if query.Get("api-version") == "" {
+		query.Add("api-version", adoPipelineOIDCAPIVersion)
+	}
+	if query.Get("serviceConnectionId") == "" {
+		query.Add("serviceConnectionId", a.conf.ServiceConnectionID)
+	}
+	if query.Get("audience") == "" {
+		query.Add("audience", "api://AzureADTokenExchange")
+	}
+	req.URL.RawQuery = query.Encode()
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.conf.IDTokenRequestToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("adoPipelineAssertion: cannot request token: %v", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("adoPipelineAssertion: cannot parse response: %v", err)
+	}
+
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("adoPipelineAssertion: received HTTP status %d with response: %s", resp.StatusCode, body)
+	}
+
+	var tokenRes struct {
+		Value *string `json:"oidcToken"`
+	}
+	if err := json.Unmarshal(body, &tokenRes); err != nil {
+		return nil, fmt.Errorf("adoPipelineAssertion: cannot unmarshal response: %v", err)
+	}
+
+	return tokenRes.Value, nil
+}
+
+func (a *ADOPipelineOIDCAuthorizer) tokenSource(ctx context.Context, req *http.Request) (Authorizer, error) {
+	assertion, err := a.adoPipelineAssertion(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if assertion == nil {
+		return nil, fmt.Errorf("ADOPipelineOIDCAuthorizer: nil JWT assertion received from ADOPipeline")
+	}
+
+	conf := clientCredentialsConfig{
+		Environment:        a.conf.Environment,
+		TenantID:           a.conf.TenantID,
+		AuxiliaryTenantIDs: a.conf.AuxiliaryTenantIDs,
+		ClientID:           a.conf.ClientID,
+		FederatedAssertion: *assertion,
+		Scopes:             a.conf.Scopes,
+		TokenURL:           a.conf.TokenURL,
+		Audience:           a.conf.Audience,
+	}
+
+	source, err := conf.TokenSource(ctx, clientCredentialsAssertionType)
+	if err != nil {
+		return nil, fmt.Errorf("ADOPipelineOIDCAuthorizer: building Authorizer: %+v", err)
+	}
+	return source, nil
+}
+
+func (a *ADOPipelineOIDCAuthorizer) Token(ctx context.Context, req *http.Request) (*oauth2.Token, error) {
+	source, err := a.tokenSource(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return source.Token(ctx, req)
+}
+
+func (a *ADOPipelineOIDCAuthorizer) AuxiliaryTokens(ctx context.Context, req *http.Request) ([]*oauth2.Token, error) {
+	source, err := a.tokenSource(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return source.AuxiliaryTokens(ctx, req)
+}
+
+type adoPipelineOIDCConfig struct {
+	// Environment is the national cloud environment to use
+	Environment environments.Environment
+
+	// TenantID is the required tenant ID for the primary token
+	TenantID string
+
+	// AuxiliaryTenantIDs is an optional list of tenant IDs for which to obtain additional tokens
+	AuxiliaryTenantIDs []string
+
+	// ClientID is the application's ID.
+	ClientID string
+
+	// ServiceConnectionID is the ADO service connection ID used when authenticating
+	ServiceConnectionID string
+
+	// IDTokenRequestURL is the URL for ADO Pipeline's OIDC provider.
+	IDTokenRequestURL string
+
+	// IDTokenRequestToken is the bearer token for the request to the OIDC provider.
+	IDTokenRequestToken string
+
+	// Scopes specifies a list of requested permission scopes (used for v2 tokens)
+	Scopes []string
+
+	// TokenURL is the clientCredentialsToken endpoint, which overrides the default endpoint constructed from a tenant ID
+	TokenURL string
+
+	// Audience optionally specifies the intended audience of the
+	// request.  If empty, the value of TokenURL is used as the
+	// intended audience.
+	Audience string
+}
+
+func (c *adoPipelineOIDCConfig) TokenSource(ctx context.Context) (Authorizer, error) {
+	return NewCachedAuthorizer(&ADOPipelineOIDCAuthorizer{
+		conf: c,
+	})
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
@@ -16,6 +16,7 @@ import (
 // - Client certificate authentication
 // - Client secret authentication
 // - OIDC authentication
+// - ADO Pipeline OIDC authentication
 // - GitHub OIDC authentication
 // - MSI authentication
 // - Azure CLI authentication
@@ -26,7 +27,8 @@ import (
 // For client certificate authentication, specify TenantID, ClientID and ClientCertificateData / ClientCertificatePath.
 // For client secret authentication, specify TenantID, ClientID and ClientSecret.
 // For OIDC authentication, specify TenantID, ClientID and OIDCAssertionToken.
-// For GitHub OIDC authentication, specify TenantID, ClientID, GitHubOIDCTokenRequestURL and GitHubOIDCTokenRequestToken.
+// For ADO Pipeline OIDC authentication, specify TenantID, ClientID, ADOPipelineServiceConnectionID, OIDCTokenRequestURL and OIDCTokenRequestToken.
+// For GitHub OIDC authentication, specify TenantID, ClientID, OIDCTokenRequestURL and OIDCTokenRequestToken.
 // MSI authentication (if enabled) using the Azure Metadata Service is then attempted
 // Azure CLI authentication (if enabled) is attempted last
 //
@@ -90,14 +92,34 @@ func NewAuthorizerFromCredentials(ctx context.Context, c Credentials, api enviro
 		}
 	}
 
-	if c.EnableAuthenticationUsingGitHubOIDC && strings.TrimSpace(c.TenantID) != "" && strings.TrimSpace(c.ClientID) != "" && strings.TrimSpace(c.GitHubOIDCTokenRequestURL) != "" && strings.TrimSpace(c.GitHubOIDCTokenRequestToken) != "" {
+	if c.EnableAuthenticationUsingADOPipelineOIDC && strings.TrimSpace(c.TenantID) != "" && strings.TrimSpace(c.ClientID) != "" && strings.TrimSpace(c.OIDCTokenRequestURL) != "" && strings.TrimSpace(c.OIDCTokenRequestToken) != "" && strings.TrimSpace(c.ADOPipelineServiceConnectionID) != "" {
+		opts := ADOPipelineOIDCAuthorizerOptions{
+			Api:                 api,
+			AuxiliaryTenantIds:  c.AuxiliaryTenantIDs,
+			ClientId:            c.ClientID,
+			Environment:         c.Environment,
+			IdTokenRequestUrl:   c.OIDCTokenRequestURL,
+			IdTokenRequestToken: c.OIDCTokenRequestToken,
+			ServiceConnectionId: c.ADOPipelineServiceConnectionID,
+			TenantId:            c.TenantID,
+		}
+		a, err := NewADOPipelineOIDCAuthorizer(context.Background(), opts)
+		if err != nil {
+			return nil, fmt.Errorf("could not configure ADOPipelineOIDC Authorizer: %s", err)
+		}
+		if a != nil {
+			return a, nil
+		}
+	}
+
+	if c.EnableAuthenticationUsingGitHubOIDC && strings.TrimSpace(c.TenantID) != "" && strings.TrimSpace(c.ClientID) != "" && strings.TrimSpace(c.OIDCTokenRequestURL) != "" && strings.TrimSpace(c.OIDCTokenRequestToken) != "" {
 		opts := GitHubOIDCAuthorizerOptions{
 			Api:                 api,
 			AuxiliaryTenantIds:  c.AuxiliaryTenantIDs,
 			ClientId:            c.ClientID,
 			Environment:         c.Environment,
-			IdTokenRequestUrl:   c.GitHubOIDCTokenRequestURL,
-			IdTokenRequestToken: c.GitHubOIDCTokenRequestToken,
+			IdTokenRequestUrl:   c.OIDCTokenRequestURL,
+			IdTokenRequestToken: c.OIDCTokenRequestToken,
 			TenantId:            c.TenantID,
 		}
 		a, err := NewGitHubOIDCAuthorizer(context.Background(), opts)

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
@@ -49,10 +49,16 @@ type Credentials struct {
 	// OIDCAssertionToken specifies the OIDC Assertion Token to authenticate using Client Credentials.
 	OIDCAssertionToken string
 
-	// EnableAuthenticationUsingGitHubOIDC specifies whether GitHub OIDC
+	// EnableAuthenticationUsingGitHubOIDC specifies whether GitHub OIDC should be checked.
 	EnableAuthenticationUsingGitHubOIDC bool
-	// GitHubOIDCTokenRequestURL specifies the URL for GitHub's OIDC provider
-	GitHubOIDCTokenRequestURL string
-	// GitHubOIDCTokenRequestToken specifies the bearer token for the request to GitHub's OIDC provider
-	GitHubOIDCTokenRequestToken string
+
+	// EnableAuthenticationUsingADOPipelineOIDC specifies whether ADO Pipeline OIDC should be checked.
+	EnableAuthenticationUsingADOPipelineOIDC bool
+
+	// OIDCTokenRequestURL specifies the URL for the OIDC provider
+	OIDCTokenRequestURL string
+	// OIDCTokenRequestToken specifies the bearer token for the request to the OIDC provider
+	OIDCTokenRequestToken string
+	// ADOPipelineServiceConnectionID specifies the ADO Service Connection ID to authenticate.
+	ADOPipelineServiceConnectionID string
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -443,16 +445,8 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 	// Instantiate a RetryableHttp client and configure its CheckRetry func
 	r := c.retryableClient(ctx, func(ctx context.Context, r *http.Response, err error) (bool, error) {
-		// First check for badly malformed responses
-		if r == nil {
-			if req.IsIdempotent() {
-				return true, nil
-			}
-			return false, fmt.Errorf("HTTP response was nil; connection may have been reset")
-		}
-
 		// Eventual consistency checks
-		if !c.DisableRetries {
+		if r != nil && !c.DisableRetries {
 			if r.StatusCode == http.StatusFailedDependency {
 				return true, nil
 			}
@@ -472,6 +466,19 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 					return shouldRetry, err
 				}
 			}
+		}
+
+		// Check for failed connections etc and decide if retries are appropriate
+		if r == nil {
+			if req.IsIdempotent() {
+				if !isResourceManagerHost(req) {
+					return extendedRetryPolicy(r, err)
+				}
+
+				return retryablehttp.DefaultRetryPolicy(ctx, r, err)
+			}
+
+			return false, fmt.Errorf("HTTP response was nil; connection may have been reset")
 		}
 
 		// Fall back to default retry policy to handle rate limiting, server errors etc.
@@ -615,7 +622,7 @@ func (c *Client) ExecutePaged(ctx context.Context, req *Request) (*Response, err
 			return resp, err
 		}
 	}
-	if nextLink == nil {
+	if nextLink == nil || string(*nextLink) == "" {
 		// This is the last page
 		return resp, nil
 	}
@@ -744,6 +751,115 @@ func containsStatusCode(expected []int, actual int) bool {
 	for _, v := range expected {
 		if actual == v {
 			return true
+		}
+	}
+
+	return false
+}
+
+// extendedRetryPolicy extends the defaultRetryPolicy implementation in go-retryablehhtp with
+// additional error conditions that should not be retried indefinitely
+// TODO - This should be removed as part of 5.0 release of AzureRM, and the base layer returned to the `retryablehttp.DefaultRetryPolicy` for all requests.
+func extendedRetryPolicy(resp *http.Response, err error) (bool, error) {
+	// A regular expression to match the error returned by net/http when the
+	// configured number of redirects is exhausted. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	redirectsErrorRe := regexp.MustCompile(`stopped after \d+ redirects\z`)
+
+	// A regular expression to match the error returned by net/http when the
+	// scheme specified in the URL is invalid. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	schemeErrorRe := regexp.MustCompile(`unsupported protocol scheme`)
+
+	// A regular expression to match the error returned by net/http when a
+	// request header or value is invalid. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	invalidHeaderErrorRe := regexp.MustCompile(`invalid header`)
+
+	// A regular expression to match the error returned by net/http when the
+	// TLS certificate is not trusted. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	notTrustedErrorRe := regexp.MustCompile(`certificate is not trusted`)
+
+	// A regular expression to catch dial timeouts in the underlying TCP session
+	// connection
+	tcpDialTCPRe := regexp.MustCompile(`dial tcp`)
+
+	// A regular expression to match complete packet loss
+	completePacketLossRe := regexp.MustCompile(`EOF`)
+
+	if err != nil {
+		var v *url.Error
+		if errors.As(err, &v) {
+			// Don't retry if the error was due to too many redirects.
+			if redirectsErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			// Don't retry if the error was due to an invalid protocol scheme.
+			if schemeErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			// Don't retry if the error was due to an invalid header.
+			if invalidHeaderErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			// Don't retry if the error was due to TLS cert verification failure.
+			if notTrustedErrorRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			if tcpDialTCPRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			if completePacketLossRe.MatchString(v.Error()) {
+				return false, v
+			}
+
+			var certificateVerificationError *tls.CertificateVerificationError
+			if ok := errors.As(v.Err, &certificateVerificationError); ok {
+				return false, v
+			}
+		}
+
+		// The error is likely recoverable so retry.
+		return true, nil
+	}
+
+	// 429 Too Many Requests is recoverable. Sometimes the server puts
+	// a Retry-After response header to indicate when the server is
+	// available to start processing request from client.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true, nil
+	}
+
+	// Check the response code. We retry on 500-range responses to allow
+	// the server time to recover, as 500's are typically not permanent
+	// errors and may relate to outages on the server side. This will catch
+	// invalid response codes as well, like 0 and 999.
+	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
+		return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+	}
+
+	return false, nil
+}
+
+// exclude Resource Manager calls from the network failure retry avoidance to help users on unreliable networks
+// This code path should be removed when the Data Plane separation work is completed and 5.0 ships.
+func isResourceManagerHost(req *Request) bool {
+	knownResourceManagerHosts := []string{
+		"management.azure.com",
+		"management.chinacloudapi.cn",
+		"management.usgovcloudapi.net",
+	}
+	if url := req.Request.URL; url != nil {
+		for _, host := range knownResourceManagerHosts {
+			if strings.Contains(url.Host, host) {
+				return true
+			}
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,8 +68,8 @@ github.com/hashicorp/go-azure-helpers/lang/pointer
 github.com/hashicorp/go-azure-helpers/lang/response
 github.com/hashicorp/go-azure-helpers/resourcemanager/features
 github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids
-# github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20240927.1005214
-## explicit; go 1.21
+# github.com/hashicorp/go-azure-sdk/microsoft-graph v0.20250131.1134653
+## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/microsoft-graph/administrativeunits/beta/administrativeunit
 github.com/hashicorp/go-azure-sdk/microsoft-graph/applications/beta/application
 github.com/hashicorp/go-azure-sdk/microsoft-graph/applications/stable/application
@@ -130,8 +130,8 @@ github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/stable/synch
 github.com/hashicorp/go-azure-sdk/microsoft-graph/users/beta/user
 github.com/hashicorp/go-azure-sdk/microsoft-graph/users/stable/manager
 github.com/hashicorp/go-azure-sdk/microsoft-graph/users/stable/user
-# github.com/hashicorp/go-azure-sdk/sdk v0.20240927.1005214
-## explicit; go 1.21
+# github.com/hashicorp/go-azure-sdk/sdk v0.20250131.1134653
+## explicit; go 1.22
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/claims
 github.com/hashicorp/go-azure-sdk/sdk/client


### PR DESCRIPTION
Update the go-azure-sdk to v0.20250131.1134653, with a couple of fixes below:

- Provider config: The GtihubOIDCRequest(URL|Token) fields in the sdk has been renamed to removing the Github prefix.

Meanwhile, this PR, as its azurerm [counterpart](https://github.com/hashicorp/terraform-provider-azurerm/pull/28674), exposes the ADO OIDC changes to the users:

1. Add a new provider property: `ado_pipeline_service_connection_id`
2. Extends the env var for the provider property `oidc_request_token`, to include `SYSTEM_ACCESSTOKEN`
3. Extends the env var for the provider property `oidc_request_url`, to include `SYSTEM_OIDCREQUESTURI`

## Test

### Github Action

```yaml
name: terraform-provider-azuread OIDC test
on: [workflow_dispatch]

permissions:
  id-token: write
  contents: read
jobs:
  build-and-deploy:
    runs-on: ubuntu-latest
    steps:
      - name: 'Checkout terraform-provider-azuread repo'
        uses: actions/checkout@v4
        with:
          repository: 'magodo/terraform-provider-azuread'
          ref: 'sdk_v0.20250131.1134653'
      - name: 'Setup Go'
        uses: actions/setup-go@v5
        with:
          go-version: '1.23'

      - name: 'Unit Test'
        run: |
          export TF_ACC=1
          export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
          export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
          export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
          go test -v -run="TestAccProvider_githubOidcAuth" ./internal/provider

      - name: 'E2E Test'
        run: |
          # Install provider
          go install 
          # Install terraform-client-import
          go install github.com/magodo/terraform-client-go/cmd/terraform-client-import@main

          # Import a RG
          export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
          export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
          export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
          export ARM_PROVIDER_ENHANCED_VALIDATION=1
          export ARM_RESOURCE_PROVIDER_REGISTRATIONS=none
          export ARM_USE_OIDC=true
          export APP_ID=${{ secrets.AAD_APP_OBJECT_ID }}
          ~/go/bin/terraform-client-import -type azuread_application -id /applications/${APP_ID} -path ~/go/bin/terraform-provider-azuread
```

![image](https://github.com/user-attachments/assets/363593be-018e-4650-a8d2-393841ecff43)

### ADO Pipeline

```yml
trigger: 
 - none

pool:
   vmImage: 'ubuntu-latest'

resources:
  repositories:
    - repository: terraform-provider-azuread
      type: github
      endpoint: magodo-pat-read-public-repo
      name: magodo/terraform-provider-azuread
      ref: sdk_v0.20250131.1134653

steps: 
- task: GoTool@0
  inputs:
    version: '1.23.3'

- checkout: terraform-provider-azuread

- task: AzureCLI@2
  inputs:
    azureSubscription: $(CONNECTION_ID)
    scriptType: bash
    scriptLocation: "inlineScript"
    inlineScript: |
      set -e

      # Unit Test
      go test -v -run="TestAccProvider_adoOidcAuth" ./internal/provider

      # E2E Test
      go install 
      go install github.com/magodo/terraform-client-go/cmd/terraform-client-import@main

      ~/go/bin/terraform-client-import -type azuread_application -id /applications/${APP_ID} -path ~/go/bin/terraform-provider-azuread

  env:
    TF_ACC: 1
    APP_ID: $(AAD_APP_OBJECT_ID)
    ARM_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
    ARM_TENANT_ID: $(AZURE_TENANT_ID)
    ARM_CLIENT_ID: $(AZURE_CLIENT_ID) 
    ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID: $(CONNECTION_ID)
    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
    SYSTEM_OIDCREQUESTURI: $(System.OidcRequestUri)
    ARM_PROVIDER_ENHANCED_VALIDATION: 1
    ARM_RESOURCE_PROVIDER_REGISTRATIONS: none
    ARM_USE_OIDC: true
    ARM_USE_CLI: false # Not necessary, just in case
```

![image](https://github.com/user-attachments/assets/f36ac492-57f7-4085-8c0a-1841f2b5ec39)
