### PR TITLE
applications: retry on 409 after creating application

### DIFF
--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1241,6 +1241,7 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 
 	// Attempt to patch the newly created application and set the display name, which will tell us whether it exists yet, then set it back to the desired value.
 	// The SDK handles retries for us here in the event of 404, 429 or 5xx, then returns after giving up.
+	// Our retry function also retries on 409.
 	uid, err := uuid.GenerateUUID()
 	if err != nil {
 		return tf.ErrorDiagF(err, "Failed to generate a UUID")

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1241,7 +1241,7 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 
 	// Attempt to patch the newly created application and set the display name, which will tell us whether it exists yet, then set it back to the desired value.
 	// The SDK handles retries for us here in the event of 404, 429 or 5xx, then returns after giving up.
-	// Our retry function also retries on 409.
+	// Due to an unusual implementation on this service, the retry function also retries on 409. See https://github.com/hashicorp/terraform-provider-azuread/issues/1764#issuecomment-3282278691 for more information.
 	uid, err := uuid.GenerateUUID()
 	if err != nil {
 		return tf.ErrorDiagF(err, "Failed to generate a UUID")

--- a/internal/services/applications/applications.go
+++ b/internal/services/applications/applications.go
@@ -27,7 +27,7 @@ import (
 
 func applicationUpdateRetryFunc() client.RequestRetryFunc {
 	return func(resp *http.Response, o *odata.OData) (bool, error) {
-		if response.WasNotFound(resp) {
+		if response.WasNotFound(resp) || response.WasConflict(resp) {
 			return true, nil
 		} else if response.WasBadRequest(resp) && o != nil && o.Error != nil {
 			return o.Error.Match("Permission (scope or role) cannot be deleted or updated unless disabled first"), nil

--- a/internal/services/applications/applications.go
+++ b/internal/services/applications/applications.go
@@ -27,6 +27,7 @@ import (
 
 func applicationUpdateRetryFunc() client.RequestRetryFunc {
 	return func(resp *http.Response, o *odata.OData) (bool, error) {
+		// inconsistent state on this resource can result in a 409 Conflict being returned, in this exception case we retry as per the service design, see  https://github.com/hashicorp/terraform-provider-azuread/issues/1764#issuecomment-3282278691 for more information.
 		if response.WasNotFound(resp) || response.WasConflict(resp) {
 			return true, nil
 		} else if response.WasBadRequest(resp) && o != nil && o.Error != nil {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

We recently started experiencing the issue reported at https://github.com/hashicorp/terraform-provider-azuread/issues/1764.  We have engaged Azure Support and I've posted their response in a [comment on the issue.](https://github.com/hashicorp/terraform-provider-azuread/issues/1764#issuecomment-3282278691).

This is my first contribution to this project, and given the simplicity of it, I am hopeful that a maintainer or regular contributor will test it.  I _am_ able to `build`, but of course the change is quite small.  Since the provider is depending on the SDK for handling other retry-able errors, I'm hopeful we can add the 409 -- admittedly, I have not interrogated the SDK.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_application` - retry in case of 409 conflict, resolves [issue 1764](https://github.com/hashicorp/terraform-provider-azuread/issues/1764)


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1764 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
