### PR TITLE
Make `access_type` required and support application roles and SharePoint URLs

### DIFF
--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -16,6 +16,8 @@ When authenticated with a user principal, this resource requires one of the foll
 
 ## Example Usage
 
+### Granting Group Membership
+
 ```terraform
 resource "azuread_group" "example" {
   display_name     = "example-group"
@@ -28,42 +30,85 @@ resource "azuread_access_package_catalog" "example" {
 }
 
 resource "azuread_access_package_resource_catalog_association" "example" {
-  catalog_id             = azuread_access_package_catalog.example_catalog.id
-  resource_origin_id     = azuread_group.example_group.object_id
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_group.example.object_id
   resource_origin_system = "AadGroup"
 }
 
 resource "azuread_access_package" "example" {
   display_name = "example-package"
   description  = "Example Package"
-  catalog_id   = azuread_access_package_catalog.example_catalog.id
+  catalog_id   = azuread_access_package_catalog.example.id
 }
 
 resource "azuread_access_package_resource_package_association" "example" {
   access_package_id               = azuread_access_package.example.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_type                     = "Member"
+}
+```
+
+### Granting Application Role
+
+```terraform
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "msgraph" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
+}
+
+resource "azuread_application" "example" {
+  display_name = "example-application"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-catalog"
+  description  = "Example catalog"
+}
+
+resource "azuread_access_package_resource_catalog_association" "example" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_service_principal.example.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package" "example" {
+  display_name = "example-package"
+  description  = "Example Package"
+  catalog_id   = azuread_access_package_catalog.example.id
+}
+
+resource "azuread_access_package_resource_package_association" "example" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_type                     = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
 }
 ```
 
 ## Argument Reference
 
-* `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
-* `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
+- `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
+- `access_type` - (Required) The role of access type to the specified resource. For `AadGroup` valid values are `Member`, or `Owner`, For `AadApplication` this it must be a the UUID of an app role and for `SharePointOnline` it should be a URL. Changing this forces a new resource to be created.
+- `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
+- `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 5 minutes) Used when creating the resource.
-* `read` - (Defaults to 5 minutes) Used when retrieving the resource.
-* `delete` - (Defaults to 5 minutes) Used when deleting the resource.
+- `create` - (Defaults to 5 minutes) Used when creating the resource.
+- `read` - (Defaults to 5 minutes) Used when retrieving the resource.
+- `delete` - (Defaults to 5 minutes) Used when deleting the resource.
 
 ## Import
 

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -93,7 +93,7 @@ resource "azuread_access_package_resource_package_association" "example" {
 ## Argument Reference
 
 - `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-- `access_type` - (Required) The role of access type to the specified resource. For `AadGroup` valid values are `Member`, or `Owner`, For `AadApplication` this it must be a the UUID of an app role and for `SharePointOnline` it should be a URL. Changing this forces a new resource to be created.
+- `access_type` - (Optional) The role of access type to the specified resource. For `AadGroup` valid values are `Member`, or `Owner`, for `AadApplication` it must be the UUID of an app role and for `SharePointOnline` it should be a URL. Defaults to `Member`. Changing this forces a new resource to be created.
 - `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -6,7 +6,6 @@ package identitygovernance_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -21,13 +20,13 @@ import (
 
 type AccessPackageResourcePackageAssociationResource struct{}
 
-func TestAccAccessPackageResourcePackageAssociation_completeWithGroup(t *testing.T) {
+func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
 	r := AccessPackageResourcePackageAssociationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:  r.completeWithGroup(data),
+			Config:  r.complete(data),
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -38,13 +37,13 @@ func TestAccAccessPackageResourcePackageAssociation_completeWithGroup(t *testing
 	})
 }
 
-func TestAccAccessPackageResourcePackageAssociation_completeWithGroupOwner(t *testing.T) {
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeOwner(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
 	r := AccessPackageResourcePackageAssociationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:  r.completeWithGroupOwner(data),
+			Config:  r.completeWithAccessTypeOwner(data),
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -55,13 +54,13 @@ func TestAccAccessPackageResourcePackageAssociation_completeWithGroupOwner(t *te
 	})
 }
 
-func TestAccAccessPackageResourcePackageAssociation_completeWithApplication(t *testing.T) {
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplication(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
 	r := AccessPackageResourcePackageAssociationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:  r.completeWithApplication(data),
+			Config:  r.completeWithAccessTypeApplication(data),
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -69,18 +68,6 @@ func TestAccAccessPackageResourcePackageAssociation_completeWithApplication(t *t
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccAccessPackageResourcePackageAssociation_invalidAccessType(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
-	r := AccessPackageResourcePackageAssociationResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.invalidAccessType(data),
-			ExpectError: regexp.MustCompile(`expected access_type to be one of \[Member Owner\]`),
-		},
 	})
 }
 
@@ -102,7 +89,7 @@ func (AccessPackageResourcePackageAssociationResource) Exists(ctx context.Contex
 	return pointer.To(roleScope != nil), nil
 }
 
-func (AccessPackageResourcePackageAssociationResource) completeWithGroup(data acceptance.TestData) string {
+func (AccessPackageResourcePackageAssociationResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -136,7 +123,7 @@ resource "azuread_access_package_resource_package_association" "test" {
 `, data.RandomInteger)
 }
 
