### PR TITLE
use `go-version` for `link-milestone.yaml`

### DIFF
--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: ./.go-version
-
+          # we cannot use go-version-file here because no repositories are checked out so there is no file to reference
+          go-version: '1.24.1'
       - run: |
           go install github.com/stephybun/link-milestone@latest
           link-milestone


### PR DESCRIPTION
Link Milestone action always fails due to it not finding a `.go-version` file. Update to match `link-milestone.yaml` action on azurerm.