### PR TITLE
Update redirect URI validation to support `brk-multihub://` as a valid redirect URI scheme

### DIFF
--- a/internal/helpers/tf/validation/uri.go
+++ b/internal/helpers/tf/validation/uri.go
@@ -41,7 +41,7 @@ func IsRedirectUriFunc(urnAllowed bool, allowAllSchemes bool) pluginsdk.SchemaVa
 		// See https://docs.microsoft.com/en-us/azure/active-directory-b2c/tutorial-create-user-flows?pivots=b2c-custom-policy#register-the-proxyidentityexperienceframework-application
 		var allowedSchemes []string
 		if !allowAllSchemes {
-			allowedSchemes = []string{"http", "https", "ms-appx-web"}
+			allowedSchemes = []string{"http", "https", "ms-appx-web", "brk-multihub"}
 		}
 
 		warnings, errors = IsUriFunc(allowedSchemes, urnAllowed, true, true)(i, k)


### PR DESCRIPTION
Update redirect URI validation to support `brk-multihub://` as a valid redirect URI scheme, as it is needed when enabling nested app authentication for Outlook add-ins (https://learn.microsoft.com/en-us/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in#add-a-trusted-broker-through-spa-redirect)

This should fix https://github.com/hashicorp/terraform-provider-azuread/issues/1600#issue-2750569573