### PR TITLE
`azuread_custom_security_attribute_assignment`: Custom Security Attribute Assignation to Service Principals and Users

### DIFF
--- a/docs/resources/custom_security_attribute_assignment.md
+++ b/docs/resources/custom_security_attribute_assignment.md
@@ -1,0 +1,223 @@
+---
+subcategory: "Custom Security Attributes"
+---
+
+# Resource: azuread_custom_security_attribute_assignment
+
+Manages custom security attribute assignments for a user, or service principal.
+
+-> **Note** Custom security attribute definitions (attribute sets and attribute names) must be created in the Azure portal or via the Microsoft Graph API before they can be assigned using this resource. This resource manages assignments only, not definitions.
+
+-> **Note** The Microsoft Graph v1.0 API is used for this resource. One resource instance manages one attribute set on one principal. To manage multiple attribute sets on the same principal, create multiple resource instances.
+
+## API Permissions
+
+The following API permissions are required in order to use this resource.
+
+When authenticated with a service principal, this resource requires the following application role: `CustomSecAttributeAssignment.ReadWrite.All`
+
+When authenticated with a user principal, this resource requires one of the following directory roles: `Attribute Assignment Administrator`
+
+
+## Example Usage
+
+*Assign a single string attribute to a service principal*
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_custom_security_attribute_assignment" "example" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Engineering"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+}
+```
+
+*Assign a multi-value string collection attribute*
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_custom_security_attribute_assignment" "example" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Engineering"
+
+  attribute {
+    name   = "AllowedLocations"
+    values = ["US", "EU", "APAC"]
+  }
+}
+```
+
+*Assign a boolean attribute*
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_custom_security_attribute_assignment" "example" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Security"
+
+  attribute {
+    name          = "IsCompliant"
+    boolean_value = true
+  }
+}
+```
+
+*Assign multiple attributes of different types in one attribute set*
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_custom_security_attribute_assignment" "example" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Engineering"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+
+  attribute {
+    name   = "AllowedLocations"
+    values = ["US", "EU"]
+  }
+
+  attribute {
+    name          = "IsCompliant"
+    boolean_value = true
+  }
+}
+```
+
+*Assign attributes to a user*
+
+```terraform
+data "azuread_domains" "example" {
+  only_initial = true
+}
+
+resource "azuread_user" "example" {
+  display_name        = "Example User"
+  user_principal_name = "example@${data.azuread_domains.example.domains.0.domain_name}"
+  password            = "SecretP@sswd99!"
+}
+
+resource "azuread_custom_security_attribute_assignment" "example" {
+  principal_id  = azuread_user.example.object_id
+  attribute_set = "HR"
+
+  attribute {
+    name  = "Department"
+    value = "Engineering"
+  }
+}
+```
+
+*Manage multiple attribute sets on the same principal*
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example"
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_custom_security_attribute_assignment" "engineering" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Engineering"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+}
+
+resource "azuread_custom_security_attribute_assignment" "security" {
+  principal_id  = azuread_service_principal.example.object_id
+  attribute_set = "Security"
+
+  attribute {
+    name          = "IsCompliant"
+    boolean_value = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `principal_id` - (Required) The object ID of the principal to which the custom security attributes are assigned. Supported object types are users and service principals. Changing this forces a new resource to be created.
+
+* `attribute_set` - (Required) The name of the attribute set containing the attributes to assign. Changing this forces a new resource to be created.
+
+* `attribute` - (Required) One or more `attribute` blocks as documented below.
+
+---
+
+An `attribute` block supports the following:
+
+* `name` - (Required) The name of the custom security attribute to assign.
+
+* `value` - (Optional) A single string value for the attribute. Exactly one of `value`, `values`, or `boolean_value` must be set.
+
+* `values` - (Optional) A list of string values for the attribute (multi-value string collection). Exactly one of `value`, `values`, or `boolean_value` must be set.
+
+* `boolean_value` - (Optional) A boolean value for the attribute. Exactly one of `value`, `values`, or `boolean_value` must be set.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resource, in the format `<principal_id>/<attribute_set>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 minutes) Used when creating the resource.
+* `read` - (Defaults to 5 minutes) Used when retrieving the resource.
+* `update` - (Defaults to 10 minutes) Used when updating the resource.
+* `delete` - (Defaults to 10 minutes) Used when deleting the resource.
+
+## Import
+
+Custom security attribute assignments can be imported using the object ID of the principal and the name of the attribute set, separated by a `/`, e.g.
+
+```shell
+terraform import azuread_custom_security_attribute_assignment.example "00000000-0000-0000-0000-000000000000/Engineering"
+```
+
+-> **Note** When deleting this resource, Terraform will null out all managed attributes rather than removing the attribute set. This is a limitation of the Microsoft Graph API, which does not support deletion of custom security attribute assignments — only clearing their values.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -23,6 +23,7 @@ import (
 	applications "github.com/hashicorp/terraform-provider-azuread/internal/services/applications/client"
 	approleassignments "github.com/hashicorp/terraform-provider-azuread/internal/services/approleassignments/client"
 	conditionalaccess "github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess/client"
+	customsecurityattributes "github.com/hashicorp/terraform-provider-azuread/internal/services/customsecurityattributes/client"
 	directoryobjects "github.com/hashicorp/terraform-provider-azuread/internal/services/directoryobjects/client"
 	directoryroles "github.com/hashicorp/terraform-provider-azuread/internal/services/directoryroles/client"
 	domains "github.com/hashicorp/terraform-provider-azuread/internal/services/domains/client"
@@ -48,21 +49,22 @@ type Client struct {
 
 	StopContext context.Context
 
-	AdministrativeUnits *administrativeunits.Client
-	Applications        *applications.Client
-	AppRoleAssignments  *approleassignments.Client
-	ConditionalAccess   *conditionalaccess.Client
-	DirectoryObjects    *directoryobjects.Client
-	DirectoryRoles      *directoryroles.Client
-	Domains             *domains.Client
-	Groups              *groups.Client
-	IdentityGovernance  *identitygovernance.Client
-	Invitations         *invitations.Client
-	Policies            *policies.Client
-	ServicePrincipals   *serviceprincipals.Client
-	Synchronization     *synchronization.Client
-	UserFlows           *userflows.Client
-	Users               *users.Client
+	AdministrativeUnits      *administrativeunits.Client
+	Applications             *applications.Client
+	AppRoleAssignments       *approleassignments.Client
+	ConditionalAccess        *conditionalaccess.Client
+	CustomSecurityAttributes *customsecurityattributes.Client
+	DirectoryObjects         *directoryobjects.Client
+	DirectoryRoles           *directoryroles.Client
+	Domains                  *domains.Client
+	Groups                   *groups.Client
+	IdentityGovernance       *identitygovernance.Client
+	Invitations              *invitations.Client
+	Policies                 *policies.Client
+	ServicePrincipals        *serviceprincipals.Client
+	Synchronization          *synchronization.Client
+	UserFlows                *userflows.Client
+	Users                    *users.Client
 }
 
 func (client *Client) build(ctx context.Context, o *common.ClientOptions) error {
@@ -81,6 +83,9 @@ func (client *Client) build(ctx context.Context, o *common.ClientOptions) error 
 	}
 	if client.ConditionalAccess, err = conditionalaccess.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for ConditionalAccess: %v", err)
+	}
+	if client.CustomSecurityAttributes, err = customsecurityattributes.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for CustomSecurityAttributes: %v", err)
 	}
 	if client.DirectoryObjects, err = directoryobjects.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for DirectoryObjects: %v", err)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/applications"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/approleassignments"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/conditionalaccess"
+	"github.com/hashicorp/terraform-provider-azuread/internal/services/customsecurityattributes"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/directoryobjects"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/directoryroles"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/domains"
@@ -41,6 +42,7 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 		applications.Registration{},
 		approleassignments.Registration{},
 		conditionalaccess.Registration{},
+		customsecurityattributes.Registration{},
 		directoryobjects.Registration{},
 		directoryroles.Registration{},
 		domains.Registration{},

--- a/internal/services/customsecurityattributes/client/client.go
+++ b/internal/services/customsecurityattributes/client/client.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	serviceprincipalBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/beta/serviceprincipal"
+	"github.com/hashicorp/terraform-provider-azuread/internal/common"
+)
+
+type Client struct {
+	ServicePrincipalClientBeta *serviceprincipalBeta.ServicePrincipalClient
+}
+
+func NewClient(o *common.ClientOptions) (*Client, error) {
+	servicePrincipalClientBeta, err := serviceprincipalBeta.NewServicePrincipalClientWithBaseURI(o.Environment.MicrosoftGraph)
+	if err != nil {
+		return nil, err
+	}
+	o.Configure(servicePrincipalClientBeta.Client)
+
+	return &Client{
+		ServicePrincipalClientBeta: servicePrincipalClientBeta,
+	}, nil
+}

--- a/internal/services/customsecurityattributes/client/client.go
+++ b/internal/services/customsecurityattributes/client/client.go
@@ -4,22 +4,22 @@
 package client
 
 import (
-	serviceprincipalBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/beta/serviceprincipal"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/stable/serviceprincipal"
 	"github.com/hashicorp/terraform-provider-azuread/internal/common"
 )
 
 type Client struct {
-	ServicePrincipalClientBeta *serviceprincipalBeta.ServicePrincipalClient
+	ServicePrincipalClient *serviceprincipal.ServicePrincipalClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
-	servicePrincipalClientBeta, err := serviceprincipalBeta.NewServicePrincipalClientWithBaseURI(o.Environment.MicrosoftGraph)
+	servicePrincipalClient, err := serviceprincipal.NewServicePrincipalClientWithBaseURI(o.Environment.MicrosoftGraph)
 	if err != nil {
 		return nil, err
 	}
-	o.Configure(servicePrincipalClientBeta.Client)
+	o.Configure(servicePrincipalClient.Client)
 
 	return &Client{
-		ServicePrincipalClientBeta: servicePrincipalClientBeta,
+		ServicePrincipalClient: servicePrincipalClient,
 	}, nil
 }

--- a/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource.go
+++ b/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource.go
@@ -178,7 +178,7 @@ func customSecurityAttributeAssignmentDiff(_ context.Context, d *pluginsdk.Resou
 //	{
 //	  "customSecurityAttributes": {
 //	    "<attributeSet>": {
-//	      "@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+//	      "@odata.type": "#Microsoft.DirectoryServices.CustomSecurityAttributeValue",
 //	      "<name>": "singleValue",
 //	      "<name>@odata.type": "#Collection(String)",
 //	      "<name>": ["val1", "val2"],
@@ -188,7 +188,7 @@ func customSecurityAttributeAssignmentDiff(_ context.Context, d *pluginsdk.Resou
 //	}
 func expandCustomSecurityAttributes(attributeSet string, input []interface{}) (map[string]interface{}, error) {
 	setPayload := map[string]interface{}{
-		"@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+		"@odata.type": "#Microsoft.DirectoryServices.CustomSecurityAttributeValue",
 	}
 
 	for _, rawAttr := range input {
@@ -341,7 +341,7 @@ func resolveObjectPath(ctx context.Context, c *msgraph.Client, objectId string) 
 }
 
 func customSecurityAttributeAssignmentResourceCreateUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
-	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClient
 
 	principalId := d.Get("principal_id").(string)
 	attributeSet := d.Get("attribute_set").(string)
@@ -401,7 +401,7 @@ func customSecurityAttributeAssignmentResourceCreateUpdate(ctx context.Context, 
 }
 
 func customSecurityAttributeAssignmentResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
-	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClient
 
 	principalId, attributeSet, err := parseResourceID(d.Id())
 	if err != nil {
@@ -470,7 +470,7 @@ func customSecurityAttributeAssignmentResourceRead(ctx context.Context, d *plugi
 }
 
 func customSecurityAttributeAssignmentResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
-	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClient
 
 	principalId, attributeSet, err := parseResourceID(d.Id())
 	if err != nil {
@@ -511,7 +511,7 @@ func customSecurityAttributeAssignmentResourceDelete(ctx context.Context, d *plu
 // buildClearPayload constructs a payload that nulls out every attribute tracked by this resource.
 func buildClearPayload(attributeSet string, input []interface{}) map[string]interface{} {
 	setPayload := map[string]interface{}{
-		"@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+		"@odata.type": "#Microsoft.DirectoryServices.CustomSecurityAttributeValue",
 	}
 
 	for _, rawAttr := range input {

--- a/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource.go
+++ b/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource.go
@@ -1,0 +1,532 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package customsecurityattributes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	sdkClient "github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/msgraph"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/validation"
+)
+
+func customSecurityAttributeAssignmentResource() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		CreateContext: customSecurityAttributeAssignmentResourceCreateUpdate,
+		ReadContext:   customSecurityAttributeAssignmentResourceRead,
+		UpdateContext: customSecurityAttributeAssignmentResourceCreateUpdate,
+		DeleteContext: customSecurityAttributeAssignmentResourceDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(10 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(10 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		CustomizeDiff: customSecurityAttributeAssignmentDiff,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			parts := strings.SplitN(id, "/", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				return fmt.Errorf("expected import ID in format <principal_id>/<attribute_set>, got %q", id)
+			}
+			if _, errs := validation.IsUUID(parts[0], "principal_id"); len(errs) > 0 {
+				return fmt.Errorf("principal_id %q is not a valid UUID", parts[0])
+			}
+			return nil
+		}),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"principal_id": {
+				Description:  "The object ID of the principal (user, group, or service principal) to which the custom security attributes are assigned",
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"attribute_set": {
+				Description:  "The name of the attribute set",
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"attribute": {
+				Description: "One or more attribute blocks within this attribute set",
+				Type:        pluginsdk.TypeSet,
+				Required:    true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Description:  "The name of the custom security attribute",
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"value": {
+							Description: "A single string value for the attribute. Mutually exclusive with values and boolean_value",
+							Type:        pluginsdk.TypeString,
+							Optional:    true,
+							Computed:    true,
+						},
+
+						"values": {
+							Description: "A list of string values for the attribute (multi-value). Mutually exclusive with value and boolean_value",
+							Type:        pluginsdk.TypeList,
+							Optional:    true,
+							Computed:    true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+
+						"boolean_value": {
+							Description: "A boolean value for the attribute. Mutually exclusive with value and values",
+							Type:        pluginsdk.TypeBool,
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// customSecurityAttributeAssignmentDiff validates that each attribute block sets
+// exactly one of value, values, or boolean_value. This is done in CustomizeDiff
+// because ExactlyOneOf is not supported inside TypeSet nested blocks in the plugin SDK.
+//
+// We use GetRawConfig() instead of GetOk() because boolean_value=false is Go's zero
+// value and indistinguishable from "not set" via the normal schema API.
+func customSecurityAttributeAssignmentDiff(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return nil
+	}
+
+	attrVal := raw.GetAttr("attribute")
+	if attrVal.IsNull() || !attrVal.IsKnown() {
+		return nil
+	}
+
+	for it := attrVal.ElementIterator(); it.Next(); {
+		_, elem := it.Element()
+		if elem.IsNull() || !elem.IsKnown() {
+			continue
+		}
+
+		nameVal := elem.GetAttr("name")
+		name := ""
+		if !nameVal.IsNull() && nameVal.IsKnown() {
+			name = nameVal.AsString()
+		}
+
+		valueVal := elem.GetAttr("value")
+		valuesVal := elem.GetAttr("values")
+		boolVal := elem.GetAttr("boolean_value")
+
+		// A field is "set" if it is non-null and known in the raw config.
+		// This correctly handles boolean_value=false (non-null, known, valid).
+		hasValue := !valueVal.IsNull() && valueVal.IsKnown() && valueVal.AsString() != ""
+		hasValues := !valuesVal.IsNull() && valuesVal.IsKnown() && valuesVal.LengthInt() > 0
+		hasBool := !boolVal.IsNull() && boolVal.IsKnown()
+
+		setCount := 0
+		if hasValue {
+			setCount++
+		}
+		if hasValues {
+			setCount++
+		}
+		if hasBool {
+			setCount++
+		}
+
+		if setCount == 0 {
+			return fmt.Errorf("attribute %q: exactly one of value, values, or boolean_value must be set", name)
+		}
+		if setCount > 1 {
+			return fmt.Errorf("attribute %q: only one of value, values, or boolean_value may be set", name)
+		}
+	}
+
+	return nil
+}
+
+// expandCustomSecurityAttributes converts the Terraform schema into the JSON payload
+// the Graph API expects. The Graph API represents custom security attributes as:
+//
+//	{
+//	  "customSecurityAttributes": {
+//	    "<attributeSet>": {
+//	      "@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+//	      "<name>": "singleValue",
+//	      "<name>@odata.type": "#Collection(String)",
+//	      "<name>": ["val1", "val2"],
+//	      "<name>": true
+//	    }
+//	  }
+//	}
+func expandCustomSecurityAttributes(attributeSet string, input []interface{}) (map[string]interface{}, error) {
+	setPayload := map[string]interface{}{
+		"@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+	}
+
+	for _, rawAttr := range input {
+		attrMap, ok := rawAttr.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name := attrMap["name"].(string)
+		if name == "" {
+			return nil, fmt.Errorf("attribute name must not be empty in attribute_set %q", attributeSet)
+		}
+
+		singleVal := attrMap["value"].(string)
+		multiValRaw, _ := attrMap["values"].([]interface{})
+		boolVal, _ := attrMap["boolean_value"].(bool)
+
+		// Route to the correct Graph API type.
+		// CustomizeDiff guarantees exactly one field is meaningfully set.
+		// boolean_value=false is valid and must be sent explicitly.
+		switch {
+		case len(multiValRaw) > 0:
+			vals := make([]string, 0, len(multiValRaw))
+			for _, v := range multiValRaw {
+				vals = append(vals, v.(string))
+			}
+			setPayload[name+"@odata.type"] = "#Collection(String)"
+			setPayload[name] = vals
+
+		case singleVal != "":
+			setPayload[name] = singleVal
+
+		default:
+			// boolean_value — send true or false explicitly (including false)
+			setPayload[name] = boolVal
+		}
+	}
+
+	return map[string]interface{}{
+		attributeSet: setPayload,
+	}, nil
+}
+
+// flattenAttributes converts the attribute set map from the Graph API back into
+// the flat list of attribute blocks used in the schema.
+func flattenAttributes(setVal map[string]interface{}) []interface{} {
+	attrs := make([]interface{}, 0)
+
+	for key, val := range setVal {
+		if strings.HasPrefix(key, "@") || strings.HasSuffix(key, "@odata.type") {
+			continue
+		}
+
+		attrMap := map[string]interface{}{
+			"name":          key,
+			"value":         "",
+			"values":        []interface{}{},
+			"boolean_value": false,
+		}
+
+		switch v := val.(type) {
+		case bool:
+			attrMap["boolean_value"] = v
+
+		case []interface{}:
+			strVals := make([]interface{}, 0, len(v))
+			for _, sv := range v {
+				strVals = append(strVals, fmt.Sprintf("%v", sv))
+			}
+			attrMap["values"] = strVals
+
+		default:
+			attrMap["value"] = fmt.Sprintf("%v", v)
+		}
+
+		attrs = append(attrs, attrMap)
+	}
+
+	return attrs
+}
+
+// patchCSA is intentionally unused — PATCH is done inline via raw HTTP in create/update/delete.
+
+// selectOptions implements sdkClient.Options to append a $select query parameter.
+type selectOptions struct {
+	fields []string
+}
+
+func (o *selectOptions) ToHeaders() *sdkClient.Headers { return nil }
+func (o *selectOptions) ToOData() *odata.Query {
+	return &odata.Query{Select: o.fields}
+}
+func (o *selectOptions) ToQuery() *sdkClient.QueryParams { return nil }
+
+// parseResourceID splits the composite resource ID "<principalId>/<attributeSet>" into its parts.
+func parseResourceID(id string) (principalId string, attributeSet string, err error) {
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("expected resource ID in format <principal_id>/<attribute_set>, got %q", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+// resolveObjectPath does a GET on /directoryObjects/{id} to read the @odata.type,
+// then returns the type-specific path (e.g. /servicePrincipals/{id}, /users/{id}, /groups/{id}).
+// This is required because /directoryObjects/{id} does not support PATCH of customSecurityAttributes.
+func resolveObjectPath(ctx context.Context, c *msgraph.Client, objectId string) (string, pluginsdk.Diagnostics) {
+	directoryObjectPath := fmt.Sprintf("/directoryObjects/%s", objectId)
+
+	req, err := c.NewRequest(ctx, sdkClient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK},
+		HttpMethod:          http.MethodGet,
+		Path:                directoryObjectPath,
+		OptionsObject:       &selectOptions{fields: []string{"id"}},
+	})
+	if err != nil {
+		return "", tf.ErrorDiagF(err, "Building GET request to resolve object type for %q", objectId)
+	}
+
+	httpResp, err := req.Execute(ctx)
+	if err != nil {
+		return "", tf.ErrorDiagF(err, "Resolving object type for principal %q", objectId)
+	}
+	if httpResp == nil || httpResp.Response == nil {
+		return "", tf.ErrorDiagF(errors.New("response was nil"), "Resolving object type for principal %q", objectId)
+	}
+
+	var body map[string]interface{}
+	if err := httpResp.Unmarshal(&body); err != nil {
+		return "", tf.ErrorDiagF(err, "Decoding object type response for principal %q", objectId)
+	}
+
+	odataType, _ := body["@odata.type"].(string)
+	log.Printf("[DEBUG] Resolved @odata.type for principal %q: %s", objectId, odataType)
+
+	switch {
+	case strings.EqualFold(odataType, "#microsoft.graph.servicePrincipal"):
+		return fmt.Sprintf("/servicePrincipals/%s", objectId), nil
+	case strings.EqualFold(odataType, "#microsoft.graph.user"):
+		return fmt.Sprintf("/users/%s", objectId), nil
+	case strings.EqualFold(odataType, "#microsoft.graph.group"):
+		return fmt.Sprintf("/groups/%s", objectId), nil
+	default:
+		return "", tf.ErrorDiagF(
+			fmt.Errorf("unsupported object type %q — must be servicePrincipal, user, or group", odataType),
+			"Resolving object type for principal %q", objectId,
+		)
+	}
+}
+
+func customSecurityAttributeAssignmentResourceCreateUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+
+	principalId := d.Get("principal_id").(string)
+	attributeSet := d.Get("attribute_set").(string)
+	rawAttrs := d.Get("attribute").(*pluginsdk.Set).List()
+
+	csaPayload, err := expandCustomSecurityAttributes(attributeSet, rawAttrs)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Building custom security attributes payload")
+	}
+
+	payload := map[string]interface{}{
+		"customSecurityAttributes": csaPayload,
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Marshalling custom security attributes")
+	}
+
+	log.Printf("[DEBUG] Custom security attributes PATCH payload for principal %q: %s", principalId, string(payloadJSON))
+
+	// Resolve the object type so we can PATCH the correct type-specific endpoint.
+	// /directoryObjects/{id} does not support customSecurityAttributes in PATCH.
+	objectPath, diags := resolveObjectPath(ctx, spClient.Client, principalId)
+	if diags != nil {
+		return diags
+	}
+
+	req, err := spClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusNoContent, http.StatusOK},
+		HttpMethod:          http.MethodPatch,
+		Path:                objectPath,
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Building PATCH request for principal %q", principalId)
+	}
+
+	if err = req.Marshal(payload); err != nil {
+		return tf.ErrorDiagF(err, "Marshalling PATCH payload for principal %q", principalId)
+	}
+
+	httpResp, err := req.Execute(ctx)
+	if err != nil {
+		return tf.ErrorDiagF(err, "Setting custom security attributes on principal %q", principalId)
+	}
+	if httpResp == nil || httpResp.Response == nil {
+		return tf.ErrorDiagF(errors.New("response was nil"), "Setting custom security attributes on principal %q", principalId)
+	}
+
+	log.Printf("[DEBUG] Successfully PATCHed custom security attributes on principal %q (HTTP %d)", principalId, httpResp.Response.StatusCode)
+
+	// Encode both principal_id and attribute_set into the resource ID so import works
+	d.SetId(principalId + "/" + attributeSet)
+
+	return customSecurityAttributeAssignmentResourceRead(ctx, d, meta)
+}
+
+func customSecurityAttributeAssignmentResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+
+	principalId, attributeSet, err := parseResourceID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing resource ID")
+	}
+
+	objectPath, diags := resolveObjectPath(ctx, spClient.Client, principalId)
+	if diags != nil {
+		return diags
+	}
+
+	req, err := spClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK},
+		HttpMethod:          http.MethodGet,
+		Path:                objectPath,
+		OptionsObject:       &selectOptions{fields: []string{"id", "customSecurityAttributes"}},
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Building GET request for principal %q", principalId)
+	}
+
+	httpResp, err := req.Execute(ctx)
+	if err != nil {
+		if httpResp != nil && response.WasNotFound(httpResp.Response) {
+			log.Printf("[DEBUG] Principal %q was not found - removing from state!", principalId)
+			d.SetId("")
+			return nil
+		}
+		return tf.ErrorDiagF(err, "Retrieving custom security attributes for principal %q", principalId)
+	}
+
+	if httpResp == nil || httpResp.Response == nil {
+		return tf.ErrorDiagF(errors.New("response was nil"), "Retrieving principal %q", principalId)
+	}
+
+	var body map[string]interface{}
+	if err := httpResp.Unmarshal(&body); err != nil {
+		return tf.ErrorDiagF(err, "Decoding response for principal %q", principalId)
+	}
+
+	rawCSAVal, ok := body["customSecurityAttributes"]
+	if !ok || rawCSAVal == nil {
+		log.Printf("[DEBUG] customSecurityAttributes not present in response for principal %q (may lack read permission)", principalId)
+		tf.Set(d, "principal_id", principalId)
+		tf.Set(d, "attribute_set", attributeSet)
+		return nil
+	}
+
+	rawCSA, ok := rawCSAVal.(map[string]interface{})
+	if !ok {
+		return tf.ErrorDiagF(fmt.Errorf("unexpected type for customSecurityAttributes"), "Parsing response for principal %q", principalId)
+	}
+
+	rawJSON, _ := json.Marshal(rawCSA)
+	log.Printf("[DEBUG] Custom security attributes read back for principal %q: %s", principalId, string(rawJSON))
+
+	tf.Set(d, "principal_id", principalId)
+	tf.Set(d, "attribute_set", attributeSet)
+
+	if setVal, ok := rawCSA[attributeSet].(map[string]interface{}); ok {
+		tf.Set(d, "attribute", flattenAttributes(setVal))
+	}
+
+	return nil
+}
+
+func customSecurityAttributeAssignmentResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	spClient := meta.(*clients.Client).CustomSecurityAttributes.ServicePrincipalClientBeta
+
+	principalId, attributeSet, err := parseResourceID(d.Id())
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "id", "Parsing resource ID")
+	}
+
+	objectPath, diags := resolveObjectPath(ctx, spClient.Client, principalId)
+	if diags != nil {
+		return diags
+	}
+	rawAttrs := d.Get("attribute").(*pluginsdk.Set).List()
+
+	clearPayload := map[string]interface{}{
+		"customSecurityAttributes": buildClearPayload(attributeSet, rawAttrs),
+	}
+
+	req, err := spClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusNoContent, http.StatusOK},
+		HttpMethod:          http.MethodPatch,
+		Path:                objectPath,
+	})
+	if err != nil {
+		return tf.ErrorDiagF(err, "Building PATCH request for principal %q", principalId)
+	}
+
+	if err = req.Marshal(clearPayload); err != nil {
+		return tf.ErrorDiagF(err, "Marshalling clear payload for principal %q", principalId)
+	}
+
+	if _, err := req.Execute(ctx); err != nil {
+		return tf.ErrorDiagF(err, "Clearing custom security attributes on principal %q", principalId)
+	}
+
+	return nil
+}
+
+// buildClearPayload constructs a payload that nulls out every attribute tracked by this resource.
+func buildClearPayload(attributeSet string, input []interface{}) map[string]interface{} {
+	setPayload := map[string]interface{}{
+		"@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+	}
+
+	for _, rawAttr := range input {
+		attrMap, ok := rawAttr.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name := attrMap["name"].(string)
+		setPayload[name] = nil
+	}
+
+	return map[string]interface{}{
+		attributeSet: setPayload,
+	}
+}
+
+// unmarshalCSA is kept for reference. The resource uses raw HTTP reads instead,
+// since the SDK's CustomSecurityAttributeValue type is a stub that cannot hold attribute data.

--- a/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource_test.go
+++ b/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
-	serviceprincipalBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/beta/serviceprincipal"
 	sdkClient "github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -147,7 +145,7 @@ func TestAccCustomSecurityAttributeAssignment_requiresImport(t *testing.T) {
 // ── Exists helper ─────────────────────────────────────────────────────────────
 
 // Exists checks that the custom security attribute assignment exists in Azure by
-// reading the customSecurityAttributes property from the service principal.
+// reading the customSecurityAttributes property from the principal via raw HTTP.
 func (r CustomSecurityAttributeAssignmentResource) Exists(ctx context.Context, c *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	// Parse the composite ID: <principalId>/<attributeSet>
 	id := state.ID
@@ -163,29 +161,12 @@ func (r CustomSecurityAttributeAssignmentResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("could not parse resource ID %q: expected <principalId>/<attributeSet>", id)
 	}
 
-	spId := beta.NewServicePrincipalID(principalId)
-	opts := serviceprincipalBeta.GetServicePrincipalOperationOptions{
-		Select: pointer.To([]string{"id", "customSecurityAttributes"}),
-	}
-
-	resp, err := c.CustomSecurityAttributes.ServicePrincipalClientBeta.GetServicePrincipal(ctx, spId, opts)
-	if err != nil {
-		return pointer.To(false), fmt.Errorf("retrieving service principal %q: %+v", principalId, err)
-	}
-	if resp.Model == nil {
-		return pointer.To(false), nil
-	}
-
-	// Read customSecurityAttributes via raw JSON since the SDK type is a stub
-	csaClient := c.CustomSecurityAttributes.ServicePrincipalClientBeta
-	req, err := csaClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
+	req, err := c.CustomSecurityAttributes.ServicePrincipalClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
 		ContentType:         "application/json; charset=utf-8",
 		ExpectedStatusCodes: []int{http.StatusOK},
 		HttpMethod:          http.MethodGet,
 		Path:                fmt.Sprintf("/servicePrincipals/%s", principalId),
-		OptionsObject: &selectOpts{
-			fields: []string{"id", "customSecurityAttributes"},
-		},
+		OptionsObject:       &selectOpts{fields: []string{"id", "customSecurityAttributes"}},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("building GET request: %+v", err)

--- a/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource_test.go
+++ b/internal/services/customsecurityattributes/custom_security_attribute_assignment_resource_test.go
@@ -1,0 +1,363 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package customsecurityattributes_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+	serviceprincipalBeta "github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/beta/serviceprincipal"
+	sdkClient "github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+)
+
+// ── Test resource struct ──────────────────────────────────────────────────────
+
+type CustomSecurityAttributeAssignmentResource struct{}
+
+// ── Acceptance tests ──────────────────────────────────────────────────────────
+
+// TestAccCustomSecurityAttributeAssignment_singleStringValue creates a resource
+// with a single-string attribute and verifies it is readable.
+func TestAccCustomSecurityAttributeAssignment_singleStringValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	// Custom security attributes cannot be truly deleted via the API (only nulled),
+	// so we skip the destroy check.
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.singleStringValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("attribute_set").HasValue("TestAttributeSet"),
+				check.That(data.ResourceName).Key("attribute.#").HasValue("1"),
+			),
+		},
+		// Import by <principal_id>/<attribute_set>
+		data.ImportStep(),
+	})
+}
+
+// TestAccCustomSecurityAttributeAssignment_multiStringValues creates a resource
+// with a multi-value string collection attribute.
+func TestAccCustomSecurityAttributeAssignment_multiStringValues(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.multiStringValues(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("attribute.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// TestAccCustomSecurityAttributeAssignment_booleanValue creates a resource
+// with a boolean attribute.
+func TestAccCustomSecurityAttributeAssignment_booleanValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.booleanValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("attribute.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// TestAccCustomSecurityAttributeAssignment_multipleAttributes creates a resource
+// with multiple attribute blocks of different types in the same attribute set.
+func TestAccCustomSecurityAttributeAssignment_multipleAttributes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.multipleAttributes(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("attribute.#").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// TestAccCustomSecurityAttributeAssignment_update verifies that updating attribute
+// values in-place works without recreating the resource.
+func TestAccCustomSecurityAttributeAssignment_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.singleStringValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.singleStringValueUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// TestAccCustomSecurityAttributeAssignment_requiresImport verifies that attempting
+// to create a duplicate resource produces the expected error.
+func TestAccCustomSecurityAttributeAssignment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_custom_security_attribute_assignment", "test")
+	r := CustomSecurityAttributeAssignmentResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.singleStringValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport(data)),
+	})
+}
+
+// ── Exists helper ─────────────────────────────────────────────────────────────
+
+// Exists checks that the custom security attribute assignment exists in Azure by
+// reading the customSecurityAttributes property from the service principal.
+func (r CustomSecurityAttributeAssignmentResource) Exists(ctx context.Context, c *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	// Parse the composite ID: <principalId>/<attributeSet>
+	id := state.ID
+	var principalId, attributeSet string
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '/' {
+			principalId = id[:i]
+			attributeSet = id[i+1:]
+			break
+		}
+	}
+	if principalId == "" || attributeSet == "" {
+		return nil, fmt.Errorf("could not parse resource ID %q: expected <principalId>/<attributeSet>", id)
+	}
+
+	spId := beta.NewServicePrincipalID(principalId)
+	opts := serviceprincipalBeta.GetServicePrincipalOperationOptions{
+		Select: pointer.To([]string{"id", "customSecurityAttributes"}),
+	}
+
+	resp, err := c.CustomSecurityAttributes.ServicePrincipalClientBeta.GetServicePrincipal(ctx, spId, opts)
+	if err != nil {
+		return pointer.To(false), fmt.Errorf("retrieving service principal %q: %+v", principalId, err)
+	}
+	if resp.Model == nil {
+		return pointer.To(false), nil
+	}
+
+	// Read customSecurityAttributes via raw JSON since the SDK type is a stub
+	csaClient := c.CustomSecurityAttributes.ServicePrincipalClientBeta
+	req, err := csaClient.Client.NewRequest(ctx, sdkClient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK},
+		HttpMethod:          http.MethodGet,
+		Path:                fmt.Sprintf("/servicePrincipals/%s", principalId),
+		OptionsObject: &selectOpts{
+			fields: []string{"id", "customSecurityAttributes"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("building GET request: %+v", err)
+	}
+
+	httpResp, err := req.Execute(ctx)
+	if err != nil {
+		return pointer.To(false), nil
+	}
+
+	var body map[string]interface{}
+	if err := httpResp.Unmarshal(&body); err != nil {
+		return nil, fmt.Errorf("decoding response: %+v", err)
+	}
+
+	csaRaw, ok := body["customSecurityAttributes"].(map[string]interface{})
+	if !ok {
+		return pointer.To(false), nil
+	}
+
+	setVal, ok := csaRaw[attributeSet].(map[string]interface{})
+	if !ok {
+		return pointer.To(false), nil
+	}
+
+	// The attribute set exists and has at least one non-metadata key
+	for k := range setVal {
+		if k != "@odata.type" {
+			return pointer.To(true), nil
+		}
+	}
+
+	return pointer.To(false), nil
+}
+
+// selectOpts implements sdkClient.Options to append a $select query parameter.
+type selectOpts struct {
+	fields []string
+}
+
+func (o *selectOpts) ToHeaders() *sdkClient.Headers { return nil }
+func (o *selectOpts) ToOData() *odata.Query {
+	return &odata.Query{Select: o.fields}
+}
+func (o *selectOpts) ToQuery() *sdkClient.QueryParams { return nil }
+
+// ── Terraform config templates ────────────────────────────────────────────────
+
+// template returns the shared service principal used by all test configs.
+// NOTE: The attribute set "TestAttributeSet" and its attributes must be
+// pre-created in the tenant before running these tests. Custom security
+// attribute definitions cannot be managed by this provider.
+func (r CustomSecurityAttributeAssignmentResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctestCSA-%[1]d"
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+`, data.RandomInteger)
+}
+
+func (r CustomSecurityAttributeAssignmentResource) singleStringValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "test" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+}
+`, r.template(data))
+}
+
+func (r CustomSecurityAttributeAssignmentResource) singleStringValueUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "test" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name  = "Environment"
+    value = "Staging"
+  }
+}
+`, r.template(data))
+}
+
+func (r CustomSecurityAttributeAssignmentResource) multiStringValues(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "test" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name   = "AllowedLocations"
+    values = ["US", "EU"]
+  }
+}
+`, r.template(data))
+}
+
+func (r CustomSecurityAttributeAssignmentResource) booleanValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "test" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name          = "IsCompliant"
+    boolean_value = true
+  }
+}
+`, r.template(data))
+}
+
+func (r CustomSecurityAttributeAssignmentResource) multipleAttributes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "test" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+
+  attribute {
+    name   = "AllowedLocations"
+    values = ["US", "EU"]
+  }
+
+  attribute {
+    name          = "IsCompliant"
+    boolean_value = true
+  }
+}
+`, r.template(data))
+}
+
+func (r CustomSecurityAttributeAssignmentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_custom_security_attribute_assignment" "import" {
+  principal_id  = azuread_service_principal.test.object_id
+  attribute_set = "TestAttributeSet"
+
+  attribute {
+    name  = "Environment"
+    value = "Production"
+  }
+}
+`, r.singleStringValue(data))
+}
+
+// ── JSON debug helper (used in Exists) ────────────────────────────────────────
+
+var _ = json.Marshal // ensure json import is used

