### PR TITLE
`azuread_service_principal` - Support a global_secure_access feature

### DIFF
--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -64,6 +64,7 @@ The following attributes are exported:
 * `description` - A description of the service principal provided for internal end-users.
 * `display_name` - The display name of the application associated with this service principal.
 * `features` - A `features` block as described below.
+* `feature_tags` - A `feature_tags` block as described below.
 * `homepage_url` - Home page or landing page of the associated application.
 * `login_url` - The URL where the service provider redirects the user to Azure AD to authenticate. Azure AD uses the URL to launch the application from Microsoft 365 or the Azure AD My Apps.
 * `logout_url` - The URL that will be used by Microsoft's authorization service to logout an user using OpenId Connect front-channel, back-channel or SAML logout protocols, taken from the associated application.
@@ -99,7 +100,18 @@ The following attributes are exported:
 * `custom_single_sign_on_app` - Whether this service principal represents a custom SAML application.
 * `enterprise_application` - Whether this service principal represents an Enterprise Application.
 * `gallery_application` - Whether this service principal represents a gallery application.
+* `global_secure_access_application` - Whether this service principal represents a Global Secure Access application.
 * `visible_to_users` - Whether this app is visible to users in My Apps and Office 365 Launcher.
+
+---
+
+`feature_tags` block exports the following:
+
+* `custom_single_sign_on` - Whether this service principal represents a custom SAML application.
+* `enterprise` - Whether this service principal represents an Enterprise Application.
+* `gallery` - Whether this service principal represents a gallery application.
+* `global_secure_access` - Whether this service principal represents a Global Secure Access application.
+* `hide` - Whether this app is visible to users in My Apps and Office 365 Launcher.
 
 ---
 

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -123,6 +123,7 @@ The following arguments are supported:
 * `custom_single_sign_on` - (Optional) Whether this service principal represents a custom SAML application. Enabling this will assign the `WindowsAzureActiveDirectoryCustomSingleSignOnApplication` tag. Defaults to `false`.
 * `enterprise` - (Optional) Whether this service principal represents an Enterprise Application. Enabling this will assign the `WindowsAzureActiveDirectoryIntegratedApp` tag. Defaults to `false`.
 * `gallery` - (Optional) Whether this service principal represents a gallery application. Enabling this will assign the `WindowsAzureActiveDirectoryGalleryApplicationNonPrimaryV1` tag. Defaults to `false`.
+* `global_secure_access` - (Optional) Whether this service principal represents a Global Secure Access application. Enabling this will assign the `IsAccessibleViaZTNAClient` and `PrivateAccessNonWebApplication` tags. Defaults to `false`.
 * `hide` - (Optional) Whether this app is invisible to users in My Apps and Office 365 Launcher. Enabling this will assign the `HideApp` tag. Defaults to `false`.
 
 ---

--- a/internal/services/serviceprincipals/service_principal_data_source.go
+++ b/internal/services/serviceprincipals/service_principal_data_source.go
@@ -128,6 +128,12 @@ func servicePrincipalData() *pluginsdk.Resource {
 							Computed:    true,
 						},
 
+						"global_secure_access": {
+							Description: "Whether this service principal represents a Global Secure Access application",
+							Type:        pluginsdk.TypeBool,
+							Computed:    true,
+						},
+
 						"hide": {
 							Description: "Whether this app is invisible to users in My Apps and Office 365 Launcher",
 							Type:        pluginsdk.TypeBool,
@@ -158,6 +164,12 @@ func servicePrincipalData() *pluginsdk.Resource {
 
 						"gallery_application": {
 							Description: "Whether this service principal represents a gallery application",
+							Type:        pluginsdk.TypeBool,
+							Computed:    true,
+						},
+
+						"global_secure_access_application": {
+							Description: "Whether this service principal represents a Global Secure Access application",
 							Type:        pluginsdk.TypeBool,
 							Computed:    true,
 						},

--- a/internal/services/serviceprincipals/service_principal_data_source_test.go
+++ b/internal/services/serviceprincipals/service_principal_data_source_test.go
@@ -98,6 +98,7 @@ func (ServicePrincipalDataSource) testCheckFunc(data acceptance.TestData) accept
 		check.That(data.ResourceName).Key("feature_tags.0.custom_single_sign_on").HasValue("true"),
 		check.That(data.ResourceName).Key("feature_tags.0.enterprise").HasValue("true"),
 		check.That(data.ResourceName).Key("feature_tags.0.gallery").HasValue("true"),
+		check.That(data.ResourceName).Key("feature_tags.0.global_secure_access").HasValue("true"),
 		check.That(data.ResourceName).Key("feature_tags.0.hide").HasValue("true"),
 		check.That(data.ResourceName).Key("homepage_url").HasValue(fmt.Sprintf("https://test-%d.internal", data.RandomInteger)),
 		check.That(data.ResourceName).Key("login_url").HasValue(fmt.Sprintf("https://test-%d.internal/login", data.RandomInteger)),

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -132,6 +132,12 @@ func servicePrincipalResource() *pluginsdk.Resource {
 							Optional:    true,
 						},
 
+						"global_secure_access": {
+							Description: "Whether this service principal represents a Global Secure Access application",
+							Type:        pluginsdk.TypeBool,
+							Optional:    true,
+						},
+
 						"hide": {
 							Description: "Whether this app is invisible to users in My Apps and Office 365 Launcher",
 							Type:        pluginsdk.TypeBool,
@@ -164,6 +170,12 @@ func servicePrincipalResource() *pluginsdk.Resource {
 
 						"gallery_application": {
 							Description: "Whether this service principal represents a gallery application",
+							Type:        pluginsdk.TypeBool,
+							Optional:    true,
+						},
+
+						"global_secure_access_application": {
+							Description: "Whether this service principal represents a Global Secure Access application",
 							Type:        pluginsdk.TypeBool,
 							Optional:    true,
 						},

--- a/internal/services/serviceprincipals/service_principal_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_resource_test.go
@@ -486,6 +486,7 @@ resource "azuread_service_principal" "test" {
     custom_single_sign_on = true
     enterprise            = true
     gallery               = true
+	global_secure_access  = true
     hide                  = true
   }
 }
@@ -511,6 +512,7 @@ resource "azuread_service_principal" "test" {
     custom_single_sign_on = false
     enterprise            = false
     gallery               = false
+	global_secure_access  = false
     hide                  = false
   }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the global secure access feature tag to the service principal resource.
The goal is to enable configuration and management of service principals that utilize Global Secure Access features.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azuread_service_principal - support for the global secure access feature tag


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

n/a

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

n/a

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
