### PR TITLE
identity_governance: Updates access_package_resource_package_association to handle MS Graph resource ID changes

### DIFF
--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -42,6 +42,18 @@ func GetAccessPackageResourcesRoleScope(ctx context.Context, client *entitlement
 		if roleScope.Id != nil && *roleScope.Id == id.AccessPackageResourceRoleScopeId {
 			return &roleScope, nil
 		}
+		if strings.Contains(id.AccessPackageResourceRoleScopeId, "_") {
+			parts := strings.Split(id.AccessPackageResourceRoleScopeId, "_")
+			if len(parts) != 2 {
+				continue
+			}
+			accessPackageResourceRoleId := parts[0]
+			accessPackageResourceScopeId := parts[1]
+			if roleScope.AccessPackageResourceRole != nil && roleScope.AccessPackageResourceRole.Id != nil && *roleScope.AccessPackageResourceRole.Id == accessPackageResourceRoleId &&
+				roleScope.AccessPackageResourceScope != nil && roleScope.AccessPackageResourceScope.Id != nil && *roleScope.AccessPackageResourceScope.Id == accessPackageResourceScopeId {
+				return &roleScope, nil
+			}
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR fixes the issue describes in #1828 
MS Graph changed the format of the id of the [accessPackageResourceRoleScope](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageresourcerolescope?view=graph-rest-beta) resource.
Previously it was a composited id, with format `{accessPackageResourceRole_id}_{accessPackageResourceScope_id}`, now a new UUID was introduced for the base resource `accessPackageResourceRoleScope`.

The change adds a fallback that triggers when a resource with the ID from the state cannot be found. The fallback then attempts to instead find the resource using the parts of the previous composite id. If sucessful it updates the state with the new, corrected id.

For deletion currently the Graph API seems even more broken: It only accepts IDs in the old format, returns HTTP/400 on attempts to delete with the new ID. Therefore I also added a fallback there which attempts to delete with the old ID format if the regular request fails.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
 
As this is a pure MS Graph backend change, I don't see how it should be testable.

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_access_package_resource_package_association ` - fix Graph backend ID format changes [GH-1830]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1828

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
