### PR TITLE
Fix timeout issue for groupFindByName

### DIFF
--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -41,7 +41,7 @@ func groupWithoutMembersResource() *pluginsdk.Resource {
 		UpdateContext: groupWithoutMembersResourceUpdate,
 		DeleteContext: groupWithoutMembersResourceDelete,
 
-		CustomizeDiff: groupWithoutMembersResourceCustomizeDiff,
+		CustomizeDiff: groupWithoutMembersResourceCustomizeDiff(5 * time.Minute),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(20 * time.Minute),
@@ -309,98 +309,106 @@ func groupWithoutMembersResource() *pluginsdk.Resource {
 	}
 }
 
-func groupWithoutMembersResourceCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
-	client := meta.(*clients.Client).Groups.GroupClientBeta
+func groupWithoutMembersResourceCustomizeDiff(groupReadTimeout time.Duration) pluginsdk.CustomizeDiffFunc {
+	return func(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
+		client := meta.(*clients.Client).Groups.GroupClientBeta
 
-	// Check for duplicate names
-	oldDisplayName, newDisplayName := diff.GetChange("display_name")
-	if pluginsdk.ValueIsNotEmptyOrUnknown(diff.Id()) && diff.Get("prevent_duplicate_names").(bool) && pluginsdk.ValueIsNotEmptyOrUnknown(newDisplayName) &&
-		(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
-		result, err := groupFindByName(ctx, client, newDisplayName.(string))
-		if err != nil {
-			return fmt.Errorf("could not check for existing group(s): %+v", err)
-		}
-		if result != nil && len(*result) > 0 {
-			for _, existingGroup := range *result {
-				if existingGroup.Id == nil {
-					return fmt.Errorf("API error: group returned with nil object ID during duplicate name check")
-				}
-				if diff.Id() == "" || diff.Id() == *existingGroup.Id {
-					return tf.ImportAsDuplicateError("azuread_group", *existingGroup.Id, newDisplayName.(string))
+		// CustomizeDiff does not have access to a ResourceData to call d.Timeout(...).
+		// We have to specify our own timeout here.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, groupReadTimeout)
+		defer cancel()
+
+		// Check for duplicate names
+		oldDisplayName, newDisplayName := diff.GetChange("display_name")
+		if pluginsdk.ValueIsNotEmptyOrUnknown(diff.Id()) && diff.Get("prevent_duplicate_names").(bool) && pluginsdk.ValueIsNotEmptyOrUnknown(newDisplayName) &&
+			(oldDisplayName.(string) == "" || oldDisplayName.(string) != newDisplayName.(string)) {
+			result, err := groupFindByName(ctx, client, newDisplayName.(string))
+			if err != nil {
+				return fmt.Errorf("could not check for existing group(s): %+v", err)
+			}
+			if result != nil && len(*result) > 0 {
+				for _, existingGroup := range *result {
+					if existingGroup.Id == nil {
+						return fmt.Errorf("API error: group returned with nil object ID during duplicate name check")
+					}
+					if diff.Id() == "" || diff.Id() == *existingGroup.Id {
+						return tf.ImportAsDuplicateError("azuread_group", *existingGroup.Id, newDisplayName.(string))
+					}
 				}
 			}
 		}
-	}
 
-	mailEnabled := diff.Get("mail_enabled").(bool)
-	securityEnabled := diff.Get("security_enabled").(bool)
-	groupTypes := make([]string, 0)
-	for _, v := range diff.Get("types").(*pluginsdk.Set).List() {
-		groupTypes = append(groupTypes, v.(string))
-	}
-
-	if slices.Contains(groupTypes, GroupTypeDynamicMembership) && diff.Get("dynamic_membership.#").(int) == 0 {
-		return fmt.Errorf("`dynamic_membership` must be specified when `types` contains %q", GroupTypeDynamicMembership)
-	}
-
-	if mailEnabled && !slices.Contains(groupTypes, GroupTypeUnified) {
-		return fmt.Errorf("`types` must contain %q for mail-enabled groups", GroupTypeUnified)
-	}
-
-	if !mailEnabled && slices.Contains(groupTypes, GroupTypeUnified) {
-		return fmt.Errorf("`mail_enabled` must be true for unified groups")
-	}
-
-	if mailNickname := diff.Get("mail_nickname").(string); mailEnabled && mailNickname == "" {
-		return fmt.Errorf("`mail_nickname` is required for mail-enabled groups")
-	}
-
-	if diff.Get("assignable_to_role").(bool) && !securityEnabled {
-		return fmt.Errorf("`assignable_to_role` can only be `true` for security-enabled groups")
-	}
-
-	visibilityOld, visibilityNew := diff.GetChange("visibility")
-
-	if !slices.Contains(groupTypes, GroupTypeUnified) {
-		if autoSubscribeNewMembers, ok := diff.GetOk("auto_subscribe_new_members"); ok && autoSubscribeNewMembers.(bool) {
-			return fmt.Errorf("`auto_subscribe_new_members` is only supported for unified groups")
+		mailEnabled := diff.Get("mail_enabled").(bool)
+		securityEnabled := diff.Get("security_enabled").(bool)
+		groupTypes := make([]string, 0)
+		for _, v := range diff.Get("types").(*pluginsdk.Set).List() {
+			groupTypes = append(groupTypes, v.(string))
 		}
 
-		if behaviors, ok := diff.GetOk("behaviors"); ok && len(behaviors.(*pluginsdk.Set).List()) > 0 {
-			return fmt.Errorf("`behaviors` is only supported for unified groups")
+		if slices.Contains(groupTypes, GroupTypeDynamicMembership) && diff.Get("dynamic_membership.#").(int) == 0 {
+			return fmt.Errorf("`dynamic_membership` must be specified when `types` contains %q", GroupTypeDynamicMembership)
 		}
 
-		if allowExternalSenders, ok := diff.GetOk("external_senders_allowed"); ok && allowExternalSenders.(bool) {
-			return fmt.Errorf("`external_senders_allowed` is only supported for unified groups")
+		if mailEnabled && !slices.Contains(groupTypes, GroupTypeUnified) {
+			return fmt.Errorf("`types` must contain %q for mail-enabled groups", GroupTypeUnified)
 		}
 
-		if hideFromAddressLists, ok := diff.GetOk("hide_from_address_lists"); ok && hideFromAddressLists.(bool) {
-			return fmt.Errorf("`hide_from_address_lists` is only supported for unified groups")
+		if !mailEnabled && slices.Contains(groupTypes, GroupTypeUnified) {
+			return fmt.Errorf("`mail_enabled` must be true for unified groups")
 		}
 
-		if hideFromOutlookClients, ok := diff.GetOk("hide_from_outlook_clients"); ok && hideFromOutlookClients.(bool) {
-			return fmt.Errorf("`hide_from_outlook_clients` is only supported for unified groups")
+		if mailNickname := diff.Get("mail_nickname").(string); mailEnabled && mailNickname == "" {
+			return fmt.Errorf("`mail_nickname` is required for mail-enabled groups")
 		}
 
-		if provisioning, ok := diff.GetOk("provisioning_options"); ok && len(provisioning.(*pluginsdk.Set).List()) > 0 {
-			return fmt.Errorf("`provisioning_options` is only supported for unified groups")
+		if diff.Get("assignable_to_role").(bool) && !securityEnabled {
+			return fmt.Errorf("`assignable_to_role` can only be `true` for security-enabled groups")
 		}
 
-		if theme := diff.Get("theme"); theme.(string) != "" {
-			return fmt.Errorf("`theme` is only supported for unified groups")
+		visibilityOld, visibilityNew := diff.GetChange("visibility")
+
+		if !slices.Contains(groupTypes, GroupTypeUnified) {
+			if autoSubscribeNewMembers, ok := diff.GetOk("auto_subscribe_new_members"); ok && autoSubscribeNewMembers.(bool) {
+				return fmt.Errorf("`auto_subscribe_new_members` is only supported for unified groups")
+			}
+
+			if behaviors, ok := diff.GetOk("behaviors"); ok && len(behaviors.(*pluginsdk.Set).List()) > 0 {
+				return fmt.Errorf("`behaviors` is only supported for unified groups")
+			}
+
+			if allowExternalSenders, ok := diff.GetOk("external_senders_allowed"); ok && allowExternalSenders.(bool) {
+				return fmt.Errorf("`external_senders_allowed` is only supported for unified groups")
+			}
+
+			if hideFromAddressLists, ok := diff.GetOk("hide_from_address_lists"); ok && hideFromAddressLists.(bool) {
+				return fmt.Errorf("`hide_from_address_lists` is only supported for unified groups")
+			}
+
+			if hideFromOutlookClients, ok := diff.GetOk("hide_from_outlook_clients"); ok && hideFromOutlookClients.(bool) {
+				return fmt.Errorf("`hide_from_outlook_clients` is only supported for unified groups")
+			}
+
+			if provisioning, ok := diff.GetOk("provisioning_options"); ok && len(provisioning.(*pluginsdk.Set).List()) > 0 {
+				return fmt.Errorf("`provisioning_options` is only supported for unified groups")
+			}
+
+			if theme := diff.Get("theme"); theme.(string) != "" {
+				return fmt.Errorf("`theme` is only supported for unified groups")
+			}
+
+			if visibilityNew.(string) == GroupVisibilityHiddenMembership {
+				return fmt.Errorf("`visibility` can only be %q for unified groups", GroupVisibilityHiddenMembership)
+			}
 		}
 
-		if visibilityNew.(string) == GroupVisibilityHiddenMembership {
-			return fmt.Errorf("`visibility` can only be %q for unified groups", GroupVisibilityHiddenMembership)
+		if (visibilityOld.(string) == GroupVisibilityPrivate || visibilityOld.(string) == GroupVisibilityPublic) &&
+			visibilityNew.(string) == GroupVisibilityHiddenMembership {
+			diff.ForceNew("visibility")
 		}
+
+		return nil
 	}
-
-	if (visibilityOld.(string) == GroupVisibilityPrivate || visibilityOld.(string) == GroupVisibilityPublic) &&
-		visibilityNew.(string) == GroupVisibilityHiddenMembership {
-		diff.ForceNew("visibility")
-	}
-
-	return nil
 }
 
 func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {

--- a/internal/services/groups/groups.go
+++ b/internal/services/groups/groups.go
@@ -25,6 +25,7 @@ func groupDefaultMailNickname() string {
 	return resultString[:8] + "-" + resultString[8:]
 }
 
+// NEVER call this function without a timeout context --> CustomDiff for example
 func groupFindByName(ctx context.Context, client *groupBeta.GroupClient, displayName string) (*[]beta.Group, error) {
 	options := groupBeta.ListGroupsOperationOptions{
 		Filter: pointer.To(fmt.Sprintf("displayName eq '%s'", displayName)),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes the timeout issue when checking for existing group display name

Terraform provider CustomDiff functions are not CRUD operations and therefore does not include a timeout in the passed context. CustomDiffs normally should not include remote calls, but client.ListGroups is used as a remote call to check in order to prevent duplicates.
Since CustomDiff context doesn't have a timeout attached, the PR fix will attach one in the helper function if a context without timeout is passed.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
Manual testing only, since I don't have access to a full test infrastructure

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_group` - fix timeout issue when display_name is renamed


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1541
Fixes #1634

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
