### PR TITLE
`azuread_group_role_management_policy` - stop drift by making `approval_status` computed

### DIFF
--- a/internal/services/policies/group_role_management_policy_resource.go
+++ b/internal/services/policies/group_role_management_policy_resource.go
@@ -220,6 +220,7 @@ func (r GroupRoleManagementPolicyResource) Arguments() map[string]*pluginsdk.Sch
 						Description: "The approval stages for the activation",
 						Type:        pluginsdk.TypeList,
 						Optional:    true,
+						Computed:    true,
 						MaxItems:    1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/policies/group_role_management_policy_resource_test.go
+++ b/internal/services/policies/group_role_management_policy_resource_test.go
@@ -21,6 +21,22 @@ import (
 
 type GroupRoleManagementPolicyResource struct{}
 
+func TestGroupRoleManagementPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group_role_management_policy", "test")
+	r := GroupRoleManagementPolicyResource{}
+
+	// Ignore the dangling resource post-test as the policy remains while the group is in a pending deletion state
+	data.ResourceTestIgnoreDangling(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestGroupRoleManagementPolicy_member(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_group_role_management_policy", "test")
 	r := GroupRoleManagementPolicyResource{}
@@ -84,6 +100,43 @@ func (GroupRoleManagementPolicyResource) Exists(ctx context.Context, clients *cl
 	}
 
 	return pointer.To(true), nil
+}
+
+func (GroupRoleManagementPolicyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "this" {
+  display_name     = "PAM Basic Test %[1]s"
+  security_enabled = true
+}
+
+resource "azuread_group_role_management_policy" "test" {
+  group_id = azuread_group.this.object_id
+  role_id  = "member"
+
+  active_assignment_rules {
+    expiration_required                = true
+    expire_after                       = "P30D"
+    require_justification              = true
+    require_multifactor_authentication = true
+    require_ticket_info                = false
+  }
+
+  eligible_assignment_rules {
+    expiration_required = false
+    expire_after        = "P365D"
+  }
+
+  activation_rules {
+    maximum_duration                   = "PT12H"
+    require_approval                   = false
+    require_justification              = true
+    require_multifactor_authentication = true
+    require_ticket_info                = true
+  }
+}
+`, data.RandomString)
 }
 
 func (GroupRoleManagementPolicyResource) member(data acceptance.TestData) string {

--- a/internal/services/policies/group_role_management_policy_resource_test.go
+++ b/internal/services/policies/group_role_management_policy_resource_test.go
@@ -21,14 +21,14 @@ import (
 
 type GroupRoleManagementPolicyResource struct{}
 
-func TestGroupRoleManagementPolicy_basic(t *testing.T) {
+func TestGroupRoleManagementPolicy_activationRules(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_group_role_management_policy", "test")
 	r := GroupRoleManagementPolicyResource{}
 
 	// Ignore the dangling resource post-test as the policy remains while the group is in a pending deletion state
 	data.ResourceTestIgnoreDangling(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.activationRules(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -102,7 +102,7 @@ func (GroupRoleManagementPolicyResource) Exists(ctx context.Context, clients *cl
 	return pointer.To(true), nil
 }
 
-func (GroupRoleManagementPolicyResource) basic(data acceptance.TestData) string {
+func (GroupRoleManagementPolicyResource) activationRules(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -115,25 +115,8 @@ resource "azuread_group_role_management_policy" "test" {
   group_id = azuread_group.this.object_id
   role_id  = "member"
 
-  active_assignment_rules {
-    expiration_required                = true
-    expire_after                       = "P30D"
-    require_justification              = true
-    require_multifactor_authentication = true
-    require_ticket_info                = false
-  }
-
-  eligible_assignment_rules {
-    expiration_required = false
-    expire_after        = "P365D"
-  }
-
   activation_rules {
-    maximum_duration                   = "PT12H"
-    require_approval                   = false
-    require_justification              = true
-    require_multifactor_authentication = true
-    require_ticket_info                = true
+    maximum_duration = "PT12H"
   }
 }
 `, data.RandomString)


### PR DESCRIPTION
This PR makes the `approval_status` consistent with the other properties in this resource that are Computed Optional, and resolves a bug where, when an `activation_rules` block is configured, previously an impossible change would always appear in plans.

I added a test (`TestGroupRoleManagementPolicy_activationRules`) that fails when run against the `main` branch:

```
   testcase.go:122: Step 1/2 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # azuread_group_role_management_policy.test will be updated in-place
          ~ resource "azuread_group_role_management_policy" "test" {
                id           = "Group_9dff2f65-d602-45ca-8195-55f0cccb7a1a_f305ca62-d9ae-44c7-b8e4-4b4ca5198e84"
                # (4 unchanged attributes hidden)
        
              ~ activation_rules {
                    # (6 unchanged attributes hidden)
        
                  - approval_stage {
                    }
                }
        
                # (3 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
2025-03-14T09:05:35.383-0400 [WARN]  sdk.helper_schema: Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.: tf_rpc=Configure tf_req_id=9bef211b-7ce6-72c0-0c43-32c0e8c4d9e1 tf_provider_addr=registry.terraform.io/hashicorp/azuread
--- FAIL: TestGroupRoleManagementPolicy_activationRules (52.86s)

FAIL
```

Fixes #1398 

Test:

<img width="593" alt="image" src="https://github.com/user-attachments/assets/4d40381f-e184-4c42-954f-b417d1225d0f" />
