### PR TITLE
fix(docs): correct resource IDs for importing delegated permissions and claims mapping policy

### DIFF
--- a/docs/resources/claims_mapping_policy.md
+++ b/docs/resources/claims_mapping_policy.md
@@ -73,6 +73,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Claims Mapping Policy can be imported using the object ID of the associated service principal and the ID of the claims mapping policy, e.g.
 
 ```shell
-terraform import azuread_claims_mapping_policy.my_policy /servicePrincipals/00000000-abcd-0000-0000-000000000000/claimsMappingPolicies/00000000-efgh-0000-0000-000000000000
+terraform import azuread_claims_mapping_policy.my_policy /policies/claimsMappingPolicies/00000000-0000-0000-0000-000000000000
 ```
 

--- a/docs/resources/claims_mapping_policy.md
+++ b/docs/resources/claims_mapping_policy.md
@@ -70,7 +70,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Claims Mapping Policy can be imported using the object ID of the associated service principal and the ID of the claims mapping policy, e.g.
+Claims Mapping Policies can be imported using the `id`, e.g.
 
 ```shell
 terraform import azuread_claims_mapping_policy.my_policy /policies/claimsMappingPolicies/00000000-0000-0000-0000-000000000000

--- a/docs/resources/claims_mapping_policy.md
+++ b/docs/resources/claims_mapping_policy.md
@@ -70,8 +70,9 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Claims Mapping Policy can be imported using the `id`, e.g.
+Claims Mapping Policy can be imported using the object ID of the associated service principal and the ID of the claims mapping policy, e.g.
 
 ```shell
-terraform import azuread_claims_mapping_policy.my_policy 00000000-0000-0000-0000-000000000000
+terraform import azuread_claims_mapping_policy.my_policy /servicePrincipals/00000000-abcd-0000-0000-000000000000/claimsMappingPolicies/00000000-efgh-0000-0000-000000000000
 ```
+

--- a/docs/resources/service_principal_claims_mapping_policy_assignment.md
+++ b/docs/resources/service_principal_claims_mapping_policy_assignment.md
@@ -46,7 +46,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Claims Mapping Policy can be imported using the `id`, in the form `/servicePrincipals/service-principal-uuid/claimsMappingPolicies/claims-mapping-policy-uuid`, e.g:
+Claims Mapping Policy Assignments can be imported using the `id`, in the form `/servicePrincipals/{servicePrincipalId}/claimsMappingPolicies/{claimsMappingPolicyId}`, e.g:
 
 ```shell
 terraform import azuread_service_principal_claims_mapping_policy_assignment.app /servicePrincipals/00000000-0000-0000-0000-000000000000/claimsMappingPolicies/11111111-0000-0000-0000-000000000000

--- a/docs/resources/service_principal_claims_mapping_policy_assignment.md
+++ b/docs/resources/service_principal_claims_mapping_policy_assignment.md
@@ -46,8 +46,8 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Claims Mapping Policy can be imported using the `id`, in the form `service-principal-uuid/claimsMappingPolicy/claims-mapping-policy-uuid`, e.g:
+Claims Mapping Policy can be imported using the `id`, in the form `/servicePrincipals/service-principal-uuid/claimsMappingPolicies/claims-mapping-policy-uuid`, e.g:
 
 ```shell
-terraform import azuread_service_principal_claims_mapping_policy_assignment.app 00000000-0000-0000-0000-000000000000/claimsMappingPolicy/11111111-0000-0000-0000-000000000000
+terraform import azuread_service_principal_claims_mapping_policy_assignment.app /servicePrincipals/00000000-0000-0000-0000-000000000000/claimsMappingPolicies/11111111-0000-0000-0000-000000000000
 ```

--- a/docs/resources/service_principal_delegated_permission_grant.md
+++ b/docs/resources/service_principal_delegated_permission_grant.md
@@ -133,5 +133,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Delegated permission grants can be imported using their ID, e.g.
 
 ```shell
-terraform import azuread_service_principal_delegated_permission_grant.example aaBBcDDeFG6h5JKLMN2PQrrssTTUUvWWxxxxxyyyzzz
+terraform import azuread_service_principal_delegated_permission_grant.example /oauth2PermissionGrants/aaBBcDDeFG6h5JKLMN2PQrrssTTUUvWWxxxxxyyyzzz
 ```

--- a/docs/resources/synchronization_job.md
+++ b/docs/resources/synchronization_job.md
@@ -88,7 +88,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Synchronization jobs can be imported using the `id`, e.g.
 
 ```shell
-terraform import azuread_synchronization_job.example 00000000-0000-0000-0000-000000000000/job/dataBricks.f5532fc709734b1a90e8a1fa9fd03a82.8442fd39-2183-419c-8732-74b6ce866bd5
+terraform import azuread_synchronization_job.example /servicePrincipals/00000000-0000-0000-0000-000000000000/synchronization/jobs/dataBricks.f5532fc709734b1a90e8a1fa9fd03a82.8442fd39-2183-419c-8732-74b6ce866bd5
 ```
 
--> This ID format is unique to Terraform and is composed of the Service Principal Object ID and the ID of the Synchronization Job Id in the format `{servicePrincipalId}/job/{jobId}`.
+-> This ID format is unique to Terraform and is composed of the Service Principal Object ID and the ID of the Synchronization Job Id in the format `/servicePrincipals/{servicePrincipalId}/synchronization/jobs/{synchronizationJobId}`.


### PR DESCRIPTION
- Updated docs for various resource to have correct resource IDs for imports.
  - `azuread_claims_mapping_policy`
  - `azuread_service_principal_delegated_permission_grant`
  - `azuread_synchronization_job`


Will fix #1647, #1652 and #1658.