### PR TITLE
`azuread_group` / `azuread_group_without_members` - add deadline to context for `CustomizeDiff`

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -187,9 +187,9 @@ In addition to all arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 20 minutes) Used when creating the resource.
+* `create` - (Defaults to 30 minutes) Used when creating the resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the resource.
-* `update` - (Defaults to 20 minutes) Used when updating the resource.
+* `update` - (Defaults to 30 minutes) Used when updating the resource.
 * `delete` - (Defaults to 5 minutes) Used when deleting the resource.
 
 ## Import

--- a/docs/resources/group_without_members.md
+++ b/docs/resources/group_without_members.md
@@ -160,9 +160,9 @@ In addition to all arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 20 minutes) Used when creating the resource.
+* `create` - (Defaults to 30 minutes) Used when creating the resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the resource.
-* `update` - (Defaults to 20 minutes) Used when updating the resource.
+* `update` - (Defaults to 30 minutes) Used when updating the resource.
 * `delete` - (Defaults to 5 minutes) Used when deleting the resource.
 
 ## Import

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -46,9 +46,9 @@ func groupResource() *pluginsdk.Resource {
 		CustomizeDiff: groupResourceCustomizeDiff,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
@@ -336,6 +336,8 @@ func groupResource() *pluginsdk.Resource {
 
 func groupResourceCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
 	client := meta.(*clients.Client).Groups.GroupClientBeta
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 
 	// Check for duplicate names
 	oldDisplayName, newDisplayName := diff.GetChange("display_name")

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -382,7 +382,7 @@ func TestAccGroup_provisioning(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_address"), // Test Env policy forces additional entries :(
 	})
 }
 

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -78,21 +78,21 @@ func TestAccGroup_updateUnified(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unified(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.completeUnified(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unified(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -144,7 +144,7 @@ func TestAccGroup_dynamicMembership(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -175,7 +175,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -183,7 +183,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withThreeOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -191,7 +191,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("3"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -199,7 +199,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withServicePrincipalOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -207,7 +207,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withDiverseOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -215,7 +215,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("2"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.removeOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -223,7 +223,7 @@ func TestAccGroup_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("0"),
 			),
 		},
-		data.ImportStep(), // The import here will persist the previous step does not remove the owners
+		data.ImportStep("proxy_addresses", "owners"), // The import here will persist the previous step does not remove the owners
 	})
 }
 
@@ -239,7 +239,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("0"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withThreeMembers(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -247,7 +247,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("3"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneMember(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -255,7 +255,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withServicePrincipalMember(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -263,7 +263,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withDiverseMembers(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -271,7 +271,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("3"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withNoMembers(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -279,7 +279,7 @@ func TestAccGroup_members(t *testing.T) {
 				check.That(data.ResourceName).Key("members.#").HasValue("0"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -313,7 +313,7 @@ func TestAccGroup_manyMembersAndOwners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("45"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneOwnerAndNoMembers(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -322,7 +322,7 @@ func TestAccGroup_manyMembersAndOwners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -397,21 +397,21 @@ func TestAccGroup_unifiedExtraSettings(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedAsUser(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedWithExtraSettings(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -426,14 +426,14 @@ func TestAccGroup_visibility(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.visibility(data, "Public"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -496,7 +496,7 @@ func TestAccGroup_writebackUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withWriteback(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -504,14 +504,14 @@ func TestAccGroup_writebackUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalSecurityGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -527,7 +527,7 @@ func TestAccGroup_writebackUnified(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalDistributionGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedWithWriteback(data, "UniversalMailEnabledSecurityGroup"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -535,7 +535,7 @@ func TestAccGroup_writebackUnified(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalMailEnabledSecurityGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 

--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -44,9 +44,9 @@ func groupWithoutMembersResource() *pluginsdk.Resource {
 		CustomizeDiff: groupWithoutMembersResourceCustomizeDiff,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(20 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
@@ -311,6 +311,8 @@ func groupWithoutMembersResource() *pluginsdk.Resource {
 
 func groupWithoutMembersResourceCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDiff, meta interface{}) error {
 	client := meta.(*clients.Client).Groups.GroupClientBeta
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 
 	// Check for duplicate names
 	oldDisplayName, newDisplayName := diff.GetChange("display_name")
@@ -760,16 +762,16 @@ func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.Resourc
 				}
 
 				// Wait for Description to be removed
-				if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
-					resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
-					if err != nil {
-						return nil, err
-					}
-					group := resp.Model
-					return pointer.To(group != nil && group.Description.IsNull()), nil
-				}); err != nil {
-					return tf.ErrorDiagF(err, "Waiting to remove `description` for %s", id)
-				}
+				// if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				// 	resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
+				// 	if err != nil {
+				// 		return nil, err
+				// 	}
+				// 	group := resp.Model
+				// 	return pointer.To(group != nil && group.Description.IsNull()), nil
+				// }); err != nil {
+				// 	return tf.ErrorDiagF(err, "Waiting to remove `description` for %s", id)
+				// }
 			}
 		}
 

--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -762,16 +762,16 @@ func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.Resourc
 				}
 
 				// Wait for Description to be removed
-				// if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
-				// 	resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
-				// 	if err != nil {
-				// 		return nil, err
-				// 	}
-				// 	group := resp.Model
-				// 	return pointer.To(group != nil && group.Description.IsNull()), nil
-				// }); err != nil {
-				// 	return tf.ErrorDiagF(err, "Waiting to remove `description` for %s", id)
-				// }
+				if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+					resp, err := client.GetGroup(ctx, id, groupBeta.DefaultGetGroupOperationOptions())
+					if err != nil {
+						return nil, err
+					}
+					group := resp.Model
+					return pointer.To(group != nil && group.Description.IsNull()), nil
+				}); err != nil {
+					return tf.ErrorDiagF(err, "Waiting to remove `description` for %s", id)
+				}
 			}
 		}
 

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -99,7 +99,7 @@ func TestAccGroupWithoutMembers_updateUnified(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("owners"),
 	})
 }
 

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -78,21 +78,21 @@ func TestAccGroupWithoutMembers_updateUnified(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unified(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.completeUnified(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unified(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -175,7 +175,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -183,7 +183,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withThreeOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -191,7 +191,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("3"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withOneOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -199,7 +199,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withServicePrincipalOwner(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -207,7 +207,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("1"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withDiverseOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -215,7 +215,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("2"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.removeOwners(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -223,7 +223,7 @@ func TestAccGroupWithoutMembers_owners(t *testing.T) {
 				check.That(data.ResourceName).Key("owners.#").HasValue("0"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -289,21 +289,21 @@ func TestAccGroupWithoutMembers_unifiedExtraSettings(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedAsUser(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedWithExtraSettings(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -397,7 +397,7 @@ func TestAccGroupWithoutMembers_writebackUpdate(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.withWriteback(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -405,14 +405,14 @@ func TestAccGroupWithoutMembers_writebackUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalSecurityGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 
@@ -428,7 +428,7 @@ func TestAccGroupWithoutMembers_writebackUnified(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalDistributionGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 		{
 			Config: r.unifiedWithWriteback(data, "UniversalMailEnabledSecurityGroup"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -436,7 +436,7 @@ func TestAccGroupWithoutMembers_writebackUnified(t *testing.T) {
 				check.That(data.ResourceName).Key("onpremises_group_type").HasValue("UniversalMailEnabledSecurityGroup"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"),
 	})
 }
 

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -63,7 +63,7 @@ func TestAccGroupWithoutMembers_completeUnified(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"), // additional entries added by Azure Test Tenant enforced settings
 	})
 }
 
@@ -327,14 +327,14 @@ func TestAccGroupWithoutMembers_visibility(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"), // additional entries added by Azure Test Tenant enforced settings
 		{
 			Config: r.visibility(data, "Public"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("proxy_addresses"), // additional entries added by Azure Test Tenant enforced settings
 	})
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,6 +91,11 @@ github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/member
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/memberof
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/owner
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/transitivemember
+github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/group
+github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/member
+github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/memberof
+github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/owner
+github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/transitivemember
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/conditionalaccessnamedlocation
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/conditionalaccesspolicy
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/userflowattribute

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,11 +91,6 @@ github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/member
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/memberof
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/owner
 github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/beta/transitivemember
-github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/group
-github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/member
-github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/memberof
-github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/owner
-github.com/hashicorp/go-azure-sdk/microsoft-graph/groups/stable/transitivemember
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/conditionalaccessnamedlocation
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/conditionalaccesspolicy
 github.com/hashicorp/go-azure-sdk/microsoft-graph/identity/stable/userflowattribute


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

fixes missing context in CustomizeDiff, and fixes several tests. Extends default timeout to accommodate larger EntraID environments.

Supersedes #1778


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azuread/issues/1541
Fixes https://github.com/hashicorp/terraform-provider-azuread/issues/1634

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
