### PR TITLE
Fix authentication context ClaimValue being overwritten during policy update

### DIFF
--- a/internal/services/policies/group_role_management_policy_resource.go
+++ b/internal/services/policies/group_role_management_policy_resource.go
@@ -825,7 +825,6 @@ func buildPolicyForUpdate(metadata *sdk.ResourceMetaData, policy *stable.Unified
 		}
 
 		if existingRule, ok := policyRules["AuthenticationContext_EndUser_Assignment"].(stable.UnifiedRoleManagementPolicyAuthenticationContextRule); ok {
-			rule.ClaimValue = existingRule.ClaimValue
 			rule.Target = existingRule.Target
 		}
 


### PR DESCRIPTION
Fix authentication context ClaimValue being overwritten during policy update.

This PR fixes a bug where the `required_conditional_access_authentication_context` field in `azuread_group_role_management_policy` resource sets `claimValue` to `null` instead of the user-provided value.

This bug prevented users from setting conditional access authentication contexts for PIM for Groups policies, forcing them to use workarounds with the `msgraph` provider. With this fix, users can now properly configure authentication contexts using the typed `azuread_group_role_management_policy` resource as intended.

The Read function already correctly reads the ClaimValue, confirming this is purely an update bug and the fix is complete.



<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

In `internal/services/policies/group_role_management_policy_resource.go`, the `buildPolicyForUpdate` function overwrites the user input with old value and hence we need to remove the line `rule.ClaimValue = existingRule.ClaimValue`:

    
```go
   if metadata.ResourceData.HasChange("activation_rules.0.required_conditional_access_authentication_context") {
   rule := stable.UnifiedRoleManagementPolicyAuthenticationContextRule{
   Id:         pointer.To("AuthenticationContext_EndUser_Assignment"),
   IsEnabled:  nullable.Value(model.ActivationRules[0].RequireConditionalAccessContext != ""),
   ClaimValue: nullable.NoZero(model.ActivationRules[0].RequireConditionalAccessContext),  // Line 824: Correctly sets from user input
   }
    
   if existingRule, ok := policyRules["AuthenticationContext_EndUser_Assignment"].(stable.UnifiedRoleManagementPolicyAuthenticationContextRule); ok {
   rule.ClaimValue = existingRule.ClaimValue
   rule.Target = existingRule.Target
   }
    
   updatedRules = append(updatedRules, rule)
   }
```

The pattern is clear: only copy Target from existing rule (API-controlled field that shouldn't change), never copy user-controlled data fields.

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1605

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
