### PR TITLE
`azuread_application_pre_authorized` - Fix unexpected removal of unmanaged pre-authorized apps

### DIFF
--- a/internal/services/applications/application_pre_authorized_resource.go
+++ b/internal/services/applications/application_pre_authorized_resource.go
@@ -260,7 +260,6 @@ func applicationPreAuthorizedResourceDelete(ctx context.Context, d *pluginsdk.Re
 	for _, a := range *app.Api.PreAuthorizedApplications {
 		if !strings.EqualFold(a.AppId.GetOrZero(), id.AppId) {
 			newPreAuthorizedApps = append(newPreAuthorizedApps, a)
-			break
 		}
 	}
 


### PR DESCRIPTION
Range breaks at first pre_authed app with a different id during deletion, but we must preserve all existing pre_authorized apps with a different id.

Shall fix [#1584](https://github.com/hashicorp/terraform-provider-azuread/issues/1584)