--- a/internal/services/customsecurityattributes/parse/custom_security_attribute_assignment_id.go
+++ b/internal/services/customsecurityattributes/parse/custom_security_attribute_assignment_id.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
+)
+
+func ParseServicePrincipalID(id string) (*beta.ServicePrincipalId, error) {
+	spId, err := beta.ParseServicePrincipalID(id)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a service principal ID: %w", id, err)
+	}
+	return spId, nil
+}

--- a/internal/services/customsecurityattributes/registration.go
+++ b/internal/services/customsecurityattributes/registration.go
@@ -1,0 +1,32 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package customsecurityattributes
+
+import (
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
+)
+
+type Registration struct{}
+
+func (r Registration) Name() string {
+	return "Custom Security Attributes"
+}
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "feature/custom-security-attributes"
+}
+
+func (r Registration) WebsiteCategories() []string {
+	return []string{"Custom Security Attributes"}
+}
+
+func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{}
+}
+
+func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{
+		"azuread_custom_security_attribute_assignment": customSecurityAttributeAssignmentResource(),
+	}
+}


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds a new resource azuread_custom_security_attribute_assignment that manages custom security attribute assignments on Azure AD principals (users and service principals).The Microsoft Graph v1.0 API is used for this resource. 

Key design decisions:
* One resource instance manages one attribute set on one principal. Multiple attribute sets on the same principal require multiple resource instances.
* The resource ID is <principal_id>/<attribute_set_name> to support import 
* Three explicit value fields (value, values, boolean_value) mirror the Graph API's distinct attribute types (String, StringCollection, Boolean). Mutual exclusion is enforced, only one can be set at a time. 
* Delete nulls out all managed attributes rather than removing the attribute set (the Graph API does not support deletion of assignments, only clearing). This in the console is equivalent to unassigning the attribute of the principal.

## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

* `azuread_custom_security_attribute_assignment`  - new resource for managing custom security attribute assignments on users and service principals


This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #912

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This PR adds the ability to assign custom security attributes to Azure AD principals. Custom security attributes are used in security-sensitive scenarios such as Conditional Access policy filtering. No changes to encryption or logging.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
