### PR TITLE
Add `object_id` to `named_location`

### DIFF
--- a/docs/data-sources/named_location.md
+++ b/docs/data-sources/named_location.md
@@ -35,7 +35,8 @@ The following attributes are exported:
 * `country` - A `country` block as documented below, which describes a country-based named location.
 * `id` - The ID of the named location.
 * `ip` - An `ip` block as documented below, which describes an IP-based named location.
-* 
+* `object_id` - The object ID of the named location.
+
 ---
 
 `country` block exports the following:

--- a/docs/resources/named_location.md
+++ b/docs/resources/named_location.md
@@ -75,6 +75,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the named location.
+* `object_id` - The object ID of the named location.
 
 ## Timeouts
 

--- a/internal/services/conditionalaccess/named_location_data_source.go
+++ b/internal/services/conditionalaccess/named_location_data_source.go
@@ -81,6 +81,12 @@ func namedLocationDataSource() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"object_id": {
+				Description: "The object ID of the named location",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -123,6 +129,7 @@ func namedLocationDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData,
 		}
 
 		tf.Set(d, "display_name", pointer.From(namedLocation.DisplayName))
+		tf.Set(d, "object_id", pointer.From(namedLocation.Id))
 		tf.Set(d, "ip", flattenIPNamedLocation(&namedLocation))
 
 	case stable.CountryNamedLocation:
@@ -131,6 +138,7 @@ func namedLocationDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData,
 		}
 
 		tf.Set(d, "display_name", pointer.From(namedLocation.DisplayName))
+		tf.Set(d, "object_id", pointer.From(namedLocation.Id))
 		tf.Set(d, "country", flattenCountryNamedLocation(&namedLocation))
 	}
 

--- a/internal/services/conditionalaccess/named_location_resource.go
+++ b/internal/services/conditionalaccess/named_location_resource.go
@@ -119,6 +119,12 @@ func namedLocationResource() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"object_id": {
+				Description: "The object ID of the named location",
+				Type:        pluginsdk.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -261,6 +267,7 @@ func namedLocationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, m
 		}
 
 		tf.Set(d, "display_name", pointer.From(namedLocation.DisplayName))
+		tf.Set(d, "object_id", pointer.From(namedLocation.Id))
 		tf.Set(d, "ip", flattenIPNamedLocation(&namedLocation))
 
 	case stable.CountryNamedLocation:
@@ -269,6 +276,7 @@ func namedLocationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, m
 		}
 
 		tf.Set(d, "display_name", pointer.From(namedLocation.DisplayName))
+		tf.Set(d, "object_id", pointer.From(namedLocation.Id))
 		tf.Set(d, "country", flattenCountryNamedLocation(&namedLocation))
 	}
 


### PR DESCRIPTION
In the previous major version of the provider the following Terraform would work

```hcl
terraform {
  required_providers {
    azuread = {
      source  = "hashicorp/azuread"
      version = "~> 2.0"
    }
  }
}


resource "azuread_conditional_access_policy" "example" {
  display_name = "example policy"
  state        = "disabled"

  conditions {
    client_app_types = ["all"]

    applications {
      included_applications = ["All"]
    }

    locations {
      included_locations = ["All"]
      excluded_locations = [azuread_named_location.example.id]
    }

    users {
      included_users = ["All"]
    }
  }

  grant_controls {
    operator          = "OR"
    built_in_controls = ["block"]
  }

}

resource "azuread_named_location" "example" {
  display_name = "example"
  ip {
    ip_ranges = ["8.8.8.8/32"]
  }
}

```

However in the current version an error is produced due to the change in the `id` attribute and the following error is produced
```
╷
│ Error: Could not create conditional access policy
│ 
│   with azuread_conditional_access_policy.example,
│   on main.tf line 11, in resource "azuread_conditional_access_policy" "example":
│   11: resource "azuread_conditional_access_policy" "example" {
│ 
│ unexpected status 400 (400 Bad Request) with error: BadRequest: 1040: NamedLocation with id /identity/conditionalAccess/namedLocations/0c5924be-4bae-48ab-9245-ecbd46e3ee50 does
│ not exist in the directory.
╵
```

It is of course possible to get the correct value with `split` but this doesn't feel very elegant
```hcl
      excluded_locations = [split("/", azuread_named_location.example.id)[4]]
```

This PR adds the `object_id` to the `azuread_named_location` resource and data source using the ID returned from the graph API

It might be worth adding a new test on the `azuread_conditional_access_policy` resource that uses a named location - let me know if you'd like this added

Fixes: https://github.com/hashicorp/terraform-provider-azuread/issues/1504
