### PR TITLE
Fix azuread_privileged_access_group_(eligibility|assignment)_schedule resource update functionality (redux)

### DIFF
--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
@@ -104,10 +104,12 @@ func (r PrivilegedAccessGroupAssignmentScheduleResource) Create() sdk.ResourceFu
 
 			id := stable.NewIdentityGovernancePrivilegedAccessGroupAssignmentScheduleID(resourceId.ID())
 			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
-				if u, err := scheduleClient.GetPrivilegedAccessGroupAssignmentSchedule(ctx, id, privilegedaccessgroupassignmentschedule.DefaultGetPrivilegedAccessGroupAssignmentScheduleOperationOptions()); err != nil {
-					if !response.WasNotFound(u.HttpResponse) {
-						return pointer.To(false), fmt.Errorf("waiting for creation of %s: %+v", id, err)
+				resp, err := scheduleClient.GetPrivilegedAccessGroupAssignmentSchedule(ctx, id, privilegedaccessgroupassignmentschedule.DefaultGetPrivilegedAccessGroupAssignmentScheduleOperationOptions())
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return pointer.To(false), nil
 					}
+					return nil, fmt.Errorf("waiting for creation of %s: %+v", id, err)
 				}
 				return pointer.To(true), nil
 			}); err != nil {

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
@@ -224,6 +224,7 @@ func (r PrivilegedAccessGroupAssignmentScheduleResource) Update() sdk.ResourceFu
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupAssignmentScheduleRequestClient
+			scheduleClient := metadata.Client.IdentityGovernance.PrivilegedAccessGroupAssignmentScheduleClient
 
 			resourceId, err := parse.ParsePrivilegedAccessGroupScheduleID(metadata.ResourceData.Id())
 			if err != nil {
@@ -271,6 +272,27 @@ func (r PrivilegedAccessGroupAssignmentScheduleResource) Update() sdk.ResourceFu
 
 			if pointer.From(request.Status) == PrivilegedAccessGroupScheduleRequestStatusFailed {
 				return fmt.Errorf("creating updated assignment schedule request: request is in a failed state")
+			}
+
+			newResourceId, err := parse.ParsePrivilegedAccessGroupScheduleID(request.TargetScheduleId.GetOrZero())
+			if err != nil {
+				return err
+			}
+
+			metadata.SetID(newResourceId)
+
+			id := stable.NewIdentityGovernancePrivilegedAccessGroupAssignmentScheduleID(newResourceId.ID())
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				resp, err := scheduleClient.GetPrivilegedAccessGroupAssignmentSchedule(ctx, id, privilegedaccessgroupassignmentschedule.DefaultGetPrivilegedAccessGroupAssignmentScheduleOperationOptions())
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return pointer.To(false), nil
+					}
+					return nil, fmt.Errorf("waiting for update of %s: %+v", id, err)
+				}
+				return pointer.To(true), nil
+			}); err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
 			return nil

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource.go
@@ -242,7 +242,7 @@ func (r PrivilegedAccessGroupAssignmentScheduleResource) Update() sdk.ResourceFu
 				AccessId:      stable.PrivilegedAccessGroupRelationships(resourceId.Relationship),
 				PrincipalId:   nullable.Value(model.PrincipalId),
 				GroupId:       nullable.Value(resourceId.GroupId),
