### PR TITLE
Feat/graph proxy endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,8 @@ The following arguments are supported:
 * `client_id_file_path` (Optional) The path to a file containing the Client ID which should be used when authenticating as a service principal. This can also be sourced from the `ARM_CLIENT_ID_FILE_PATH` environment variable.
 * `environment` - (Optional) The Cloud Environment which be used. Possible values are: `global` (also `public`), `usgovernmentl4` (also `usgovernment`), `usgovernmentl5` (also `dod`), `germany` (also `german`), and `china`. Defaults to `global`. This can also be sourced from the `ARM_ENVIRONMENT` environment variable.
 * `metadata_host` - (Optional) The Hostname of the Azure Metadata Service (for example `management.azure.com`), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the `ARM_METADATA_HOSTNAME` Environment Variable.
+* `microsoft_graph_endpoint` - (Optional) Override the Microsoft Graph base endpoint (for example, a reverse proxy). Do not include `/v1.0` or `/beta`. This can also be sourced from the `ARM_MS_GRAPH_ENDPOINT` environment variable.
+* `microsoft_graph_resource_id` - (Optional) Override the Microsoft Graph resource identifier used for token requests (for example, `api://<app-id>` for a proxy). This can also be sourced from the `ARM_MS_GRAPH_RESOURCE_ID` environment variable.
 
 ~> **Note on Custom Environments** When connecting to a Custom Azure Environment, the metadata service must support the `2022-09-01` API version in order to work with this provider. This API version is the earliest version to support Microsoft Graph.
 


### PR DESCRIPTION
## Description

This PR adds support for overriding Microsoft Graph settings in the AzureAD provider to support proxy/custom Graph deployments.

Changes included:

- Adds new provider arguments:
  - `microsoft_graph_endpoint` (env: `ARM_MS_GRAPH_ENDPOINT`)
  - `microsoft_graph_resource_id` (env: `ARM_MS_GRAPH_RESOURCE_ID`)
- Trims trailing `/` from `microsoft_graph_endpoint` for consistent behavior.
- Preserves the Microsoft Graph App ID when endpoint/resource overrides are applied.
- Adds validation and existing safety checks to ensure Graph endpoint resolution remains valid.
- Updates provider docs for the new arguments.
- Adds acceptance tests for:
  - endpoint-only override
  - endpoint + resource ID override

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my changes & updated relevant documentation.
- [ ] I have successfully run tests with my changes locally. (update this checkbox based on your run)
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- Added:
  - `TestAccProvider_graphEndpointOverride`
  - `TestAccProvider_graphEndpointAndResourceIdOverride`

Example local run command:

```bash
TF_ACC=1 go test ./internal/provider -run 'TestAccProvider_graphEndpointOverride|TestAccProvider_graphEndpointAndResourceIdOverride'
