### PR TITLE
`azuread_directory_role_eligibility_schedule_request`: fix deletion logic

### DIFF
--- a/internal/services/directoryroles/client/client.go
+++ b/internal/services/directoryroles/client/client.go
@@ -10,20 +10,20 @@ import (
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/directoryroletemplates/stable/directoryroletemplate"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleassignment"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroledefinition"
-	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityschedule"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityscheduleinstance"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityschedulerequest"
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {
-	DirectoryObjectClient                         *directoryobject.DirectoryObjectClient
-	DirectoryRoleAssignmentClient                 *directoryroleassignment.DirectoryRoleAssignmentClient
-	DirectoryRoleClient                           *directoryrole.DirectoryRoleClient
-	DirectoryRoleDefinitionClient                 *directoryroledefinition.DirectoryRoleDefinitionClient
-	DirectoryRoleEligibilityScheduleClient        *directoryroleeligibilityschedule.DirectoryRoleEligibilityScheduleClient
-	DirectoryRoleEligibilityScheduleRequestClient *directoryroleeligibilityschedulerequest.DirectoryRoleEligibilityScheduleRequestClient
-	DirectoryRoleMemberClient                     *member.MemberClient
-	DirectoryRoleTemplateClient                   *directoryroletemplate.DirectoryRoleTemplateClient
+	DirectoryObjectClient                          *directoryobject.DirectoryObjectClient
+	DirectoryRoleAssignmentClient                  *directoryroleassignment.DirectoryRoleAssignmentClient
+	DirectoryRoleClient                            *directoryrole.DirectoryRoleClient
+	DirectoryRoleDefinitionClient                  *directoryroledefinition.DirectoryRoleDefinitionClient
+	DirectoryRoleEligibilityScheduleInstanceClient *directoryroleeligibilityscheduleinstance.DirectoryRoleEligibilityScheduleInstanceClient
+	DirectoryRoleEligibilityScheduleRequestClient  *directoryroleeligibilityschedulerequest.DirectoryRoleEligibilityScheduleRequestClient
+	DirectoryRoleMemberClient                      *member.MemberClient
+	DirectoryRoleTemplateClient                    *directoryroletemplate.DirectoryRoleTemplateClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -57,11 +57,11 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(directoryRoleMemberClient.Client)
 
-	directoryRoleEligibilityScheduleClient, err := directoryroleeligibilityschedule.NewDirectoryRoleEligibilityScheduleClientWithBaseURI(o.Environment.MicrosoftGraph)
+	directoryRoleEligibilityScheduleInstanceClient, err := directoryroleeligibilityscheduleinstance.NewDirectoryRoleEligibilityScheduleInstanceClientWithBaseURI(o.Environment.MicrosoftGraph)
 	if err != nil {
 		return nil, err
 	}
-	o.Configure(directoryRoleEligibilityScheduleClient.Client)
+	o.Configure(directoryRoleEligibilityScheduleInstanceClient.Client)
 
 	directoryRoleEligibilityScheduleRequestClient, err := directoryroleeligibilityschedulerequest.NewDirectoryRoleEligibilityScheduleRequestClientWithBaseURI(o.Environment.MicrosoftGraph)
 	if err != nil {
@@ -76,13 +76,13 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	o.Configure(directoryRoleTemplateClient.Client)
 
 	return &Client{
-		DirectoryObjectClient:                         directoryObjectClient,
-		DirectoryRoleAssignmentClient:                 directoryRoleAssignmentClient,
-		DirectoryRoleClient:                           directoryRoleClient,
-		DirectoryRoleDefinitionClient:                 directoryRoleDefinitionClient,
-		DirectoryRoleEligibilityScheduleClient:        directoryRoleEligibilityScheduleClient,
-		DirectoryRoleEligibilityScheduleRequestClient: directoryRoleEligibilityScheduleRequestClient,
-		DirectoryRoleMemberClient:                     directoryRoleMemberClient,
-		DirectoryRoleTemplateClient:                   directoryRoleTemplateClient,
+		DirectoryObjectClient:                          directoryObjectClient,
+		DirectoryRoleAssignmentClient:                  directoryRoleAssignmentClient,
+		DirectoryRoleClient:                            directoryRoleClient,
+		DirectoryRoleDefinitionClient:                  directoryRoleDefinitionClient,
+		DirectoryRoleEligibilityScheduleInstanceClient: directoryRoleEligibilityScheduleInstanceClient,
+		DirectoryRoleEligibilityScheduleRequestClient:  directoryRoleEligibilityScheduleRequestClient,
+		DirectoryRoleMemberClient:                      directoryRoleMemberClient,
+		DirectoryRoleTemplateClient:                    directoryRoleTemplateClient,
 	}, nil
 }

--- a/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource.go
+++ b/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource.go
@@ -193,11 +193,42 @@ func directoryRoleEligibilityScheduleRequestResourceRead(ctx context.Context, d 
 
 func directoryRoleEligibilityScheduleRequestResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
 	client := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleRequestClient
+	scheduleClient := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleClient
 	id := stable.NewRoleManagementDirectoryRoleEligibilityScheduleRequestID(d.Id())
 
 	resp, err := client.GetDirectoryRoleEligibilityScheduleRequest(ctx, id, directoryroleeligibilityschedulerequest.DefaultGetDirectoryRoleEligibilityScheduleRequestOperationOptions())
 	if err != nil {
-		return tf.ErrorDiagF(err, "Retrieving %s", id)
+		// Check if the Schedule still exists, any other error we must return
+		if !response.WasNotFound(resp.HttpResponse) {
+			return tf.ErrorDiagF(err, "Retrieving %s", id)
+		}
+
+		// After (typically) 45 days the request resources are purged by the service, however, the underlying resource (the schedule) has the same GUID, so we need to check if it's still there or Terraform will try to recreate this resource and fail as it already exists.
+		// TODO - This resource needs a redesign/replacement in the longer term to avoid this, however, this will likely be a breaking change requiring a major version to implement.
+		scheduleID := stable.NewRoleManagementDirectoryRoleEligibilityScheduleID(d.Id())
+		scheduleResp, err2 := scheduleClient.GetDirectoryRoleEligibilitySchedule(ctx, scheduleID, directoryroleeligibilityschedule.DefaultGetDirectoryRoleEligibilityScheduleOperationOptions())
+		if err2 != nil {
+			if response.WasNotFound(scheduleResp.HttpResponse) {
+				log.Printf("[DEBUG] %s was not found - removing from state", id)
+				return nil
+			}
+		}
+
+		roleEligibilitySchedule := scheduleResp.Model
+		if roleEligibilitySchedule == nil {
+			return tf.ErrorDiagF(errors.New("model was nil"), "API Error")
+		}
+
+		if resp, err := scheduleClient.DeleteDirectoryRoleEligibilitySchedule(ctx, scheduleID, directoryroleeligibilityschedule.DefaultDeleteDirectoryRoleEligibilityScheduleOperationOptions()); err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				log.Printf("[DEBUG] %s was not found - removing from state", id)
+				return nil
+			}
+
+			return tf.ErrorDiagF(err, "Deleting %s", scheduleID)
+		}
+
+		return nil
 	}
 
 	roleEligibilityScheduleRequest := resp.Model

--- a/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource.go
+++ b/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
-	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityschedule"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityscheduleinstance"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/rolemanagement/stable/directoryroleeligibilityschedulerequest"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -143,37 +143,37 @@ func directoryRoleEligibilityScheduleRequestResourceCreate(ctx context.Context, 
 
 func directoryRoleEligibilityScheduleRequestResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
 	client := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleRequestClient
-	scheduleClient := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleClient
+	instanceClient := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleInstanceClient
 	id := stable.NewRoleManagementDirectoryRoleEligibilityScheduleRequestID(d.Id())
 
 	resp, err := client.GetDirectoryRoleEligibilityScheduleRequest(ctx, id, directoryroleeligibilityschedulerequest.DefaultGetDirectoryRoleEligibilityScheduleRequestOperationOptions())
 	if err != nil {
-		// Check if the Schedule still exists, any other error we must return
 		if !response.WasNotFound(resp.HttpResponse) {
 			return tf.ErrorDiagF(err, "Retrieving %s", id)
 		}
 
-		// After (typically) 45 days the request resources are purged by the service, however, the underlying resource (the schedule) has the same GUID, so we need to check if it's still there or Terraform will try to recreate this resource and fail as it already exists.
-		// TODO - This resource needs a redesign/replacement in the longer term to avoid this, however, this will likely be a breaking change requiring a major version to implement.
-		scheduleID := stable.NewRoleManagementDirectoryRoleEligibilityScheduleID(d.Id())
-		scheduleResp, err2 := scheduleClient.GetDirectoryRoleEligibilitySchedule(ctx, scheduleID, directoryroleeligibilityschedule.DefaultGetDirectoryRoleEligibilityScheduleOperationOptions())
-		if err2 != nil {
-			if response.WasNotFound(scheduleResp.HttpResponse) {
-				log.Printf("[DEBUG] %s was not found - removing from state", id)
-				d.SetId("")
-				return nil
-			}
+		// The service typically purges request resources after 45 days while the eligible assignment remains.
+		// Request IDs are not a reliable identity for the resulting schedule, so locate the direct assignment by
+		// the principal, role definition and scope stored in Terraform state.
+		principalId := d.Get("principal_id").(string)
+		roleDefinitionId := d.Get("role_definition_id").(string)
+		directoryScopeId := d.Get("directory_scope_id").(string)
+
+		roleEligibilityScheduleInstance, err := findDirectRoleEligibilityScheduleInstance(ctx, instanceClient, principalId, roleDefinitionId, directoryScopeId)
+		if err != nil {
+			return tf.ErrorDiagF(err, "Retrieving role eligibility schedule instances for principal %q", principalId)
 		}
-		roleEligibilitySchedule := scheduleResp.Model
-		if roleEligibilitySchedule == nil {
-			return tf.ErrorDiagF(errors.New("model was nil"), "API Error")
+		if roleEligibilityScheduleInstance == nil {
+			log.Printf("[DEBUG] No direct role eligibility schedule instance was found for %s - removing from state", id)
+			d.SetId("")
+			return nil
 		}
 
-		tf.Set(d, "role_definition_id", roleEligibilitySchedule.RoleDefinitionId.GetOrZero())
-		tf.Set(d, "principal_id", roleEligibilitySchedule.PrincipalId.GetOrZero())
-		// Schedules do not expose the `justification` field, so we best effort it here and try and get it from config as it's a required property
+		tf.Set(d, "role_definition_id", roleEligibilityScheduleInstance.RoleDefinitionId.GetOrZero())
+		tf.Set(d, "principal_id", roleEligibilityScheduleInstance.PrincipalId.GetOrZero())
+		// Schedule instances do not expose justification, so retain the value from configuration/state.
 		tf.Set(d, "justification", d.Get("justification").(string))
-		tf.Set(d, "directory_scope_id", roleEligibilitySchedule.DirectoryScopeId.GetOrZero())
+		tf.Set(d, "directory_scope_id", roleEligibilityScheduleInstance.DirectoryScopeId.GetOrZero())
 
 		return nil
 	}
@@ -193,59 +193,43 @@ func directoryRoleEligibilityScheduleRequestResourceRead(ctx context.Context, d 
 
 func directoryRoleEligibilityScheduleRequestResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
 	client := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleRequestClient
-	scheduleClient := meta.(*clients.Client).DirectoryRoles.DirectoryRoleEligibilityScheduleClient
-	id := stable.NewRoleManagementDirectoryRoleEligibilityScheduleRequestID(d.Id())
-
-	resp, err := client.GetDirectoryRoleEligibilityScheduleRequest(ctx, id, directoryroleeligibilityschedulerequest.DefaultGetDirectoryRoleEligibilityScheduleRequestOperationOptions())
-	if err != nil {
-		// Check if the Schedule still exists, any other error we must return
-		if !response.WasNotFound(resp.HttpResponse) {
-			return tf.ErrorDiagF(err, "Retrieving %s", id)
-		}
-
-		// After (typically) 45 days the request resources are purged by the service, however, the underlying resource (the schedule) has the same GUID, so we need to check if it's still there or Terraform will try to recreate this resource and fail as it already exists.
-		// TODO - This resource needs a redesign/replacement in the longer term to avoid this, however, this will likely be a breaking change requiring a major version to implement.
-		scheduleID := stable.NewRoleManagementDirectoryRoleEligibilityScheduleID(d.Id())
-		scheduleResp, err2 := scheduleClient.GetDirectoryRoleEligibilitySchedule(ctx, scheduleID, directoryroleeligibilityschedule.DefaultGetDirectoryRoleEligibilityScheduleOperationOptions())
-		if err2 != nil {
-			if response.WasNotFound(scheduleResp.HttpResponse) {
-				log.Printf("[DEBUG] %s was not found - removing from state", id)
-				return nil
-			}
-		}
-
-		roleEligibilitySchedule := scheduleResp.Model
-		if roleEligibilitySchedule == nil {
-			return tf.ErrorDiagF(errors.New("model was nil"), "API Error")
-		}
-
-		if resp, err := scheduleClient.DeleteDirectoryRoleEligibilitySchedule(ctx, scheduleID, directoryroleeligibilityschedule.DefaultDeleteDirectoryRoleEligibilityScheduleOperationOptions()); err != nil {
-			if response.WasNotFound(resp.HttpResponse) {
-				log.Printf("[DEBUG] %s was not found - removing from state", id)
-				return nil
-			}
-
-			return tf.ErrorDiagF(err, "Deleting %s", scheduleID)
-		}
-
-		return nil
-	}
-
-	roleEligibilityScheduleRequest := resp.Model
-	if roleEligibilityScheduleRequest == nil {
-		return tf.ErrorDiagF(errors.New("model was nil"), "API Error")
-	}
 
 	properties := stable.UnifiedRoleEligibilityScheduleRequest{
 		Action:           pointer.To(stable.UnifiedRoleScheduleRequestActions_AdminRemove),
-		RoleDefinitionId: roleEligibilityScheduleRequest.RoleDefinitionId,
-		PrincipalId:      roleEligibilityScheduleRequest.PrincipalId,
-		Justification:    roleEligibilityScheduleRequest.Justification,
-		DirectoryScopeId: roleEligibilityScheduleRequest.DirectoryScopeId,
+		RoleDefinitionId: nullable.Value(d.Get("role_definition_id").(string)),
+		PrincipalId:      nullable.Value(d.Get("principal_id").(string)),
+		Justification:    nullable.Value(d.Get("justification").(string)),
+		DirectoryScopeId: nullable.Value(d.Get("directory_scope_id").(string)),
 	}
 
-	if _, err = client.CreateDirectoryRoleEligibilityScheduleRequest(ctx, properties, directoryroleeligibilityschedulerequest.DefaultCreateDirectoryRoleEligibilityScheduleRequestOperationOptions()); err != nil {
+	if _, err := client.CreateDirectoryRoleEligibilityScheduleRequest(ctx, properties, directoryroleeligibilityschedulerequest.DefaultCreateDirectoryRoleEligibilityScheduleRequestOperationOptions()); err != nil {
 		return tf.ErrorDiagF(err, "Removing role eligibility schedule request %q: %+v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func findDirectRoleEligibilityScheduleInstance(ctx context.Context, client *directoryroleeligibilityscheduleinstance.DirectoryRoleEligibilityScheduleInstanceClient, principalId, roleDefinitionId, directoryScopeId string) (*stable.UnifiedRoleEligibilityScheduleInstance, error) {
+	options := directoryroleeligibilityscheduleinstance.DefaultListDirectoryRoleEligibilityScheduleInstancesOperationOptions()
+	options.Filter = pointer.To(fmt.Sprintf("principalId eq '%s'", odata.EscapeSingleQuote(principalId)))
+
+	result, err := client.ListDirectoryRoleEligibilityScheduleInstancesComplete(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return matchDirectRoleEligibilityScheduleInstance(result.Items, principalId, roleDefinitionId, directoryScopeId), nil
+}
+
+func matchDirectRoleEligibilityScheduleInstance(instances []stable.UnifiedRoleEligibilityScheduleInstance, principalId, roleDefinitionId, directoryScopeId string) *stable.UnifiedRoleEligibilityScheduleInstance {
+	for i := range instances {
+		instance := &instances[i]
+		if instance.MemberType.GetOrZero() == "Direct" &&
+			instance.PrincipalId.GetOrZero() == principalId &&
+			instance.RoleDefinitionId.GetOrZero() == roleDefinitionId &&
+			instance.DirectoryScopeId.GetOrZero() == directoryScopeId {
+			return instance
+		}
 	}
 
 	return nil

--- a/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource_unit_test.go
+++ b/internal/services/directoryroles/directory_role_eligibility_schedule_request_resource_unit_test.go
@@ -1,0 +1,81 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package directoryroles
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
+	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
+)
+
+func TestMatchDirectRoleEligibilityScheduleInstance(t *testing.T) {
+	principalId := "b36e2f19-0a19-4302-8236-0acd7838dcdb"
+	roleDefinitionId := "fe930be7-5e62-47db-91af-98c3a49a38b1"
+	directoryScopeId := "/"
+
+	tests := []struct {
+		name      string
+		instances []stable.UnifiedRoleEligibilityScheduleInstance
+		wantId    string
+	}{
+		{
+			name: "direct assignment matches",
+			instances: []stable.UnifiedRoleEligibilityScheduleInstance{
+				eligibilityScheduleInstance("instance-id", "Direct", principalId, roleDefinitionId, directoryScopeId),
+			},
+			wantId: "instance-id",
+		},
+		{
+			name: "group assignment does not match",
+			instances: []stable.UnifiedRoleEligibilityScheduleInstance{
+				eligibilityScheduleInstance("instance-id", "Group", principalId, roleDefinitionId, directoryScopeId),
+			},
+		},
+		{
+			name: "different role does not match",
+			instances: []stable.UnifiedRoleEligibilityScheduleInstance{
+				eligibilityScheduleInstance("instance-id", "Direct", principalId, "62e90394-69f5-4237-9190-012177145e10", directoryScopeId),
+			},
+		},
+		{
+			name: "matching assignment is selected from multiple instances",
+			instances: []stable.UnifiedRoleEligibilityScheduleInstance{
+				eligibilityScheduleInstance("group-instance-id", "Group", principalId, roleDefinitionId, directoryScopeId),
+				eligibilityScheduleInstance("other-scope-instance-id", "Direct", principalId, roleDefinitionId, "/administrativeUnits/00000000-0000-0000-0000-000000000000"),
+				eligibilityScheduleInstance("direct-instance-id", "Direct", principalId, roleDefinitionId, directoryScopeId),
+			},
+			wantId: "direct-instance-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := matchDirectRoleEligibilityScheduleInstance(test.instances, principalId, roleDefinitionId, directoryScopeId)
+			if test.wantId == "" {
+				if result != nil {
+					t.Fatalf("expected no match, got %q", *result.Id)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected a match, got nil")
+			}
+			if result.Id == nil || *result.Id != test.wantId {
+				t.Fatalf("expected ID %q, got %#v", test.wantId, result.Id)
+			}
+		})
+	}
+}
+
+func eligibilityScheduleInstance(id, memberType, principalId, roleDefinitionId, directoryScopeId string) stable.UnifiedRoleEligibilityScheduleInstance {
+	return stable.UnifiedRoleEligibilityScheduleInstance{
+		Id:               &id,
+		MemberType:       nullable.Value(memberType),
+		PrincipalId:      nullable.Value(principalId),
+		RoleDefinitionId: nullable.Value(roleDefinitionId),
+		DirectoryScopeId: nullable.Value(directoryScopeId),
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Added deletion handling for `azuread_directory_role_eligibility_schedule_request`, which is automatically removed by the service after 45 days. This complements the previous support added in https://github.com/hashicorp/terraform-provider-azuread/pull/1682.


```console
# azuread_directory_role_eligibility_schedule_request.sample will be destroyed
  - resource "azuread_directory_role_eligibility_schedule_request" "sample" {
      - directory_scope_id = "/" -> null
      - id                 = "63d83de6-a801-f7c7-1caa-d749f927bc41" -> null
      - justification      = "Managed by Terraform" -> null
      - principal_id       = "f16915fb-a49e-cbfb-3ab9-3f30bdde3e5b" -> null
      - role_definition_id = "f16915fb-a49e-cbfb-3ab9-3f30bdde3e5b" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

azuread_directory_role_eligibility_schedule_request.sample: Destroying... [id=63d83de6-a801-f7c7-1caa-d749f927bc41]
╷
│ Error: Retrieving Role Management Directory Role Eligibility Schedule Request (Unified Role Eligibility Schedule Request: "63d83de6-a801-f7c7-1caa-d749f927bc41")
│ 
│ unexpected status 404 (404 Not Found) with error:
│ RoleAssignmentRequestNotFound: The role assignment request is not found
╵
```

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] ~~I have written new tests for my resource or datasource changes & updated any relevant documentation.~~
   - It's difficult to wait 45 days, so testing cannot be performed.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_directory_role_eligibility_schedule_request` - fix deletion logic about 45 days the request resources are purged by the service


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

https://github.com/hashicorp/terraform-provider-azuread/pull/1682

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

n/a

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