-				Action:        pointer.To(stable.ScheduleRequestActions_AdminAssign),
+				Action:        pointer.To(stable.ScheduleRequestActions_AdminUpdate),
 				Justification: nullable.NoZero(model.Justification),
 				ScheduleInfo:  schedule,
 			}

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
@@ -50,12 +50,20 @@ func TestAccPrivilegedAccessGroupAssignmentSchedule_owner(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.owner(data),
+			Config: r.owner(data, "P30D", "required"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				// There is a minimum life of 5 minutes for a schedule request to exist.
 				// Attempting to delete the request within this time frame will result in
 				// a 400 error on destroy, which we can't trap.
+				helpers.SleepCheck(5*time.Minute+15*time.Second),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.owner(data, "P45D", "updated justification"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 				helpers.SleepCheck(5*time.Minute+15*time.Second),
 			),
 		},
@@ -115,7 +123,7 @@ resource "azuread_privileged_access_group_assignment_schedule" "member" {
 `, data.RandomString, data.RandomPassword, endTime.Format(time.RFC3339))
 }
 
-func (PrivilegedAccessGroupAssignmentScheduleResource) owner(data acceptance.TestData) string {
+func (PrivilegedAccessGroupAssignmentScheduleResource) owner(data acceptance.TestData, duration string, justification string) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -151,8 +159,8 @@ resource "azuread_privileged_access_group_assignment_schedule" "owner" {
   group_id        = azuread_group.pam.object_id
   principal_id    = azuread_user.eligibile_owner.object_id
   assignment_type = "owner"
-  duration        = "P30D"
-  justification   = "required"
+  duration        = "%[3]s"
+  justification   = "%[4]s"
 }
-`, data.RandomString, data.RandomPassword)
+`, data.RandomString, data.RandomPassword, duration, justification)
 }

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
@@ -127,6 +127,8 @@ func (PrivilegedAccessGroupAssignmentScheduleResource) owner(data acceptance.Tes
 	return fmt.Sprintf(`
 provider "azuread" {}
 
+data "azuread_client_config" "current" {}
+
 data "azuread_domains" "test" {
   only_initial = true
 }
@@ -142,7 +144,9 @@ resource "azuread_group" "pam" {
   mail_enabled     = false
   security_enabled = true
 
-  owners = [azuread_user.manual_owner.object_id]
+  # Include the current SP as an owner so it has sufficient privileges to
+  # delete the group during test clean-up.
+  owners = [azuread_user.manual_owner.object_id, data.azuread_client_config.current.object_id]
 
   lifecycle {
     ignore_changes = [owners]

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
@@ -228,7 +228,7 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Update() sdk.ResourceF
 				AccessId:      stable.PrivilegedAccessGroupRelationships(resourceId.Relationship),
 				PrincipalId:   nullable.Value(model.PrincipalId),
 				GroupId:       nullable.Value(resourceId.GroupId),
-				Action:        pointer.To(stable.ScheduleRequestActions_AdminAssign),
+				Action:        pointer.To(stable.ScheduleRequestActions_AdminUpdate),
 				Justification: nullable.NoZero(model.Justification),
 				ScheduleInfo:  schedule,
 			}

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
@@ -224,6 +224,7 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Update() sdk.ResourceF
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+			scheduleClient := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleClient
 
 			resourceId, err := parse.ParsePrivilegedAccessGroupScheduleID(metadata.ResourceData.Id())
 			if err != nil {
@@ -271,6 +272,27 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Update() sdk.ResourceF
 
 			if pointer.From(request.Status) == PrivilegedAccessGroupScheduleRequestStatusFailed {
 				return fmt.Errorf("creating updated eligibility schedule request: request is in a failed state")
+			}
+
+			newResourceId, err := parse.ParsePrivilegedAccessGroupScheduleID(request.TargetScheduleId.GetOrZero())
+			if err != nil {
+				return err
+			}
+
+			metadata.SetID(newResourceId)
+
+			id := stable.NewIdentityGovernancePrivilegedAccessGroupEligibilityScheduleID(newResourceId.ID())
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				resp, err := scheduleClient.GetPrivilegedAccessGroupEligibilitySchedule(ctx, id, privilegedaccessgroupeligibilityschedule.DefaultGetPrivilegedAccessGroupEligibilityScheduleOperationOptions())
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return pointer.To(false), nil
+					}
+					return nil, fmt.Errorf("waiting for update of %s: %+v", id, err)
+				}
+				return pointer.To(true), nil
+			}); err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
 			return nil

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/stable/privilegedaccessgroupeligibilityschedulerequest"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/consistency"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/parse"
@@ -49,6 +50,7 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Create() sdk.ResourceF
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleRequestClient
+			scheduleClient := metadata.Client.IdentityGovernance.PrivilegedAccessGroupEligibilityScheduleClient
 
 			var model PrivilegedAccessGroupScheduleModel
 			if err := metadata.Decode(&model); err != nil {
@@ -99,6 +101,20 @@ func (r PrivilegedAccessGroupEligibilityScheduleResource) Create() sdk.ResourceF
 			}
 
 			metadata.SetID(resourceId)
