### PR TITLE
Add groups attribute to azuread_groups data source

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -73,7 +73,17 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `display_names` - The display names of the groups.
+* `groups` - A list of groups. Each `group` object provides the attributes documented below.
 * `object_ids` - The object IDs of the groups.
+
+---
+
+`group` object exports the following:
+
+* `display_name` - The display name of the group.
+* `mail_enabled` - Whether the group is mail-enabled.
+* `object_id` - The object ID of the group.
+* `security_enabled` - Whether the group is security-enabled.
 
 ## Timeouts
 

--- a/internal/services/groups/groups_data_source.go
+++ b/internal/services/groups/groups_data_source.go
@@ -65,6 +65,39 @@ func groupsDataSource() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"groups": {
+				Description: "A list of groups",
+				Type:        pluginsdk.TypeList,
+				Computed:    true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"display_name": {
+							Description: "The display name of the group",
+							Type:        pluginsdk.TypeString,
+							Computed:    true,
+						},
+
+						"mail_enabled": {
+							Description: "Whether the group is mail-enabled",
+							Type:        pluginsdk.TypeBool,
+							Computed:    true,
+						},
+
+						"object_id": {
+							Description: "The object ID of the group",
+							Type:        pluginsdk.TypeString,
+							Computed:    true,
+						},
+
+						"security_enabled": {
+							Description: "Whether the group is security-enabled",
+							Type:        pluginsdk.TypeBool,
+							Computed:    true,
+						},
+					},
+				},
+			},
+
 			"ignore_missing": {
 				Description:   "Ignore missing groups and return groups that were found. The data source will still fail if no groups are found",
 				Type:          pluginsdk.TypeBool,
@@ -210,6 +243,8 @@ func groupsDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta i
 
 	newDisplayNames := make([]string, 0)
 	newObjectIds := make([]string, 0)
+	groupList := make([]map[string]interface{}, 0)
+
 	for _, group := range groups {
 		if group.Id == nil {
 			return tf.ErrorDiagF(errors.New("group ID was nil"), "Bad API response")
@@ -220,6 +255,13 @@ func groupsDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta i
 
 		newObjectIds = append(newObjectIds, *group.Id)
 		newDisplayNames = append(newDisplayNames, group.DisplayName.GetOrZero())
+
+		g := make(map[string]interface{})
+		g["display_name"] = group.DisplayName.GetOrZero()
+		g["mail_enabled"] = group.MailEnabled.GetOrZero()
+		g["object_id"] = group.Id
+		g["security_enabled"] = group.SecurityEnabled.GetOrZero()
+		groupList = append(groupList, g)
 	}
 
 	h := sha1.New()
@@ -232,6 +274,7 @@ func groupsDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta i
 	tf.Set(d, "object_ids", newObjectIds)
 	tf.Set(d, "display_names", newDisplayNames)
 	tf.Set(d, "display_name_prefix", displayNamePrefix)
+	tf.Set(d, "groups", groupList)
 
 	return nil
 }

--- a/internal/services/groups/groups_data_source_test.go
+++ b/internal/services/groups/groups_data_source_test.go
@@ -31,6 +31,7 @@ func TestAccGroupsDataSource_byDisplayNames(t *testing.T) {
 			Config: r.byDisplayNames(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("groups.#").HasValue("2"),
 				check.That(data.ResourceName).Key("object_ids.#").HasValue("2"),
 			),
 		},
@@ -49,6 +50,7 @@ func TestAccGroupsDataSource_byDisplayNamesIgnoreMissing(t *testing.T) {
 			Config: r.byDisplayNamesIgnoreMissing(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("groups.#").HasValue("2"),
 				check.That(data.ResourceName).Key("object_ids.#").HasValue("2"),
 			),
 		},
@@ -68,6 +70,7 @@ func TestAccGroupsDataSource_byDisplayNamePrefix(t *testing.T) {
 			Config: r.byDisplayNamePrefix(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").MatchesRegex(moreThanZero),
+				check.That(data.ResourceName).Key("groups.#").MatchesRegex(moreThanZero),
 				check.That(data.ResourceName).Key("object_ids.#").MatchesRegex(moreThanZero),
 			),
 		},
@@ -86,6 +89,7 @@ func TestAccGroupsDataSource_byObjectIds(t *testing.T) {
 			Config: r.byObjectIds(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").HasValue("2"),
+				check.That(data.ResourceName).Key("groups.#").HasValue("2"),
 				check.That(data.ResourceName).Key("object_ids.#").HasValue("2"),
 			),
 		},
@@ -100,6 +104,7 @@ func TestAccGroupsDataSource_noNames(t *testing.T) {
 			Config: GroupsDataSource{}.noNames(),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").HasValue("0"),
+				check.That(data.ResourceName).Key("groups.#").HasValue("0"),
 				check.That(data.ResourceName).Key("object_ids.#").HasValue("0"),
 			),
 		},
@@ -118,6 +123,7 @@ func TestAccGroupsDataSource_returnAll(t *testing.T) {
 			Config: r.returnAll(),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("groups.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
 			),
 		},
@@ -136,6 +142,7 @@ func TestAccGroupsDataSource_returnAllMailEnabled(t *testing.T) {
 			Config: r.returnAllMailEnabled(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("groups.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids").ValidatesWith(testCheckHasOnlyMailEnabledGroups()),
 			),
@@ -155,6 +162,7 @@ func TestAccGroupsDataSource_returnAllSecurityEnabled(t *testing.T) {
 			Config: r.returnAllSecurityEnabled(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("groups.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids").ValidatesWith(testCheckHasOnlySecurityEnabledGroups()),
 			),
@@ -174,6 +182,7 @@ func TestAccGroupsDataSource_returnAllMailNotSecurityEnabled(t *testing.T) {
 			Config: r.returnAllMailNotSecurityEnabled(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("groups.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids").ValidatesWith(testCheckHasOnlyMailEnabledGroupsNotSecurityEnabledGroups()),
 			),
@@ -193,6 +202,7 @@ func TestAccGroupsDataSource_returnAllSecurityNotMailEnabled(t *testing.T) {
 			Config: r.returnAllSecurityNotMailEnabled(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("display_names.#").Exists(),
+				check.That(data.ResourceName).Key("groups.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids.#").Exists(),
 				check.That(data.ResourceName).Key("object_ids").ValidatesWith(testCheckHasOnlySecurityEnabledGroupsNotMailEnabledGroups()),
 			),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add a `groups` attribute to the `azuread_groups` data source similar to the [`users`](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/users#users-1) attribute on the `azuread_users` data source. This would allow for human meaningful `for_each` keys for resources that take object IDs.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The above link 404s.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `data.azuread_groups` - add `groups` attribute


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
