### PR TITLE
`access_package_resource_package_association`:  allow eligible group assignments and AppRoles

### DIFF
--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -16,6 +16,8 @@ When authenticated with a user principal, this resource requires one of the foll
 
 ## Example Usage
 
+### Group with Member access (default)
+
 ```terraform
 resource "azuread_group" "example" {
   display_name     = "example-group"
@@ -28,15 +30,15 @@ resource "azuread_access_package_catalog" "example" {
 }
 
 resource "azuread_access_package_resource_catalog_association" "example" {
-  catalog_id             = azuread_access_package_catalog.example_catalog.id
-  resource_origin_id     = azuread_group.example_group.object_id
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_group.example.object_id
   resource_origin_system = "AadGroup"
 }
 
 resource "azuread_access_package" "example" {
   display_name = "example-package"
   description  = "Example Package"
-  catalog_id   = azuread_access_package_catalog.example_catalog.id
+  catalog_id   = azuread_access_package_catalog.example.id
 }
 
 resource "azuread_access_package_resource_package_association" "example" {
@@ -45,17 +47,105 @@ resource "azuread_access_package_resource_package_association" "example" {
 }
 ```
 
+### Group with Eligible Member access (PIM)
+
+```terraform
+resource "azuread_group" "example" {
+  display_name     = "example-group"
+  security_enabled = true
+}
+
+resource "azuread_group_role_management_policy" "example" {
+  group_id = azuread_group.example.id
+  role_id  = "member"
+
+  eligible_assignment_rules {
+    expiration_required = false
+  }
+}
+
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-catalog"
+  description  = "Example catalog"
+}
+
+resource "azuread_access_package_resource_catalog_association" "example" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_group.example.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "example" {
+  display_name = "example-package"
+  description  = "Example Package"
+  catalog_id   = azuread_access_package_catalog.example.id
+}
+
+resource "azuread_access_package_resource_package_association" "example" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_type                     = "Eligible Member"
+
+  depends_on = [azuread_group_role_management_policy.example]
+}
+```
+
+### Application AppRole
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example-app"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Example AppRole"
+    display_name         = "ExampleRole"
+    value                = "ExampleRole"
+  }
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_access_package_catalog" "example" {
+  display_name = "example-catalog"
+  description  = "Example catalog"
+}
+
+resource "azuread_access_package_resource_catalog_association" "example" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_service_principal.example.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package" "example" {
+  display_name = "example-package"
+  description  = "Example Package"
+  catalog_id   = azuread_access_package_catalog.example.id
+}
+
+resource "azuread_access_package_resource_package_association" "example" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  resource_role_origin_id         = tolist(azuread_application.example.app_role)[0].id
+}
+```
+
+
 ## Argument Reference
 
 * `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
+* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, `Owner`, `Eligible Member`, or `Eligible Owner`. The default is `Member`. Cannot be used together with `resource_role_origin_id`. Changing this forces a new resource to be created.
 * `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
+* `resource_role_origin_id` - (Optional) The origin ID of the resource role (AppRole ID) for `AadApplication` resources. Cannot be used together with `access_type`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
+* `id` - The ID of this resource. The ID is combined by four fields separated by `/`: `access_package_id`, the package association id, `resource_origin_id`, and the role identifier (either the `access_type` or the `resource_role_origin_id`).
+* `resource_role_display_name` - The display name of the resource role. Only set when `resource_role_origin_id` is used.
 
 ## Timeouts
 
@@ -67,10 +157,18 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-The resource and catalog association can be imported using the access package ID, the access package ResourceRoleScope, the resource origin ID, and the access type, e.g.
+The resource and catalog association can be imported using the access package ID, the access package ResourceRoleScope, the resource origin ID, and the role identifier (access type or resource role origin ID), e.g.
+
+For group resources:
 
 ```
-terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222/33333333-3333-3333-3333-33333333/Member
+terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333/Member
 ```
 
--> This ID format is unique to Terraform and is composed of the Access Package ID, the access package ResourceRoleScope (in the format Role_Scope), the Resource Origin ID, and the Access Type, in the format `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}`.
+For application resources (using an AppRole origin ID):
+
+```
+terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333/44444444-4444-4444-4444-444444444444
+```
+
+-> This ID format is unique to Terraform and is composed of the Access Package ID, the access package ResourceRoleScope (in the format Role_Scope), the Resource Origin ID, and the Role Identifier, in the format `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{RoleIdentifier}`.

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -8,13 +8,16 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackage"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackageaccesspackageresourcerolescope"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackagecatalogaccesspackageresource"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/stable/serviceprincipal"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/consistency"
@@ -57,15 +60,35 @@ func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 			},
 
 			"access_type": {
-				Description: "The role of access type to the specified resource, valid values are `Member` and `Owner`",
+				Description:   "The role of access type to the specified resource. Valid values are `Member`, `Owner`, `Eligible Member` and `Eligible Owner`. Cannot be used together with `resource_role_origin_id`",
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Default:       "Member",
+				ConflictsWith: []string{"resource_role_origin_id"},
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"Member",
+						"Owner",
+						"Eligible Member",
+						"Eligible Owner",
+					}, false,
+				),
+			},
+
+			"resource_role_origin_id": {
+				Description:   "The origin ID of the resource role (AppRole ID) for application resources. Cannot be used together with `access_type`",
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"access_type"},
+				ValidateFunc:  validation.IsUUID,
+			},
+
+			"resource_role_display_name": {
+				Description: "The display name of the resource role",
 				Type:        pluginsdk.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "Member",
-				ValidateFunc: validation.StringInSlice([]string{
-					"Member",
-					"Owner",
-				}, false),
+				Computed:    true,
 			},
 		},
 	}
@@ -82,6 +105,7 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 	}
 
 	accessType := d.Get("access_type").(string)
+	resourceRoleOriginId := d.Get("resource_role_origin_id").(string)
 	accessPackageId := beta.NewIdentityGovernanceEntitlementManagementAccessPackageID(d.Get("access_package_id").(string))
 
 	catalogId := beta.NewIdentityGovernanceEntitlementManagementAccessPackageCatalogID(catalogResourceAssociationId.CatalogId)
@@ -99,39 +123,123 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 
 	resource := pointer.To((*resourceResp.Model)[0])
 
-	properties := beta.AccessPackageResourceRoleScope{
-		AccessPackageResourceRole: &beta.AccessPackageResourceRole{
-			DisplayName:  nullable.NoZero(accessType),
-			OriginId:     nullable.Value(fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId)),
-			OriginSystem: resource.OriginSystem,
-			AccessPackageResource: &beta.AccessPackageResource{
-				Id:           resource.Id,
-				ResourceType: resource.ResourceType,
-				OriginId:     resource.OriginId,
+	var properties beta.AccessPackageResourceRoleScope
+
+	originSystem := resource.OriginSystem.GetOrZero()
+
+	if resourceRoleOriginId != "" {
+		// Application resource role (AppRole)
+		if originSystem != "AadApplication" {
+			return tf.ErrorDiagPathF(nil, "resource_role_origin_id", "`resource_role_origin_id` can only be used with application resources (AadApplication), but the resource origin system is %q", originSystem)
+		}
+
+		// For AadApplication, the catalog resource originId is the service principal object ID.
+		// We look up AppRoles on the service principal.
+		spClient := meta.(*clients.Client).ServicePrincipals.ServicePrincipalClient
+		spId := stable.NewServicePrincipalID(catalogResourceAssociationId.OriginId)
+		spResp, err := spClient.GetServicePrincipal(ctx, spId, serviceprincipal.DefaultGetServicePrincipalOperationOptions())
+		if err != nil {
+			return tf.ErrorDiagF(err, "Retrieving Service Principal %s", spId)
+		}
+		if spResp.Model == nil {
+			return tf.ErrorDiagF(errors.New("model was nil"), "Retrieving Service Principal %s", spId)
+		}
+		sp := spResp.Model
+
+		var roleDisplayName, roleDescription string
+		var found bool
+
+		if sp.AppRoles != nil {
+			for _, appRole := range *sp.AppRoles {
+				if appRole.Id != nil && *appRole.Id == resourceRoleOriginId {
+					roleDisplayName = appRole.DisplayName.GetOrZero()
+					roleDescription = appRole.Description.GetOrZero()
+					found = true
+					break
+				}
+			}
+		}
+
+		if !found {
+			var availableRoles []string
+			if sp.AppRoles != nil {
+				for _, appRole := range *sp.AppRoles {
+					if appRole.Id != nil {
+						availableRoles = append(availableRoles, fmt.Sprintf("%s (%s)", appRole.DisplayName.GetOrZero(), *appRole.Id))
+					}
+				}
+			}
+			return tf.ErrorDiagPathF(
+				nil, "resource_role_origin_id",
+				"No AppRole with ID %q found on Service Principal %s. Available AppRoles: %s",
+				resourceRoleOriginId, spId, strings.Join(availableRoles, ", "),
+			)
+		}
+
+		properties = beta.AccessPackageResourceRoleScope{
+			AccessPackageResourceRole: &beta.AccessPackageResourceRole{
+				DisplayName:  nullable.NoZero(roleDisplayName),
+				Description:  nullable.NoZero(roleDescription),
+				OriginId:     nullable.Value(resourceRoleOriginId),
+				OriginSystem: resource.OriginSystem,
+				AccessPackageResource: &beta.AccessPackageResource{
+					Id:           resource.Id,
+					ResourceType: resource.ResourceType,
+					OriginId:     resource.OriginId,
+				},
 			},
-		},
-		AccessPackageResourceScope: &beta.AccessPackageResourceScope{
-			OriginSystem: resource.OriginSystem,
-			OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
-		},
+			AccessPackageResourceScope: &beta.AccessPackageResourceScope{
+				OriginSystem: resource.OriginSystem,
+				OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
+			},
+		}
+	} else {
+		// Group resource role (Member, Owner, Eligible Member, Eligible Owner)
+		// Strip spaces for the originId prefix: "Eligible Member" -> "EligibleMember"
+		originIdPrefix := strings.ReplaceAll(accessType, " ", "")
+
+		properties = beta.AccessPackageResourceRoleScope{
+			AccessPackageResourceRole: &beta.AccessPackageResourceRole{
+				DisplayName:  nullable.NoZero(accessType),
+				OriginId:     nullable.Value(fmt.Sprintf("%s_%s", originIdPrefix, catalogResourceAssociationId.OriginId)),
+				OriginSystem: resource.OriginSystem,
+				AccessPackageResource: &beta.AccessPackageResource{
+					Id:           resource.Id,
+					ResourceType: resource.ResourceType,
+					OriginId:     resource.OriginId,
+				},
+			},
+			AccessPackageResourceScope: &beta.AccessPackageResourceScope{
+				OriginSystem: resource.OriginSystem,
+				OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
+			},
+		}
 	}
 
 	createMsg := `Creating Access Package Resource Association from resource %q@%q to access package %q`
 
 	resp, err := client.CreateEntitlementManagementAccessPackageResourceRoleScope(ctx, accessPackageId, properties, entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultCreateEntitlementManagementAccessPackageResourceRoleScopeOperationOptions())
 	if err != nil {
-		return tf.ErrorDiagF(err, createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
+		return tf.ErrorDiagF(err, createMsg, catalogResourceAssociationId.OriginId, originSystem, accessPackageId)
 	}
 
 	resourceRoleScope := resp.Model
 	if resourceRoleScope == nil {
-		return tf.ErrorDiagF(errors.New("model was nil"), createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
+		return tf.ErrorDiagF(errors.New("model was nil"), createMsg, catalogResourceAssociationId.OriginId, originSystem, accessPackageId)
 	}
 	if resourceRoleScope.Id == nil {
-		return tf.ErrorDiagF(errors.New("model has nil ID"), createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
+		return tf.ErrorDiagF(errors.New("model has nil ID"), createMsg, catalogResourceAssociationId.OriginId, originSystem, accessPackageId)
 	}
 
-	resourceId := parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	var resourceId parse.AccessPackageResourcePackageAssociationId
+	if resourceRoleOriginId != "" {
+		resourceId = parse.NewAccessPackageResourcePackageAssociationIDWithRoleOrigin(
+			accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, resourceRoleOriginId,
+		)
+	} else {
+		resourceId = parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	}
+
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageIdAccessPackageResourceRoleScopeID(resourceId.AccessPackageId, resourceId.ResourceRoleScopeId)
 
 	// Poll for AccessPackageResourceRoleScope
@@ -186,8 +294,17 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 	catalogResourceAssociationId := parse.NewAccessPackageResourceCatalogAssociationID(accessPackage.CatalogId.GetOrZero(), resourceId.OriginId)
 
 	tf.Set(d, "access_package_id", resourceId.AccessPackageId)
-	tf.Set(d, "access_type", resourceId.AccessType)
 	tf.Set(d, "catalog_resource_association_id", catalogResourceAssociationId.ID())
+
+	if resourceId.RoleOriginId != "" {
+		tf.Set(d, "resource_role_origin_id", resourceId.RoleOriginId)
+		// Read the display name from the role scope
+		if roleScope.AccessPackageResourceRole != nil {
+			tf.Set(d, "resource_role_display_name", roleScope.AccessPackageResourceRole.DisplayName.GetOrZero())
+		}
+	} else {
+		tf.Set(d, "access_type", resourceId.AccessType)
+	}
 
 	return nil
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -36,6 +36,58 @@ func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 	})
 }
 
+func TestAccAccessPackageResourcePackageAssociation_eligibleMember(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.eligibleMember(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Eligible Member"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_eligibleOwner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.eligibleOwner(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Eligible Owner"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_applicationAppRole(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.applicationAppRole(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_role_origin_id").Exists(),
+				check.That(data.ResourceName).Key("resource_role_display_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (AccessPackageResourcePackageAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.IdentityGovernance.AccessPackageClient
 
@@ -83,6 +135,141 @@ resource "azuread_access_package" "test" {
 resource "azuread_access_package_resource_package_association" "test" {
   access_package_id               = azuread_access_package.test.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) eligibleMember(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "test-access-package-eligible-member-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_group_role_management_policy" "test_member" {
+  group_id = azuread_group.test_group.object_id
+  role_id  = "member"
+
+  eligible_assignment_rules {
+    expiration_required = false
+  }
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-eligible-member-%[1]d"
+  description  = "Test catalog eligible member %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-eligible-member-%[1]d"
+  description  = "Test Package Eligible Member %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Eligible Member"
+
+  depends_on = [azuread_group_role_management_policy.test_member]
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) eligibleOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "test-access-package-eligible-owner-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_group_role_management_policy" "test_owner" {
+  group_id = azuread_group.test_group.object_id
+  role_id  = "owner"
+
+  eligible_assignment_rules {
+    expiration_required = false
+  }
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-eligible-owner-%[1]d"
+  description  = "Test catalog eligible owner %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-eligible-owner-%[1]d"
+  description  = "Test Package Eligible Owner %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Eligible Owner"
+
+  depends_on = [azuread_group_role_management_policy.test_owner]
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) applicationAppRole(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "test-access-package-app-%[1]d"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Test AppRole"
+    display_name         = "TestRole"
+    id                   = "c3e219dc-0a44-4341-8660-868d389c9558"
+    value                = "TestRole"
+  }
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "test-catalog-app-role-%[1]d"
+  description  = "Test catalog app role %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_service_principal.test.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "test-package-app-role-%[1]d"
+  description  = "Test Package App Role %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  resource_role_origin_id         = tolist(azuread_application.test.app_role)[0].id
 }
 `, data.RandomInteger)
 }

