### PR TITLE
`azuread_conditional_access_policy` - support `everyTime` restrictions in `session_controls` request payload

### DIFF
--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -557,6 +557,14 @@ func conditionalAccessPolicyCustomizeDiff(_ context.Context, diff *pluginsdk.Res
 		return fmt.Errorf("when specifying `session_controls` but not `grant_controls`, one of the properties in the `session_controls` block must be set to an effective value in order for session controls to work")
 	}
 
+	if diff.Get("session_controls.#").(int) == 1 {
+		if diff.Get("session_controls.0.sign_in_frequency_interval").(string) == string(stable.SignInFrequencyInterval_EveryTime) {
+			if diff.Get("session_controls.0.sign_in_frequency").(int) != 0 || diff.Get("session_controls.0.sign_in_frequency_period").(string) != "" {
+				return fmt.Errorf("when `session_controls.sign_in_frequency_interval` is set to `%s`, `sign_in_frequency` and `sign_in_frequency_period` are not valid", stable.SignInFrequencyInterval_EveryTime)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -52,6 +52,27 @@ func TestAccConditionalAccessPolicy_signInFrequencyEveryTime(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+func TestAccConditionalAccessPolicy_signInFrequencyEveryTimeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_conditional_access_policy", "test")
+	r := ConditionalAccessPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.signinfrequencyintervalEverytime(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
 
 func TestAccConditionalAccessPolicy_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_conditional_access_policy", "test")

--- a/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource_test.go
@@ -38,7 +38,7 @@ func TestAccConditionalAccessPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccConditionalAccessPolicy_repro1225(t *testing.T) {
+func TestAccConditionalAccessPolicy_signInFrequencyEveryTime(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_conditional_access_policy", "test")
 	r := ConditionalAccessPolicyResource{}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR factors in API behaviour specific to defining `sign_in_frequency_interval` as `everyTime` where other settings are not allowed to be present, even if they are disabled/off.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_conditional_access_policy` - support `everyTime` restrictions on request payload


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1225

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
