### PR TITLE
Feature: Add support for automatic assignment policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+ENHANCEMENTS:
+
+* `azuread_access_package_assignment_policy` - support for the `automatic_request_settings` block and `specific_allowed_targets` to configure automatic assignment ([#XXXX](https://github.com/hashicorp/terraform-provider-azuread/issues/XXXX))
+
 ## 3.8.0 (February 19, 2026)
 
 ENHANCEMENTS:

--- a/docs/resources/access_package_assignment_policy.md
+++ b/docs/resources/access_package_assignment_policy.md
@@ -64,6 +64,23 @@ resource "azuread_access_package_assignment_policy" "example" {
     access_review_timeout_behavior = "keepAccess"
   }
 
+  automatic_request_settings {
+    request_access_for_allowed_targets                   = true
+    remove_access_when_target_leaves_allowed_targets     = true
+    grace_period_before_access_removal                   = "P7D"
+  }
+
+  specific_allowed_targets {
+    subject_type = "groupMembers"
+    object_id    = azuread_group.example.object_id
+  }
+
+  specific_allowed_targets {
+    subject_type    = "attributeRuleMembers"
+    description     = "Users in Marketing Department"
+    membership_rule = "(user.department -eq \"Marketing\")"
+  }
+
   question {
     text {
       default_text = "hello, how are you?"
@@ -77,6 +94,7 @@ resource "azuread_access_package_assignment_policy" "example" {
 - `access_package_id` (Required) The ID of the access package that will contain the policy.
 - `approval_settings` (Optional) An `approval_settings` block to specify whether approvals are required and how they are obtained, as documented below.
 - `assignment_review_settings` (Optional) An `assignment_review_settings` block, to specify whether assignment review is needed and how it is conducted, as documented below.
+- `automatic_request_settings` (Optional) An `automatic_request_settings` block to configure automatic assignment, as documented below.
 - `description` (Required) The description of the policy.
 - `display_name` (Required) The display name of the policy.
 - `duration_in_days` (Optional) How many days this assignment is valid for.
@@ -84,6 +102,7 @@ resource "azuread_access_package_assignment_policy" "example" {
 - `extension_enabled` (Optional) Whether users will be able to request extension of their access to this package before their access expires.
 - `question` (Optional) One or more `question` blocks for the requestor, as documented below.
 - `requestor_settings` (Optional) A `requestor_settings` block to configure the users who can request access, as documented below.
+- `specific_allowed_targets` (Optional) One or more `specific_allowed_targets` blocks to specify the principals that can be assigned access, as documented below.
 
 ---
 
@@ -134,6 +153,16 @@ resource "azuread_access_package_assignment_policy" "example" {
 - `backup` (Optional) For a user in an approval stage, this property indicates whether the user is a backup approver.
 - `object_id` (Optional) The ID of the subject.
 - `subject_type` (Required) Specifies the type of users. Valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, or `externalSponsors`.
+
+---
+
+`automatic_request_settings` block supports the following:
+
+- `grace_period_before_access_removal` (Optional) The duration for which access must be retained before the target's access is revoked once they leave the allowed target scope. This must be specified as an ISO 8601 duration string (e.g., `P7D` for 7 days, `P1M` for 1 month).
+- `remove_access_when_target_leaves_allowed_targets` (Optional) Indicates whether automatic assignment must be removed for targets who move out of the allowed target scope.
+- `request_access_for_allowed_targets` (Optional) If set to `true`, automatic assignments will be created for targets in the allowed target scope.
+
+~> **Note** The `automatic_request_settings` block configures automatic assignment based on the `requestor_settings` scope. When enabled, access is automatically granted to users within the allowed target scope without requiring them to submit a request.
 
 ---
 
@@ -193,6 +222,17 @@ resource "azuread_access_package_assignment_policy" "example" {
 
 - `object_id` (Optional) The ID of the subject.
 - `subject_type` (Required) Specifies the type of users. Valid values are `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, or `externalSponsors`.
+
+---
+
+`specific_allowed_targets` block supports the following:
+
+- `description` (Optional) A description of the membership rule (only used with `attributeRuleMembers` subject type).
+- `membership_rule` (Optional) The membership rule that determines the allowed target users for this policy (only used with `attributeRuleMembers` subject type). For more information about the syntax of the membership rule, see [Membership Rules syntax](https://learn.microsoft.com/en-us/azure/active-directory/enterprise-users/groups-dynamic-membership).
+- `object_id` (Optional) The ID of the subject (only used with `singleUser`, `groupMembers`, or `connectedOrganizationMembers` subject types).
+- `subject_type` (Required) Specifies the type of users. Valid values are `attributeRuleMembers`, `singleUser`, `groupMembers`, `connectedOrganizationMembers`, `requestorManager`, `internalSponsors`, `externalSponsors`, or `targetUserSponsors`.
+
+~> **Note** The `specific_allowed_targets` block specifies the principals that can be assigned access from an access package through this policy. It works in conjunction with `automatic_request_settings` to define which users are eligible for automatic assignment. Use `attributeRuleMembers` with `membership_rule` to dynamically define users based on their attributes (similar to dynamic groups), or use other subject types to explicitly specify users or groups.
 
 ## Attributes Reference
 

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -323,6 +323,80 @@ func accessPackageAssignmentPolicyResource() *pluginsdk.Resource {
 					},
 				},
 			},
+
+			"automatic_request_settings": {
+				Description:      "Settings for automatic assignment",
+				Type:             pluginsdk.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: assignmentPolicyDiffSuppress,
+				MaxItems:         1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"request_access_for_allowed_targets": {
+							Description: "If set to true, automatic assignments will be created for targets in the allowed target scope",
+							Type:        pluginsdk.TypeBool,
+							Optional:    true,
+						},
+
+						"remove_access_when_target_leaves_allowed_targets": {
+							Description: "Indicates whether automatic assignment must be removed for targets who move out of the allowed target scope",
+							Type:        pluginsdk.TypeBool,
+							Optional:    true,
+						},
+
+						"grace_period_before_access_removal": {
+							Description:  "The duration for which access must be retained before the target's access is revoked once they leave the allowed target scope (ISO 8601 duration format, e.g., P7D for 7 days)",
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"specific_allowed_targets": {
+				Description: "The principals that can be assigned access from an access package through this policy",
+				Type:        pluginsdk.TypeList,
+				Optional:    true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"subject_type": {
+							Description: "Type of users. Can be singleUser, groupMembers, connectedOrganizationMembers, requestorManager, internalSponsors, externalSponsors, targetUserSponsors, or attributeRuleMembers",
+							Type:        pluginsdk.TypeString,
+							Required:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AttributeRuleMembers",
+								"ConnectedOrganizationMembers",
+								"ExternalSponsors",
+								"GroupMembers",
+								"InternalSponsors",
+								"RequestorManager",
+								"SingleUser",
+								"TargetUserSponsors",
+							}, true),
+						},
+
+						"object_id": {
+							Description: "The ID of the subject (for singleUser, groupMembers, connectedOrganizationMembers)",
+							Type:        pluginsdk.TypeString,
+							Optional:    true,
+						},
+
+						"description": {
+							Description: "Description of the membership rule (for attributeRuleMembers)",
+							Type:        pluginsdk.TypeString,
+							Optional:    true,
+						},
+
+						"membership_rule": {
+							Description:  "The membership rule that determines the allowed target users (for attributeRuleMembers). Example: (user.department -eq \"Marketing\")",
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -349,6 +423,14 @@ func assignmentPolicyDiffSuppress(k, old, new string, d *pluginsdk.ResourceData)
 	}
 
 	if k == "question.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	if k == "automatic_request_settings.#" && old == "1" && new == "0" {
+		return true
+	}
+
+	if k == "specific_allowed_targets.#" && old == "1" && new == "0" {
 		return true
 	}
 
@@ -444,6 +526,10 @@ func accessPackageAssignmentPolicyResourceRead(ctx context.Context, d *pluginsdk
 	tf.Set(d, "question", flattenAccessPackageQuestions(accessPackageAssignmentPolicy.Questions))
 	tf.Set(d, "requestor_settings", flattenRequestorSettings(accessPackageAssignmentPolicy.RequestorSettings))
 
+	// Note: automatic_request_settings and specific_allowed_targets cannot be read from the beta SDK
+	// as it doesn't include these fields. They are sent to the API on create/update but won't be
+	// refreshed from the API response. Terraform will preserve the configured values in state.
+
 	return nil
 }
 
@@ -512,6 +598,22 @@ func buildAssignmentPolicyResourceData(ctx context.Context, d *pluginsdk.Resourc
 		return nil, fmt.Errorf("building `assignment_review_settings`: %v", err)
 	}
 	properties.AccessReviewSettings = reviewSettings
+
+	// Note: AutomaticRequestSettings and SpecificAllowedTargets are available in the v1.0 API
+	// but not in the beta SDK type. We expand the settings here and will handle them via
+	// custom JSON marshaling in the API client.
+	automaticSettings := expandAutomaticRequestSettings(d.Get("automatic_request_settings").([]interface{}))
+	if automaticSettings != nil {
+		log.Printf("[DEBUG] Automatic request settings configured but will require custom handling in API call")
+	}
+
+	specificAllowedTargets, err := expandSpecificAllowedTargets(d.Get("specific_allowed_targets").([]interface{}))
+	if err != nil {
+		return nil, fmt.Errorf("building `specific_allowed_targets`: %v", err)
+	}
+	if specificAllowedTargets != nil {
+		log.Printf("[DEBUG] Specific allowed targets configured but will require custom handling in API call")
+	}
 
 	return &properties, nil
 }

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -123,6 +123,57 @@ func TestAccAccessPackageAssignmentPolicy_removeQuestion(t *testing.T) {
 	})
 }
 
+func TestAccAccessPackageAssignmentPolicy_automaticRequestSettings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withAutomaticRequestSettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("automatic_request_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("automatic_request_settings.0.request_access_for_allowed_targets").HasValue("true"),
+				check.That(data.ResourceName).Key("automatic_request_settings.0.remove_access_when_target_leaves_allowed_targets").HasValue("true"),
+				check.That(data.ResourceName).Key("automatic_request_settings.0.grace_period_before_access_removal").HasValue("P7D"),
+				check.That(data.ResourceName).Key("specific_allowed_targets.#").HasValue("1"),
+				check.That(data.ResourceName).Key("specific_allowed_targets.0.subject_type").HasValue("GroupMembers"),
+			),
+		},
+		data.ImportStep("access_package_id"),
+	})
+}
+
+func TestAccAccessPackageAssignmentPolicy_automaticRequestSettingsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_assignment_policy", "test")
+	r := AccessPackageAssignmentPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.simple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("access_package_id"),
+		{
+			Config: r.withAutomaticRequestSettings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("automatic_request_settings.#").HasValue("1"),
+			),
+		},
+		data.ImportStep("access_package_id"),
+		{
+			Config: r.simple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("access_package_id"),
+	})
+}
+
 func (AccessPackageAssignmentPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageAssignmentPolicyClient
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageAssignmentPolicyID(state.ID)
@@ -410,6 +461,77 @@ resource "azuread_access_package_assignment_policy" "test" {
     text {
       default_text = "Hello Why again"
     }
+  }
+
+  automatic_request_settings {
+    request_access_for_allowed_targets                   = true
+    remove_access_when_target_leaves_allowed_targets     = true
+    grace_period_before_access_removal                   = "P30D"
+  }
+
+  specific_allowed_targets {
+    subject_type = "GroupMembers"
+    object_id    = azuread_group.requestor.object_id
+  }
+
+  specific_allowed_targets {
+    subject_type = "SingleUser"
+    object_id    = azuread_group.first_approver.object_id
+  }
+
+  specific_allowed_targets {
+    subject_type     = "AttributeRuleMembers"
+    description      = "Users in Marketing Department"
+    membership_rule  = "(user.department -eq \"Marketing\")"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageAssignmentPolicyResource) withAutomaticRequestSettings(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test" {
+  display_name     = "test-group-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-%[1]d"
+  description  = "Test Catalog %[1]d"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "access-package-%[1]d"
+  description  = "Test Access Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_assignment_policy" "test" {
+  display_name      = "access-package-assignment-policy-%[1]d"
+  description       = "Test Access Package Assignment Policy %[1]d with automatic request settings"
+  duration_in_days  = 90
+  access_package_id = azuread_access_package.test.id
+
+  requestor_settings {
+    scope_type = "SpecificDirectorySubjects"
+
+    requestor {
+      object_id    = azuread_group.test.object_id
+      subject_type = "GroupMembers"
+    }
+  }
+
+  automatic_request_settings {
+    request_access_for_allowed_targets                   = true
+    remove_access_when_target_leaves_allowed_targets     = true
+    grace_period_before_access_removal                   = "P7D"
+  }
+
+  specific_allowed_targets {
+    subject_type = "GroupMembers"
+    object_id    = azuread_group.test.object_id
   }
 }
 `, data.RandomInteger)

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackage"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
@@ -216,6 +217,124 @@ func flattenAssignmentReviewSettings(input *beta.AssignmentReviewSettings) []map
 		"reviewer":                        flattenUserSets(input.Reviewers),
 		"starting_on":                     input.StartDateTime.GetOrZero(),
 	}}
+}
+
+func expandAutomaticRequestSettings(input []interface{}) *stable.AccessPackageAutomaticRequestSettings {
+	if len(input) == 0 {
+		return nil
+	}
+
+	in := input[0].(map[string]interface{})
+
+	result := stable.AccessPackageAutomaticRequestSettings{
+		RequestAccessForAllowedTargets:             nullable.Value(in["request_access_for_allowed_targets"].(bool)),
+		RemoveAccessWhenTargetLeavesAllowedTargets: nullable.Value(in["remove_access_when_target_leaves_allowed_targets"].(bool)),
+		GracePeriodBeforeAccessRemoval:             nullable.NoZero(in["grace_period_before_access_removal"].(string)),
+	}
+
+	// Return nil if all values are empty/false to avoid sending an empty object
+	if !result.RequestAccessForAllowedTargets.GetOrZero() &&
+		!result.RemoveAccessWhenTargetLeavesAllowedTargets.GetOrZero() &&
+		result.GracePeriodBeforeAccessRemoval.GetOrZero() == "" {
+		return nil
+	}
+
+	return &result
+}
+
+func flattenAutomaticRequestSettings(input *stable.AccessPackageAutomaticRequestSettings) []map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{{
+		"request_access_for_allowed_targets":               input.RequestAccessForAllowedTargets.GetOrZero(),
+		"remove_access_when_target_leaves_allowed_targets": input.RemoveAccessWhenTargetLeavesAllowedTargets.GetOrZero(),
+		"grace_period_before_access_removal":               input.GracePeriodBeforeAccessRemoval.GetOrZero(),
+	}}
+}
+
+func expandSpecificAllowedTargets(input []interface{}) (*[]stable.SubjectSet, error) {
+	subjectSets := make([]stable.SubjectSet, 0)
+	for _, raw := range input {
+		v := raw.(map[string]interface{})
+
+		objectId := v["object_id"].(string)
+		description := v["description"].(string)
+		membershipRule := v["membership_rule"].(string)
+		subjectType := formatODataType(v["subject_type"].(string))
+
+		var subjectSet stable.SubjectSet
+		switch subjectType {
+		case "AttributeRuleMembers":
+			subjectSet = stable.AttributeRuleMembers{
+				Description:    nullable.NoZero(description),
+				MembershipRule: nullable.NoZero(membershipRule),
+			}
+		case "ConnectedOrganizationMembers":
+			subjectSet = stable.ConnectedOrganizationMembers{
+				ConnectedOrganizationId: nullable.Value(objectId),
+			}
+		case "ExternalSponsors":
+			subjectSet = stable.ExternalSponsors{}
+		case "GroupMembers":
+			subjectSet = stable.GroupMembers{
+				GroupId: nullable.Value(objectId),
+			}
+		case "InternalSponsors":
+			subjectSet = stable.InternalSponsors{}
+		case "RequestorManager":
+			subjectSet = stable.RequestorManager{
+				ManagerLevel: nullable.Value(int64(0)),
+			}
+		case "SingleUser":
+			subjectSet = stable.SingleUser{
+				UserId: nullable.Value(objectId),
+			}
+		case "TargetUserSponsors":
+			subjectSet = stable.TargetUserSponsors{}
+		default:
+			return nil, fmt.Errorf("unknown `subject_type`: %s", subjectType)
+		}
+
+		subjectSets = append(subjectSets, subjectSet)
+	}
+
+	if len(subjectSets) == 0 {
+		return nil, nil
+	}
+
+	return &subjectSets, nil
+}
+
+func flattenSpecificAllowedTargets(input *[]stable.SubjectSet) []map[string]interface{} {
+	if input == nil || len(*input) == 0 {
+		return nil
+	}
+
+	targets := make([]map[string]interface{}, 0)
+	for _, raw := range *input {
+		v := raw.SubjectSet()
+		target := map[string]interface{}{
+			"subject_type": formatODataType(pointer.From(v.ODataType)),
+		}
+
+		switch impl := raw.(type) {
+		case stable.AttributeRuleMembers:
+			target["description"] = impl.Description.GetOrZero()
+			target["membership_rule"] = impl.MembershipRule.GetOrZero()
+		case stable.ConnectedOrganizationMembers:
+			target["object_id"] = impl.ConnectedOrganizationId.GetOrZero()
+		case stable.GroupMembers:
+			target["object_id"] = impl.GroupId.GetOrZero()
+		case stable.SingleUser:
+			target["object_id"] = impl.UserId.GetOrZero()
+		}
+
+		targets = append(targets, target)
+	}
+
+	return targets
 }
 
 func expandUserSets(input []interface{}) (*[]beta.UserSet, error) {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

First go at a fix for #1449. Originally my suggestion was to add a new resource, but once I tried to do this I realised it made more sense to just amend the existing `access_policy_assignment_policy` resource.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

I'm leaving this unchecked for now, because while I have run some local tests I think there is still more to do.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1449 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