+
+			id := stable.NewIdentityGovernancePrivilegedAccessGroupEligibilityScheduleID(resourceId.ID())
+			if err = consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+				resp, err := scheduleClient.GetPrivilegedAccessGroupEligibilitySchedule(ctx, id, privilegedaccessgroupeligibilityschedule.DefaultGetPrivilegedAccessGroupEligibilityScheduleOperationOptions())
+				if err != nil {
+					if response.WasNotFound(resp.HttpResponse) {
+						return pointer.To(false), nil
+					}
+					return nil, fmt.Errorf("waiting for creation of %s: %+v", id, err)
+				}
+				return pointer.To(true), nil
+			}); err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
 
 			return nil
 		},

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -50,12 +50,20 @@ func TestAccPrivilegedAccessGroupEligibilitySchedule_owner(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.owner(data),
+			Config: r.owner(data, "P30D", "required"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				// There is a minimum life of 5 minutes for a schedule request to exist.
 				// Attempting to delete the request within this time frame will result in
 				// a 400 error on destroy, which we can't trap.
+				helpers.SleepCheck(5*time.Minute+15*time.Second),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.owner(data, "P45D", "updated justification"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 				helpers.SleepCheck(5*time.Minute+15*time.Second),
 			),
 		},
@@ -114,7 +122,7 @@ resource "azuread_privileged_access_group_eligibility_schedule" "member" {
 `, data.RandomString, data.RandomPassword, endTime.Format(time.RFC3339))
 }
 
-func (PrivilegedAccessGroupEligibilityScheduleResource) owner(data acceptance.TestData) string {
+func (PrivilegedAccessGroupEligibilityScheduleResource) owner(data acceptance.TestData, duration string, justification string) string {
 	return fmt.Sprintf(`
 provider "azuread" {}
 
@@ -151,8 +159,8 @@ resource "azuread_privileged_access_group_eligibility_schedule" "owner" {
   group_id        = azuread_group.pam.object_id
   principal_id    = azuread_user.eligibile_owner.object_id
   assignment_type = "owner"
-  duration        = "P30D"
-  justification   = "required"
+  duration        = "%[3]s"
+  justification   = "%[4]s"
 }
-`, data.RandomString, data.RandomPassword)
+`, data.RandomString, data.RandomPassword, duration, justification)
 }

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -126,6 +126,8 @@ func (PrivilegedAccessGroupEligibilityScheduleResource) owner(data acceptance.Te
 	return fmt.Sprintf(`
 provider "azuread" {}
 
+data "azuread_client_config" "current" {}
+
 data "azuread_domains" "test" {
   only_initial = true
 }
@@ -141,7 +143,9 @@ resource "azuread_group" "pam" {
   mail_enabled     = false
   security_enabled = true
 
-  owners = [azuread_user.manual_owner.object_id]
+  # Include the current SP as an owner so it has sufficient privileges to
+  # delete the group during test clean-up.
+  owners = [azuread_user.manual_owner.object_id, data.azuread_client_config.current.object_id]
 
   lifecycle {
     ignore_changes = [owners]


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR fixes https://github.com/hashicorp/terraform-provider-azuread/issues/1412 . It revives the abandoned PR https://github.com/hashicorp/terraform-provider-azuread/pull/1614 and adds additional fixes to make the tests green, see the commit messages for details.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_privileged_access_group_eligibility_schedule` - in `Create()` wait till resource is present
* `azuread_privileged_access_group_eligibility_schedule` - fix `Update()` ([#1412](https://github.com/hashicorp/terraform-provider-azuread/issues/1412))
* `azuread_privileged_access_group_assignment_schedule` - in `Create()` fix `waitForUpdate()` callback 
* `azuread_privileged_access_group_assignment_schedule` - fix `Update()` (analogous bug as in [#1412](https://github.com/hashicorp/terraform-provider-azuread/issues/1412))


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1412

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
