### PR TITLE
tooling - QOL updates for releases

### DIFF
--- a/internal/tools/changelog-formatter/main.go
+++ b/internal/tools/changelog-formatter/main.go
@@ -1,0 +1,294 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type sectionType string
+
+const (
+	sectionTypeBreakingChanges sectionType = "BREAKING CHANGES:"
+	sectionTypeFeatures        sectionType = "FEATURES:"
+	sectionTypeEnhancements    sectionType = "ENHANCEMENTS:"
+	sectionTypeBugs            sectionType = "BUG FIXES:"
+	sectionTypeUnknown         sectionType = "UNKNOWN"
+)
+
+type changelog struct {
+	pre          []string
+	breaking     []string
+	features     features
+	enhancements enhancements
+	bugs         bugs
+	post         []string
+}
+
+type features struct {
+	actions       []string
+	dataSources   []string
+	listResources []string
+	general       []string
+}
+
+type enhancements struct {
+	provider     []string
+	dependencies []string
+	dataSources  []string
+	general      []string
+}
+
+type bugs struct {
+	provider    []string
+	dataSources []string
+	general     []string
+}
+
+var (
+	sectionHeadingRegex = regexp.MustCompile(`(BREAKING CHANGES.*|FEATURES.*|ENHANCEMENTS.*|BUG FIXES.*)`)
+	versionHeadingRegex = regexp.MustCompile(`## \d*\.\d*\.\d* \(\w* \d{1,2}, \d{4}\)`)
+)
+
+func formatChangelog(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := strings.Split(string(bytes), "\n")
+
+	changeLog := &changelog{}
+	st := sectionTypeUnknown
+	parsingNewEntries := false
+	for idx, line := range content {
+		// Once we hit a released version's changelog heading, add the remaining content to `changelog.post`.
+		// We won't format any of the lines added here.
+		if versionHeadingRegex.MatchString(line) {
+			changeLog.post = content[idx:]
+			break
+		}
+
+		if sectionHeadingRegex.MatchString(line) {
+			parsingNewEntries = true
+
+			st = determineSectionType(line)
+			continue
+		}
+
+		if line != "" && parsingNewEntries {
+			addChangelogEntry(changeLog, st, line)
+		}
+
+		if !parsingNewEntries {
+			// If we're not currently parsing new changelog entries, i.e we haven't encountered a `BREAKING CHANGES`, `FEATURES`, `ENHANCEMENTS`, or `BUG FIXES` heading
+			// track it in `changelog.pre`. We won't format any of the lines added here.
+			changeLog.pre = append(changeLog.pre, line)
+		}
+	}
+	newContent := rebuildChangelog(changeLog)
+
+	if err := os.WriteFile(path, []byte(strings.Join(newContent, "\n")), 0o644); err != nil {
+		return fmt.Errorf("writing to `%s`", path)
+	}
+
+	return nil
+}
+
+func determineSectionType(line string) sectionType {
+	switch {
+	case strings.HasPrefix(line, "BREAKING CHANGES"):
+		return sectionTypeBreakingChanges
+	case strings.HasPrefix(line, "FEATURES"):
+		return sectionTypeFeatures
+	case strings.HasPrefix(line, "ENHANCEMENTS"):
+		return sectionTypeEnhancements
+	case strings.HasPrefix(line, "BUG FIXES"):
+		return sectionTypeBugs
+	default:
+		return sectionTypeUnknown
+	}
+}
+
+func addChangelogEntry(changeLog *changelog, st sectionType, line string) {
+	if line == "" {
+		return
+	}
+
+	switch st {
+	case sectionTypeBreakingChanges:
+		changeLog.breaking = append(changeLog.breaking, line)
+	case sectionTypeFeatures:
+		switch {
+		case strings.Contains(line, "Action"):
+			changeLog.features.actions = append(changeLog.features.actions, line)
+		case strings.Contains(line, "Data Source"):
+			changeLog.features.dataSources = append(changeLog.features.dataSources, line)
+		case strings.Contains(line, "List Resource"):
+			changeLog.features.listResources = append(changeLog.features.listResources, line)
+		default:
+			changeLog.features.general = append(changeLog.features.general, line)
+		}
+	case sectionTypeEnhancements:
+		switch {
+		case strings.Contains(line, "provider:"):
+			changeLog.enhancements.provider = append(changeLog.enhancements.provider, line)
+		case strings.Contains(line, "dependencies"):
+			changeLog.enhancements.dependencies = append(changeLog.enhancements.dependencies, line)
+		case strings.Contains(line, "Data Source"):
+			changeLog.enhancements.dataSources = append(changeLog.enhancements.dataSources, line)
+		default:
+			changeLog.enhancements.general = append(changeLog.enhancements.general, line)
+		}
+	case sectionTypeBugs:
+		switch {
+		case strings.Contains(line, "provider:"):
+			changeLog.bugs.provider = append(changeLog.bugs.provider, line)
+		case strings.Contains(line, "Data Source"):
+			changeLog.bugs.dataSources = append(changeLog.bugs.dataSources, line)
+		default:
+			changeLog.bugs.general = append(changeLog.bugs.general, line)
+		}
+	default:
+		return
+	}
+}
+
+// formatSection ensures that a changelog section is formatted as expected.
+// The empty strings ensure there is always a newline after the heading and the last changelog entry, the entries are inserted between them.
+func formatSection(entries []string, st sectionType) []string {
+	result := []string{
+		string(st),
+		"",
+		"",
+	}
+	return slices.Insert(result, 2, entries...)
+}
+
+func rebuildChangelog(changeLog *changelog) []string {
+	newContent := make([]string, 0)
+	newContent = append(newContent, changeLog.pre...)
+
+	sort := func(s []string) {
+		slices.SortFunc(s, func(a, b string) int {
+			resourceName := func(s string) string {
+				start := strings.Index(s, "`")
+				if start == -1 {
+					return s
+				}
+
+				end := strings.Index(s[start+1:], "`")
+				if end == -1 {
+					return s[start+1:]
+				}
+
+				return s[start+1 : start+1+end]
+			}
+
+			return strings.Compare(resourceName(a), resourceName(b))
+		})
+	}
+
+	if len(changeLog.breaking) > 0 {
+		fmt.Println("changelog contains breaking changes, please sort the entries manually")
+		newContent = append(newContent, formatSection(changeLog.breaking, sectionTypeBreakingChanges)...)
+	}
+
+	// Features
+	tmpContent := make([]string, 0)
+	if len(changeLog.features.actions) > 0 {
+		sort(changeLog.features.actions)
+		tmpContent = append(tmpContent, changeLog.features.actions...)
+	}
+
+	if len(changeLog.features.dataSources) > 0 {
+		sort(changeLog.features.dataSources)
+		tmpContent = append(tmpContent, changeLog.features.dataSources...)
+	}
+
+	if len(changeLog.features.listResources) > 0 {
+		sort(changeLog.features.listResources)
+		tmpContent = append(tmpContent, changeLog.features.listResources...)
+	}
+
+	if len(changeLog.features.general) > 0 {
+		sort(changeLog.features.general)
+		tmpContent = append(tmpContent, changeLog.features.general...)
+	}
+
+	if len(tmpContent) > 0 {
+		newContent = append(newContent, formatSection(tmpContent, sectionTypeFeatures)...)
+	}
+
+	// Enhancements
+	tmpContent = make([]string, 0)
+	if len(changeLog.enhancements.provider) > 0 {
+		sort(changeLog.enhancements.provider)
+		tmpContent = append(tmpContent, changeLog.enhancements.provider...)
+	}
+
+	if len(changeLog.enhancements.dependencies) > 0 {
+		sort(changeLog.enhancements.dependencies)
+		tmpContent = append(tmpContent, changeLog.enhancements.dependencies...)
+	}
+
+	if len(changeLog.enhancements.dataSources) > 0 {
+		sort(changeLog.enhancements.dataSources)
+		tmpContent = append(tmpContent, changeLog.enhancements.dataSources...)
+	}
+
+	if len(changeLog.enhancements.general) > 0 {
+		sort(changeLog.enhancements.general)
+		tmpContent = append(tmpContent, changeLog.enhancements.general...)
+	}
+
+	if len(tmpContent) > 0 {
+		newContent = append(newContent, formatSection(tmpContent, sectionTypeEnhancements)...)
+	}
+
+	// Bugs
+	tmpContent = make([]string, 0)
+	if len(changeLog.bugs.provider) > 0 {
+		sort(changeLog.bugs.provider)
+		tmpContent = append(tmpContent, changeLog.bugs.provider...)
+	}
+
+	if len(changeLog.bugs.dataSources) > 0 {
+		sort(changeLog.bugs.dataSources)
+		tmpContent = append(tmpContent, changeLog.bugs.dataSources...)
+	}
+
+	if len(changeLog.bugs.general) > 0 {
+		sort(changeLog.bugs.general)
+		tmpContent = append(tmpContent, changeLog.bugs.general...)
+	}
+
+	if len(tmpContent) > 0 {
+		newContent = append(newContent, formatSection(tmpContent, sectionTypeBugs)...)
+	}
+
+	return append(newContent, changeLog.post...)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run main.go <path to changelog>")
+		return
+	}
+	filePath := os.Args[1]
+
+	if err := formatChangelog(filePath); err != nil {
+		fmt.Println(fmt.Errorf("formatting changelog: %+v", err))
+		return
+	}
+}

--- a/scripts/release-update-changelog.sh
+++ b/scripts/release-update-changelog.sh
@@ -20,6 +20,12 @@ if [[ ! -f CHANGELOG.md ]]; then
   exit 2
 fi
 
+echo "Formatting changelog..."
+(
+  set -x
+  go run internal/tools/changelog-formatter/main.go CHANGELOG.md
+)
+
 # Get the next release
 RELEASE="$($SED -n 's/^## v?([0-9.]+) \(Unreleased\)/\1/p' CHANGELOG.md)"
 if [[ "${RELEASE}" == "" ]]; then
@@ -34,3 +40,6 @@ fi
 ( set -x; ${debug}$SED -i.bak "s/^(## v?[0-9.]+) \(Unreleased\)/\1 (${DATE})/i" CHANGELOG.md )
 
 ${debug}rm CHANGELOG.md.bak
+
+# Update the version file with this new version
+printf "%s" "${RELEASE}" > version/VERSION


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds some small helpers to the release script (mirroring AzureRM):
- auto update the new version in `version/VERSION`
- reformat changelog for consistency

## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