-func (AccessPackageResourcePackageAssociationResource) completeWithGroupOwner(data acceptance.TestData) string {
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeOwner(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -170,7 +157,7 @@ resource "azuread_access_package_resource_package_association" "test" {
 `, data.RandomInteger)
 }
 
-func (AccessPackageResourcePackageAssociationResource) completeWithApplication(data acceptance.TestData) string {
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeApplication(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -229,36 +216,3 @@ resource "azuread_access_package_resource_package_association" "test" {
 `, data.RandomInteger)
 }
 
-func (AccessPackageResourcePackageAssociationResource) invalidAccessType(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azuread" {}
-
-resource "azuread_group" "test_group" {
-  display_name     = "test-access-package-resource-catalog-association-%[1]d"
-  security_enabled = true
-}
-
-resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
-  description  = "Test catalog %[1]d"
-}
-
-resource "azuread_access_package_resource_catalog_association" "test" {
-  catalog_id             = azuread_access_package_catalog.test_catalog.id
-  resource_origin_id     = azuread_group.test_group.object_id
-  resource_origin_system = "AadGroup"
-}
-
-resource "azuread_access_package" "test" {
-  display_name = "test-package-%[1]d"
-  description  = "Test Package %[1]d"
-  catalog_id   = azuread_access_package_catalog.test_catalog.id
-}
-
-resource "azuread_access_package_resource_package_association" "test" {
-  access_package_id               = azuread_access_package.test.id
-  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
-  access_type                     = "InvalidValue"
-}
-`, data.RandomInteger)
-}

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -6,6 +6,7 @@ package identitygovernance_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -20,19 +21,66 @@ import (
 
 type AccessPackageResourcePackageAssociationResource struct{}
 
-func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
+func TestAccAccessPackageResourcePackageAssociation_completeWithGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
 	r := AccessPackageResourcePackageAssociationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:  r.complete(data),
+			Config:  r.completeWithGroup(data),
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Member"),
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithGroupOwner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithGroupOwner(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Owner"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithApplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithApplication(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_invalidAccessType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.invalidAccessType(data),
+			ExpectError: regexp.MustCompile(`expected access_type to be one of \[Member Owner\]`),
+		},
 	})
 }
 
@@ -54,7 +102,7 @@ func (AccessPackageResourcePackageAssociationResource) Exists(ctx context.Contex
 	return pointer.To(roleScope != nil), nil
 }
 
-func (AccessPackageResourcePackageAssociationResource) complete(data acceptance.TestData) string {
+func (AccessPackageResourcePackageAssociationResource) completeWithGroup(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -83,6 +131,134 @@ resource "azuread_access_package" "test" {
 resource "azuread_access_package_resource_package_association" "test" {
   access_package_id               = azuread_access_package.test.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Member"
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithGroupOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Owner"
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithApplication(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "msgraph" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
+}
+
+resource "azuread_application" "test" {
+  display_name = "acctest-packageAssociationResource-%[1]d"
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    resource_access {
+      id   = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+      type = "Role"
+    }
+  }
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+resource "azuread_app_role_assignment" "test" {
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+  principal_object_id = azuread_service_principal.test.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_service_principal.test.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) invalidAccessType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "InvalidValue"
 }
 `, data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR makes the `access_type` argument required for the `azuread_access_package_resource_package_association` resource and extends its validation to support application role UUIDs and SharePoint URLs in addition to the existing `Member` and `Owner` values for Azure AD groups.

The change enables users to grant access to application roles (by specifying a role UUID) and SharePoint Online sites (by specifying a URL) through access packages, not just group memberships.

This is the second try at this PR. The previous attempt was in #1627.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Added these new test cases:
- `TestAccAccessPackageResourcePackageAssociation_completeWithGroup` - validates group membership assignment
- `TestAccAccessPackageResourcePackageAssociation_completeWithGroupOwner` - validates group owner assignment
- `TestAccAccessPackageResourcePackageAssociation_completeWithApplication` - validates application role assignment with UUID
- `TestAccAccessPackageResourcePackageAssociation_invalidAccessType` - validates error handling for invalid access types

I've run all unit tests, but not acceptance tests, as those require creating real resources. I have, however, used the provider locally in a regular setup to create access packages as expected.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azuread_access_package_resource_package_association` - the `access_type` property is now required and supports application role UUIDs and SharePoint URLs in addition to `Member` and `Owner` values


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #1066 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This change extends the access control capabilities by enabling application role assignments and SharePoint site access through access packages. No changes to encryption or logging.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.