### PR TITLE
`azuread_users` - Support nonunique mail nicknames

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -29,6 +29,9 @@ The following arguments are supported:
 * `employee_ids` - (Optional) The employee identifiers assigned to the users by the organisation.
 * `ignore_missing` - (Optional) Ignore missing users and return users that were found. The data source will still fail if no users are found. Cannot be specified with `return_all`. Defaults to `false`.
 * `mail_nicknames` - (Optional) The email aliases of the users.
+
+-> **Note:** `mail_nicknames` are not a unique identifier for users. If multiple users share the same `mail_nickname`, all matching users will be returned.
+
 * `mails` - (Optional) The SMTP email addresses of the users.
 * `object_ids` - (Optional) The object IDs of the users.
 * `return_all` - (Optional) When `true`, the data source will return all users. Cannot be used with `ignore_missing`. Defaults to `false`.

--- a/internal/services/users/user_resource_test.go
+++ b/internal/services/users/user_resource_test.go
@@ -282,6 +282,37 @@ resource "azuread_user" "testC" {
 `, data.RandomInteger, data.RandomPassword, data.RandomString)
 }
 
+func (UserResource) explicitDuplicateMailNicknames(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+data "azuread_domains" "test" {
+  only_initial = true
+}
+
+resource "azuread_user" "testAlice" {
+  user_principal_name = "acctestUser.%[1]d.Alice@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-Alice"
+  mail_nickname       = "acctestUser-%[1]d-Alice"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testBob1" {
+  user_principal_name = "acctestUser.%[1]d.Bob1@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-Bob1"
+  mail_nickname       = "acctestUser-%[1]d-Bob"
+  password            = "%[2]s"
+}
+
+resource "azuread_user" "testBob2" {
+  user_principal_name = "acctestUser.%[1]d.C@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctestUser-%[1]d-Bob2"
+  mail_nickname       = "acctestUser-%[1]d-Bob"
+  password            = "%[2]s"
+}
+`, data.RandomInteger, data.RandomPassword, data.RandomString)
+}
+
 func (UserResource) withRandomProvider(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}

--- a/internal/services/users/users_data_source.go
+++ b/internal/services/users/users_data_source.go
@@ -211,8 +211,6 @@ func usersDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta in
 		"userType",
 	}
 
-	filteredByNonUniqueField := false
-
 	if returnAll {
 		resp, err := client.ListUsers(ctx, user.ListUsersOperationOptions{Select: &fieldsToSelect})
 		if err != nil {
@@ -276,7 +274,6 @@ func usersDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta in
 			}
 
 		} else if mailNicknames, ok := d.Get("mail_nicknames").([]interface{}); ok && len(mailNicknames) > 0 {
-			filteredByNonUniqueField = true
 			expectedCount = len(mailNicknames)
 			for _, v := range mailNicknames {
 				options := user.ListUsersOperationOptions{
@@ -358,12 +355,9 @@ func usersDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta in
 		}
 	}
 
-	// Check that a valid number of users was returned
 	if !returnAll && !ignoreMissing {
-		if !filteredByNonUniqueField && len(foundUsers) != expectedCount {
-			return tf.ErrorDiagF(fmt.Errorf("expected: %d, actual: %d", expectedCount, len(foundUsers)), "Unexpected number of users returned")
-		} else if filteredByNonUniqueField && len(foundUsers) < expectedCount {
-			return tf.ErrorDiagF(fmt.Errorf("expected at least %d, actual: %d", expectedCount, len(foundUsers)), "Unexpected number of users returned")
+		if len(foundUsers) < expectedCount {
+			return tf.ErrorDiagF(fmt.Errorf("expected at least: %d, actual: %d", expectedCount, len(foundUsers)), "Unexpected number of users returned")
 		}
 	}
 

--- a/internal/services/users/users_data_source.go
+++ b/internal/services/users/users_data_source.go
@@ -360,7 +360,6 @@ func usersDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta in
 
 	// Check that a valid number of users was returned
 	if !returnAll && !ignoreMissing {
-		fmt.Println("############## HERE: ", expectedCount, len(foundUsers), filteredByNonUniqueField)
 		if !filteredByNonUniqueField && len(foundUsers) != expectedCount {
 			return tf.ErrorDiagF(fmt.Errorf("expected: %d, actual: %d", expectedCount, len(foundUsers)), "Unexpected number of users returned")
 		} else if filteredByNonUniqueField && len(foundUsers) < expectedCount {

--- a/internal/services/users/users_data_source_test.go
+++ b/internal/services/users/users_data_source_test.go
@@ -5,7 +5,6 @@ package users_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
@@ -94,10 +93,6 @@ func TestAccUsersDataSource_explicitDuplicateMailNicknames(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{{
 		Config: UsersDataSource{}.explicitDuplicateMailNicknames(data),
-		SkipFunc: func() (bool, error) {
-			fmt.Println(os.WriteFile("/Users/wyatt.fry/tests/TestAccUsersDataSource_explicitDuplicateMailNicknames.tf", []byte(UsersDataSource{}.explicitDuplicateMailNicknames(data)), 0666))
-			return true, nil
-		},
 		Check: acceptance.ComposeTestCheckFunc(
 			check.That(data.ResourceName).Key("user_principal_names.#").HasValue("3"),
 			check.That(data.ResourceName).Key("object_ids.#").HasValue("3"),

--- a/internal/services/users/users_data_source_test.go
+++ b/internal/services/users/users_data_source_test.go
@@ -96,7 +96,7 @@ func TestAccUsersDataSource_explicitDuplicateMailNicknames(t *testing.T) {
 		Check: acceptance.ComposeTestCheckFunc(
 			check.That(data.ResourceName).Key("user_principal_names.#").HasValue("3"),
 			check.That(data.ResourceName).Key("object_ids.#").HasValue("3"),
-			check.That(data.ResourceName).Key("mail_nicknames.#").HasValue("2"),
+			check.That(data.ResourceName).Key("mail_nicknames.#").HasValue("3"),
 			check.That(data.ResourceName).Key("employee_ids.#").HasValue("3"),
 			check.That(data.ResourceName).Key("users.#").HasValue("3"),
 		),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Data Source `azuread_users` - Support nonunique mail nicknames when retrieving users by their mail nicknames. Azure does not require that this property be unique, this PR updates the retrieval and validation to more closely match the Azure API.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="519" height="181" alt="image" src="https://github.com/user-attachments/assets/b73f231b-f669-4298-9d6f-0a88f2bd1bc4" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).
* `azuread_users` - * `azuread_users` - Support nonunique mail nicknames [GH-1762] [GH-1762]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #1758

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.