### PR TITLE
tests - prefix `display_name` properties with `acctest`

### DIFF
--- a/internal/services/applications/application_federated_identity_credential_resource_test.go
+++ b/internal/services/applications/application_federated_identity_credential_resource_test.go
@@ -120,7 +120,7 @@ func (r ApplicationFederatedIdentityCredentialResource) basic(data acceptance.Te
 
 resource "azuread_application_federated_identity_credential" "test" {
   application_id = azuread_application.test.id
-  display_name   = "hashitown.example.com-%[2]s"
+  display_name   = "acctest-hashitown.example.com-%[2]s"
   audiences      = ["api://HashiTownLikesAzureAD"]
   issuer         = "https://tokens.hashitown.example.com.net"
   subject        = "%[3]s"
@@ -134,7 +134,7 @@ func (r ApplicationFederatedIdentityCredentialResource) complete(data acceptance
 
 resource "azuread_application_federated_identity_credential" "test" {
   application_id = azuread_application.test.id
-  display_name   = "hashitown.example.com-%[2]s"
+  display_name   = "acctest-hashitown.example.com-%[2]s"
   description    = "Funtime tokens for HashiTown"
   audiences      = ["api://HashiTownLikesAzureAD"]
   issuer         = "https://vending.hashitown.example.com.net"

--- a/internal/services/applications/application_flexible_federated_identity_credential_resource_test.go
+++ b/internal/services/applications/application_flexible_federated_identity_credential_resource_test.go
@@ -119,7 +119,7 @@ func (r ApplicationFlexibleFederatedIdentityCredentialResource) basic(data accep
 
 resource "azuread_application_flexible_federated_identity_credential" "test" {
   application_id             = azuread_application.test.id
-  display_name               = "hashitown.example.com-%[2]s"
+  display_name               = "acctest-hashitown.example.com-%[2]s"
   claims_matching_expression = "claims['sub'] matches 'repo:contoso/contoso-repo:ref:refs/heads/*' and claims['job_workflow_ref'] matches 'contoso/contoso-prod/.github/workflows/*.yml@refs/heads/main'"
   audience                   = "api://HashiTownLikesAzureAD"
   issuer                     = "https://token.actions.githubusercontent.com"
@@ -133,7 +133,7 @@ func (r ApplicationFlexibleFederatedIdentityCredentialResource) complete(data ac
 
 resource "azuread_application_flexible_federated_identity_credential" "test" {
   application_id             = azuread_application.test.id
-  display_name               = "hashitown.example.com-%[2]s"
+  display_name               = "acctest-hashitown.example.com-%[2]s"
   claims_matching_expression = "claims['sub'] matches 'repo:contoso/contoso-repo:ref:refs/heads/*' and claims['job_workflow_ref'] matches 'contoso/contoso-prod/.github/workflows/update.yml@refs/heads/main'"
   description                = "Funtime tokens for HashiTown"
   audience                   = "api://HashiTownLikesAzureAD"

--- a/internal/services/applications/application_password_resource_test.go
+++ b/internal/services/applications/application_password_resource_test.go
@@ -181,7 +181,7 @@ func (r ApplicationPasswordResource) complete(data acceptance.TestData, startDat
 
 resource "azuread_application_password" "test" {
   application_id = azuread_application.test.id
-  display_name   = "terraform-%[2]s"
+  display_name   = "acctest-terraform-%[2]s"
   start_date     = "%[3]s"
   end_date       = "%[4]s"
 }
@@ -194,7 +194,7 @@ func (r ApplicationPasswordResource) relativeEndDate(data acceptance.TestData) s
 
 resource "azuread_application_password" "test" {
   application_id    = azuread_application.test.id
-  display_name      = "terraform-%[2]s"
+  display_name      = "acctest-terraform-%[2]s"
   end_date_relative = "8760h"
 }
 `, r.template(data), data.RandomString)

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource_test.go
@@ -143,18 +143,18 @@ func (AccessPackageAssignmentPolicyResource) simple(data acceptance.TestData) st
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
+  display_name = "acctest-catalog-%[1]d"
   description  = "Test Catalog %[1]d"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "access-package-%[1]d"
+  display_name = "acctest-access-package-%[1]d"
   description  = "Test Access Package %[1]d"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "access-package-assignment-policy-%[1]d"
+  display_name      = "acctest-access-package-assignment-policy-%[1]d"
   description       = "Test Access Package Assignnment Policy %[1]d"
   access_package_id = azuread_access_package.test.id
 }
@@ -166,23 +166,23 @@ func (AccessPackageAssignmentPolicyResource) basic(data acceptance.TestData) str
 provider "azuread" {}
 
 resource "azuread_group" "test" {
-  display_name     = "test-group-%[1]d"
+  display_name     = "acctest-group-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "TestAcc Access Package %[1]d for access assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "testacc-access-assignment-%[1]d"
+  display_name      = "acctest-access-assignment-%[1]d"
   description       = "TestAcc Access Package Assignnment Policy %[1]d"
   duration_in_days  = 90
   access_package_id = azuread_access_package.test.id
@@ -225,23 +225,23 @@ func (AccessPackageAssignmentPolicyResource) basicWithoutQuestion(data acceptanc
 provider "azuread" {}
 
 resource "azuread_group" "test" {
-  display_name     = "test-group-%[1]d"
+  display_name     = "acctest-group-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "TestAcc Access Package %[1]d for access assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "testacc-access-assignment-%[1]d"
+  display_name      = "acctest-access-assignment-%[1]d"
   description       = "TestAcc Access Package Assignnment Policy %[1]d"
   duration_in_days  = 90
   access_package_id = azuread_access_package.test.id
@@ -278,33 +278,33 @@ func (AccessPackageAssignmentPolicyResource) complete(data acceptance.TestData) 
 provider "azuread" {}
 
 resource "azuread_group" "requestor" {
-  display_name     = "test-requestor-%[1]d"
+  display_name     = "acctest-requestor-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_group" "first_approver" {
-  display_name     = "test-approver-%[1]d"
+  display_name     = "acctest-approver-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_group" "second_approver" {
-  display_name     = "test-s-approver-%[1]d"
+  display_name     = "acctest-s-approver-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "TestAcc Catalog %[1]d for access assignment policy"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "testacc-access-assignment-%[1]d"
+  display_name = "acctest-access-assignment-%[1]d"
   description  = "Test Access Package %[1]d for assignment policy"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
 
 resource "azuread_access_package_assignment_policy" "test" {
-  display_name      = "access-package-assignment-policy-%[1]d"
+  display_name      = "acctest-access-package-assignment-policy-%[1]d"
   description       = "Test Access Package Assignnment Policy %[1]d"
   extension_enabled = true
   expiration_date   = "2096-09-23T01:02:03Z"

--- a/internal/services/identitygovernance/access_package_catalog_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_data_source_test.go
@@ -40,7 +40,7 @@ func TestAccAccessPackageCatalogDataSource_byDisplayName(t *testing.T) {
 func (AccessPackageCatalogDataSource) testCheckFunc(data acceptance.TestData) acceptance.TestCheckFunc {
 	return acceptance.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Test access package catalog %[1]d", data.RandomInteger)),
-		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("test-access-package-catalog-%[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-access-package-catalog-%[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("externally_visible").HasValue("false"),
 		check.That(data.ResourceName).Key("published").HasValue("false"),
 	)

--- a/internal/services/identitygovernance/access_package_catalog_resource_test.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource_test.go
@@ -99,7 +99,7 @@ func (AccessPackageCatalogResource) basic(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test" {
-  display_name = "test-access-package-catalog-%[1]d"
+  display_name = "acctest-access-package-catalog-%[1]d"
   description  = "Test access package catalog %[1]d"
 }
 `, data.RandomInteger)
@@ -110,7 +110,7 @@ func (AccessPackageCatalogResource) complete(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test" {
-  display_name       = "test-access-package-catalog-%[1]d"
+  display_name       = "acctest-access-package-catalog-%[1]d"
   description        = "Test access package catalog %[1]d"
   externally_visible = false
   published          = false

--- a/internal/services/identitygovernance/access_package_data_source_test.go
+++ b/internal/services/identitygovernance/access_package_data_source_test.go
@@ -40,7 +40,7 @@ func TestAccAccessPackageDataSource_byDisplayName(t *testing.T) {
 func (AccessPackageDataSource) testCheckFunc(data acceptance.TestData) acceptance.TestCheckFunc {
 	return acceptance.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("description").HasValue(fmt.Sprintf("Access Package %[1]d", data.RandomInteger)),
-		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("access-package-%[1]d", data.RandomInteger)),
+		check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctest-access-package-%[1]d", data.RandomInteger)),
 		check.That(data.ResourceName).Key("hidden").HasValue("true"),
 		check.That(data.ResourceName).Key("catalog_id").Exists(),
 	)

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource_test.go
@@ -80,12 +80,12 @@ func (r AccessPackageResourceCatalogAssociationResource) complete(data acceptanc
 provider "azuread" {}
 
 resource "azuread_group" "test_group" {
-  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  display_name     = "acctest-access-package-resource-catalog-association-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
+  display_name = "acctest-catalog-%[1]d"
   description  = "Test catalog %[1]d"
 }
 

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -59,12 +59,12 @@ func (AccessPackageResourcePackageAssociationResource) complete(data acceptance.
 provider "azuread" {}
 
 resource "azuread_group" "test_group" {
-  display_name     = "test-access-package-resource-catalog-association-%[1]d"
+  display_name     = "acctest-access-package-resource-catalog-association-%[1]d"
   security_enabled = true
 }
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
+  display_name = "acctest-catalog-%[1]d"
   description  = "Test catalog %[1]d"
 }
 
@@ -75,7 +75,7 @@ resource "azuread_access_package_resource_catalog_association" "test" {
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "test-package-%[1]d"
+  display_name = "acctest-package-%[1]d"
   description  = "Test Package %[1]d"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }

--- a/internal/services/identitygovernance/access_package_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_test.go
@@ -98,12 +98,12 @@ func (AccessPackageResource) basic(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
+  display_name = "acctest-catalog-%[1]d"
   description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "access-package-%[1]d"
+  display_name = "acctest-access-package-%[1]d"
   description  = "Access Package %[1]d"
   catalog_id   = azuread_access_package_catalog.test_catalog.id
 }
@@ -115,12 +115,12 @@ func (AccessPackageResource) complete(data acceptance.TestData) string {
 provider "azuread" {}
 
 resource "azuread_access_package_catalog" "test_catalog" {
-  display_name = "test-catalog-%[1]d"
+  display_name = "acctest-catalog-%[1]d"
   description  = "Test catalog %[1]d"
 }
 
 resource "azuread_access_package" "test" {
-  display_name = "access-package-%[1]d"
+  display_name = "acctest-access-package-%[1]d"
   description  = "Access Package %[1]d"
   hidden       = true
   catalog_id   = azuread_access_package_catalog.test_catalog.id

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
@@ -69,7 +69,6 @@ func TestAccPrivilegedAccessGroupAssignmentSchedule_owner(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
-
 }
 
 func (PrivilegedAccessGroupAssignmentScheduleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
@@ -98,7 +97,7 @@ func (PrivilegedAccessGroupAssignmentScheduleResource) member(data acceptance.Te
 provider "azuread" {}
 
 resource "azuread_group" "pam" {
-  display_name     = "Privileged Assignment %[1]s"
+  display_name     = "acctest Privileged Assignment %[1]s"
   mail_enabled     = false
   security_enabled = true
 }
@@ -109,7 +108,7 @@ data "azuread_domains" "test" {
 
 resource "azuread_user" "member" {
   user_principal_name = "pam-member-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Member %[1]s"
+  display_name        = "acctest PAM Member %[1]s"
   password            = "%[2]s"
 }
 
@@ -135,12 +134,12 @@ data "azuread_domains" "test" {
 
 resource "azuread_user" "manual_owner" {
   user_principal_name = "pam-eligible-owner-manual-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Owner (Manual) %[1]s"
+  display_name        = "acctest PAM Owner (Manual) %[1]s"
   password            = "%[2]s"
 }
 
 resource "azuread_group" "pam" {
-  display_name     = "Privileged Assignment %[1]s"
+  display_name     = "acctest Privileged Assignment %[1]s"
   mail_enabled     = false
   security_enabled = true
 
@@ -155,7 +154,7 @@ resource "azuread_group" "pam" {
 
 resource "azuread_user" "eligibile_owner" {
   user_principal_name = "pam-eligible-owner-eligible-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Owner (Eligible) %[1]s"
+  display_name        = "acctest PAM Owner (Eligible) %[1]s"
   password            = "%[2]s"
 }
 

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -97,7 +97,7 @@ func (PrivilegedAccessGroupEligibilityScheduleResource) member(data acceptance.T
 provider "azuread" {}
 
 resource "azuread_group" "pam" {
-  display_name     = "Privileged Eligibility %[1]s"
+  display_name     = "acctest Privileged Eligibility %[1]s"
   mail_enabled     = false
   security_enabled = true
 }
@@ -108,7 +108,7 @@ data "azuread_domains" "test" {
 
 resource "azuread_user" "member" {
   user_principal_name = "pam-member-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Member %[1]s"
+  display_name        = "acctest PAM Member %[1]s"
   password            = "%[2]s"
 }
 
@@ -134,12 +134,12 @@ data "azuread_domains" "test" {
 
 resource "azuread_user" "manual_owner" {
   user_principal_name = "pam-eligible-owner-manual-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Owner (Manual) %[1]s"
+  display_name        = "acctest PAM Owner (Manual) %[1]s"
   password            = "%[2]s"
 }
 
 resource "azuread_group" "pam" {
-  display_name     = "Privileged Eligibility %[1]s"
+  display_name     = "acctest Privileged Eligibility %[1]s"
   mail_enabled     = false
   security_enabled = true
 
@@ -154,7 +154,7 @@ resource "azuread_group" "pam" {
 
 resource "azuread_user" "eligibile_owner" {
   user_principal_name = "pam-eligible-owner-eligibile-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Owner (Eligibile) %[1]s"
+  display_name        = "acctest PAM Owner (Eligibile) %[1]s"
   password            = "%[2]s"
 }
 

--- a/internal/services/policies/group_role_management_policy_resource_test.go
+++ b/internal/services/policies/group_role_management_policy_resource_test.go
@@ -71,7 +71,6 @@ func TestAccGroupRoleManagementPolicy_owner(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
-
 }
 
 func (GroupRoleManagementPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
@@ -107,7 +106,7 @@ func (GroupRoleManagementPolicyResource) activationRules(data acceptance.TestDat
 provider "azuread" {}
 
 resource "azuread_group" "this" {
-  display_name     = "PAM Basic Test %[1]s"
+  display_name     = "acctest PAM Basic Test %[1]s"
   security_enabled = true
 }
 
@@ -127,7 +126,7 @@ func (GroupRoleManagementPolicyResource) member(data acceptance.TestData) string
 provider "azuread" {}
 
 resource "azuread_group" "pam" {
-  display_name     = "PAM Member Test %[1]s"
+  display_name     = "acctest PAM Member Test %[1]s"
   mail_enabled     = false
   security_enabled = true
 }
@@ -159,12 +158,12 @@ data "azuread_domains" "test" {
 
 resource "azuread_user" "approver" {
   user_principal_name = "pam-approver-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "PAM Approver Test %[1]s"
+  display_name        = "acctest PAM Approver Test %[1]s"
   password            = "%[2]s"
 }
 
 resource "azuread_group" "pam" {
-  display_name     = "PAM Owner Test %[1]s"
+  display_name     = "acctest PAM Owner Test %[1]s"
   mail_enabled     = false
   security_enabled = true
 }

--- a/internal/services/serviceprincipals/service_principal_password_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource_test.go
@@ -136,7 +136,7 @@ func (r ServicePrincipalPasswordResource) complete(data acceptance.TestData, sta
 
 resource "azuread_service_principal_password" "test" {
   service_principal_id = azuread_service_principal.test.id
-  display_name         = "terraform-%[2]s"
+  display_name         = "acctest-terraform-%[2]s"
   start_date           = "%[3]s"
   end_date             = "%[4]s"
 }
@@ -149,7 +149,7 @@ func (r ServicePrincipalPasswordResource) relativeEndDate(data acceptance.TestDa
 
 resource "azuread_service_principal_password" "test" {
   service_principal_id = azuread_service_principal.test.id
-  display_name         = "terraform-%[2]s"
+  display_name         = "acctest-terraform-%[2]s"
   end_date_relative    = "8760h"
 }
 `, r.template(data), data.RandomString)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Azure Dalek cleaners for MS Graph use `display_name` as a filter, to make sure we can find and delete any leftover resources from the tests, prefix all with `acctest`


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="460" height="222" alt="image" src="https://github.com/user-attachments/assets/e0601eee-4899-4a68-942d-f5e7af41a68c" />

<img width="509" height="206" alt="image" src="https://github.com/user-attachments/assets/fd32e518-80e3-4820-aa7e-922da059141f" />

<img width="416" height="199" alt="image" src="https://github.com/user-attachments/assets/9dc0fc41-1dd4-4bdd-b7c4-48b0ceffb173" />

<img width="491" height="199" alt="image" src="https://github.com/user-attachments/assets/006ae693-60fe-4525-89ac-d7bea74d2ad9" />



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