--- a/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
@@ -15,10 +15,17 @@ type AccessPackageResourcePackageAssociationId struct {
 	ResourceRoleScopeId string
 	OriginId            string
 	AccessType          string
+	// RoleOriginId is the origin ID of the resource role (for application AppRoles/OAuth2 scopes).
+	// When set, AccessType should be empty.
+	RoleOriginId string
 }
 
 func (id AccessPackageResourcePackageAssociationId) ID() string {
-	return fmt.Sprintf("%s/%s/%s/%s", id.AccessPackageId, id.ResourceRoleScopeId, id.OriginId, id.AccessType)
+	roleIdentifier := id.AccessType
+	if id.RoleOriginId != "" {
+		roleIdentifier = id.RoleOriginId
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", id.AccessPackageId, id.ResourceRoleScopeId, id.OriginId, roleIdentifier)
 }
 
 func NewAccessPackageResourcePackageAssociationID(catalogId, resourceRoleScopeId, originId, accessType string) AccessPackageResourcePackageAssociationId {
@@ -30,10 +37,27 @@ func NewAccessPackageResourcePackageAssociationID(catalogId, resourceRoleScopeId
 	}
 }
 
+func NewAccessPackageResourcePackageAssociationIDWithRoleOrigin(accessPackageId, resourceRoleScopeId, originId, roleOriginId string) AccessPackageResourcePackageAssociationId {
+	return AccessPackageResourcePackageAssociationId{
+		AccessPackageId:     accessPackageId,
+		ResourceRoleScopeId: resourceRoleScopeId,
+		OriginId:            originId,
+		RoleOriginId:        roleOriginId,
+	}
+}
+
+// knownAccessTypes are the group-based access types stored in the ID's 4th segment.
+var knownAccessTypes = map[string]bool{
+	"Member":          true,
+	"Owner":           true,
+	"Eligible Member": true,
+	"Eligible Owner":  true,
+}
+
 func AccessPackageResourcePackageAssociationID(idString string) (*AccessPackageResourcePackageAssociationId, error) {
 	parts := strings.Split(idString, "/")
 	if len(parts) != 4 {
-		return nil, fmt.Errorf("ID should be in the format {accessPackageId}/{resourcePackageAssociationId}/{originId}/{accessType} - but got %q", idString)
+		return nil, fmt.Errorf("ID should be in the format {accessPackageId}/{resourcePackageAssociationId}/{originId}/{roleIdentifier} - but got %q", idString)
 	}
 
 	for i, p := range parts {
@@ -44,10 +68,22 @@ func AccessPackageResourcePackageAssociationID(idString string) (*AccessPackageR
 		}
 	}
 
-	return &AccessPackageResourcePackageAssociationId{
+	roleIdentifier := parts[3]
+	if roleIdentifier == "" {
+		return nil, fmt.Errorf("specified ID segment #3 (roleIdentifier) is empty")
+	}
+
+	result := &AccessPackageResourcePackageAssociationId{
 		AccessPackageId:     parts[0],
 		ResourceRoleScopeId: parts[1],
 		OriginId:            parts[2],
-		AccessType:          parts[3],
-	}, nil
+	}
+
+	if knownAccessTypes[roleIdentifier] {
+		result.AccessType = roleIdentifier
+	} else {
+		result.RoleOriginId = roleIdentifier
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR add support for managing 
- Eligible Member
- Eligible Owner
- AppRole Assignments

using the `access_package_resource_package_association` resource.



## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `access_package_resource_package_association` - support for eligible group member/owner assignments, support for AppRoles [GH-1853]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1776 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
