### PR TITLE
`azuread_access_package_resource_package_association` - support `AadApplication` and `SharePointOnline` resources

### DIFF
--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -16,6 +16,8 @@ When authenticated with a user principal, this resource requires one of the foll
 
 ## Example Usage
 
+### Group resource (`AadGroup`)
+
 ```terraform
 resource "azuread_group" "example" {
   display_name     = "example-group"
@@ -28,34 +30,88 @@ resource "azuread_access_package_catalog" "example" {
 }
 
 resource "azuread_access_package_resource_catalog_association" "example" {
-  catalog_id             = azuread_access_package_catalog.example_catalog.id
-  resource_origin_id     = azuread_group.example_group.object_id
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_group.example.object_id
   resource_origin_system = "AadGroup"
 }
 
 resource "azuread_access_package" "example" {
   display_name = "example-package"
   description  = "Example Package"
-  catalog_id   = azuread_access_package_catalog.example_catalog.id
+  catalog_id   = azuread_access_package_catalog.example.id
 }
 
 resource "azuread_access_package_resource_package_association" "example" {
   access_package_id               = azuread_access_package.example.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_type                     = "Member"
+}
+```
+
+### Application resource (`AadApplication`)
+
+For an application resource, `access_type` is one of the application's app role IDs (a UUID). This example reuses the `azuread_access_package_catalog.example` and `azuread_access_package.example` resources from above.
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example-app"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Example role"
+    display_name         = "ExampleRole"
+    enabled              = true
+    id                   = "00000000-0000-0000-0000-000000000001"
+    value                = "Example.Role"
+  }
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_access_package_resource_catalog_association" "example_app" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_service_principal.example.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package_resource_package_association" "example_app" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example_app.id
+  access_type                     = azuread_application.example.app_role_ids["Example.Role"]
+}
+```
+
+### SharePoint Online site resource (`SharePointOnline`)
+
+For a SharePoint site resource, `resource_origin_id` is the site URL and `access_type` is the site role's origin ID (a numeric site-group ID, e.g. `5` for the site's Members group).
+
+```terraform
+resource "azuread_access_package_resource_catalog_association" "example_sharepoint" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = "https://contoso.sharepoint.com/sites/ExampleSite"
+  resource_origin_system = "SharePointOnline"
+}
+
+resource "azuread_access_package_resource_package_association" "example_sharepoint" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example_sharepoint.id
+  access_type                     = "5"
 }
 ```
 
 ## Argument Reference
 
 * `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
+* `access_type` - (Optional) The role of access type to the specified resource. The accepted value depends on the resource's origin system: for `AadGroup` resources, `Member` or `Owner`; for `AadApplication` resources, the app role UUID; for `SharePointOnline` resources, the role's origin ID (a numeric site-group ID, e.g. `5`). The default is `Member`. Changing this forces a new resource to be created.
 * `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
+* `id` - The ID of this resource, unique to Terraform. For `AadGroup` resources it is composed of four `/`-separated fields `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}`. For `AadApplication` and `SharePointOnline` resources, whose origin ID or access type may itself contain `/` (e.g. a SharePoint site URL), it is the two-field form `{AccessPackageID}/{ResourceRoleScope}`, with the remaining values recovered from the API.
 
 ## Timeouts
 
@@ -67,10 +123,10 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-The resource and catalog association can be imported using the access package ID, the access package ResourceRoleScope, the resource origin ID, and the access type, e.g.
+The resource can be imported using the access package ID and the access package ResourceRoleScope, e.g.
 
 ```
-terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222/33333333-3333-3333-3333-33333333/Member
+terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-222222222222
 ```
 
--> This ID format is unique to Terraform and is composed of the Access Package ID, the access package ResourceRoleScope (in the format Role_Scope), the Resource Origin ID, and the Access Type, in the format `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}`.
+-> This two-field ID format, `{AccessPackageID}/{ResourceRoleScope}` (the ResourceRoleScope being in the form `Role_Scope`), is unique to Terraform and works for all resource types. For backwards compatibility, the legacy four-field form `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}` used by `AadGroup` resources is also accepted on import.

--- a/docs/resources/access_package_resource_package_association.md
+++ b/docs/resources/access_package_resource_package_association.md
@@ -16,6 +16,8 @@ When authenticated with a user principal, this resource requires one of the foll
 
 ## Example Usage
 
+### Group resource (`AadGroup`)
+
 ```terraform
 resource "azuread_group" "example" {
   display_name     = "example-group"
@@ -28,34 +30,92 @@ resource "azuread_access_package_catalog" "example" {
 }
 
 resource "azuread_access_package_resource_catalog_association" "example" {
-  catalog_id             = azuread_access_package_catalog.example_catalog.id
-  resource_origin_id     = azuread_group.example_group.object_id
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_group.example.object_id
   resource_origin_system = "AadGroup"
 }
 
 resource "azuread_access_package" "example" {
   display_name = "example-package"
   description  = "Example Package"
-  catalog_id   = azuread_access_package_catalog.example_catalog.id
+  catalog_id   = azuread_access_package_catalog.example.id
 }
 
 resource "azuread_access_package_resource_package_association" "example" {
   access_package_id               = azuread_access_package.example.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.example.id
+  access_type                     = "Member"
+}
+```
+
+### Application resource (`AadApplication`)
+
+For an application resource, `access_type` is one of the application's app role IDs (a UUID). This example reuses the `azuread_access_package_catalog.example` and `azuread_access_package.example` resources from above.
+
+```terraform
+resource "azuread_application" "example" {
+  display_name = "example-app"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Example role"
+    display_name         = "ExampleRole"
+    enabled              = true
+    id                   = "00000000-0000-0000-0000-000000000001"
+    value                = "Example.Role"
+  }
+}
+
+resource "azuread_service_principal" "example" {
+  client_id = azuread_application.example.client_id
+}
+
+resource "azuread_access_package_resource_catalog_association" "example_app" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = azuread_service_principal.example.object_id
+  resource_origin_system = "AadApplication"
+}
+
+resource "azuread_access_package_resource_package_association" "example_app" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example_app.id
+  access_type                     = azuread_application.example.app_role_ids["Example.Role"]
+}
+```
+
+### SharePoint Online site resource (`SharePointOnline`)
+
+For a SharePoint site resource, `resource_origin_id` is the site URL and `access_type` is the site role's origin ID (a numeric site-group ID, e.g. `5` for the site's Members group).
+
+```terraform
+resource "azuread_access_package_resource_catalog_association" "example_sharepoint" {
+  catalog_id             = azuread_access_package_catalog.example.id
+  resource_origin_id     = "https://contoso.sharepoint.com/sites/ExampleSite"
+  resource_origin_system = "SharePointOnline"
+}
+
+resource "azuread_access_package_resource_package_association" "example_sharepoint" {
+  access_package_id               = azuread_access_package.example.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.example_sharepoint.id
+  access_type                     = "5"
 }
 ```
 
 ## Argument Reference
 
 * `access_package_id` - (Required) The ID of access package this resource association is configured to. Changing this forces a new resource to be created.
-* `access_type` - (Optional) The role of access type to the specified resource. Valid values are `Member`, or `Owner` The default is `Member`. Changing this forces a new resource to be created.
+* `access_type` - (Optional) The name or origin ID of the resource role to attach. The origin ID format depends on the resource's origin system: for `AadGroup` resources, `Member` or `Owner`; for `AadApplication` resources, the app role UUID; for `SharePointOnline` resources, the sequence number of the role in the site (e.g. `5`). The default is `Member`. Changing this forces a new resource to be created.
+
+-> The value is matched against the roles that Microsoft Graph reports for the resource, by either origin ID or display name, so any role the resource exposes can be named here. If no role matches, the error lists the roles available on that resource.
+
+-> The roles Microsoft Graph reports for a catalog resource may not immediately include every role of the underlying application or site. Where an expected role is missing, refreshing the resource in the catalog makes it available.
 * `catalog_resource_association_id` - (Required) The ID of the catalog association from the `azuread_access_package_resource_catalog_association` resource. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of this resource. The ID is combined by four fields with colon in between, the four fields are `access_package_id`, this package association id, `resource_origin_id` and `access_type`.
+* `id` - The ID of this resource, unique to Terraform. For `AadGroup` resources it is composed of four `/`-separated fields `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}`. For `AadApplication` and `SharePointOnline` resources, whose origin ID or access type may itself contain `/` (e.g. a SharePoint site URL), it is the two-field form `{AccessPackageID}/{ResourceRoleScope}`, with the remaining values recovered from the API.
 
 ## Timeouts
 
@@ -67,10 +127,10 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-The resource and catalog association can be imported using the access package ID, the access package ResourceRoleScope, the resource origin ID, and the access type, e.g.
+The resource can be imported using the access package ID and the access package ResourceRoleScope, e.g.
 
 ```
-terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-22222222/33333333-3333-3333-3333-33333333/Member
+terraform import azuread_access_package_resource_package_association.example 00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111_22222222-2222-2222-2222-222222222222
 ```
 
--> This ID format is unique to Terraform and is composed of the Access Package ID, the access package ResourceRoleScope (in the format Role_Scope), the Resource Origin ID, and the Access Type, in the format `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}`.
+-> This two-field ID format, `{AccessPackageID}/{ResourceRoleScope}` (the ResourceRoleScope being in the form `Role_Scope`), is unique to Terraform and works for all resource types. For backwards compatibility, the legacy four-field form `{AccessPackageID}/{ResourceRoleScope}/{ResourceOriginID}/{AccessType}` used by `AadGroup` resources is also accepted on import.

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -176,5 +176,9 @@ func (td TestData) externalProviders() map[string]resource.ExternalProvider {
 			VersionConstraint: "=3.6.2",
 			Source:            "registry.terraform.io/hashicorp/random",
 		},
+		"time": {
+			VersionConstraint: "=0.12.1",
+			Source:            "registry.terraform.io/hashicorp/time",
+		},
 	}
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -57,15 +57,17 @@ func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 			},
 
 			"access_type": {
-				Description: "The role of access type to the specified resource, valid values are `Member` and `Owner`",
-				Type:        pluginsdk.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "Member",
-				ValidateFunc: validation.StringInSlice([]string{
-					"Member",
-					"Owner",
-				}, false),
+				// The accepted value is the resource role's originId, whose format depends on the
+				// resource's origin system: `Member`/`Owner` for `AadGroup`, the app role id for
+				// `AadApplication`, and a SharePoint role id (e.g. a numeric group id or a URL) for
+				// `SharePointOnline`. The origin system isn't known until apply, so we only validate
+				// that a value is present and let the Graph API reject genuinely invalid roles.
+				Description:  "The resource role originId to attach. For `AadGroup` use `Member` or `Owner`; for `AadApplication` the app role id; for `SharePointOnline` the site role id.",
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "Member",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}
@@ -99,24 +101,44 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 
 	resource := pointer.To((*resourceResp.Model)[0])
 
-	properties := beta.AccessPackageResourceRoleScope{
-		AccessPackageResourceRole: &beta.AccessPackageResourceRole{
-			DisplayName:  nullable.NoZero(accessType),
-			OriginId:     nullable.Value(fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId)),
-			OriginSystem: resource.OriginSystem,
-			AccessPackageResource: &beta.AccessPackageResource{
-				Id:           resource.Id,
-				ResourceType: resource.ResourceType,
-				OriginId:     resource.OriginId,
-			},
-		},
-		AccessPackageResourceScope: &beta.AccessPackageResourceScope{
-			OriginSystem: resource.OriginSystem,
-			OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
+	createMsg := "Creating Access Package Resource Association from resource %q@%q to access package %q"
+
+	role := beta.AccessPackageResourceRole{
+		OriginId:     nullable.Value(accessType),
+		OriginSystem: resource.OriginSystem,
+		AccessPackageResource: &beta.AccessPackageResource{
+			Id:           resource.Id,
+			ResourceType: resource.ResourceType,
+			OriginId:     resource.OriginId,
 		},
 	}
 
-	createMsg := `Creating Access Package Resource Association from resource %q@%q to access package %q`
+	scope := beta.AccessPackageResourceScope{
+		OriginSystem: resource.OriginSystem,
+		OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
+	}
+
+	switch resource.OriginSystem.GetOrZero() {
+	case "AadGroup":
+		// The role is one of the fixed Member/Owner roles, addressed as
+		// "<accessType>_<resourceOriginId>"; the access_type doubles as the display name.
+		role.OriginId = nullable.Value(fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId))
+		role.DisplayName = nullable.Value(accessType)
+	case "SharePointOnline":
+		// SharePoint resources expose a single root scope; the role's display name is derived
+		// by the service from its originId, so it is left unset.
+		scope.IsRootScope = nullable.Value(true)
+		scope.DisplayName = nullable.Value("Root")
+		scope.Description = nullable.Value("Root Scope")
+	default:
+		// AadApplication and any other origin system: access_type is the role originId
+		// verbatim; the display name is derived by the service.
+	}
+
+	properties := beta.AccessPackageResourceRoleScope{
+		AccessPackageResourceRole:  &role,
+		AccessPackageResourceScope: &scope,
+	}
 
 	resp, err := client.CreateEntitlementManagementAccessPackageResourceRoleScope(ctx, accessPackageId, properties, entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultCreateEntitlementManagementAccessPackageResourceRoleScopeOperationOptions())
 	if err != nil {
@@ -131,7 +153,16 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 		return tf.ErrorDiagF(errors.New("model has nil ID"), createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
 	}
 
-	resourceId := parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	// For AadGroup the originId/accessType are "/"-free and kept in the legacy 4-segment ID.
+	// For AadApplication (UUID) and especially SharePointOnline (role URL) they may contain
+	// "/", so they're omitted from the ID and recovered from the API on read.
+	var resourceId parse.AccessPackageResourcePackageAssociationId
+	switch resource.OriginSystem.GetOrZero() {
+	case "AadGroup":
+		resourceId = parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	default:
+		resourceId = parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, "", "")
+	}
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageIdAccessPackageResourceRoleScopeID(resourceId.AccessPackageId, resourceId.ResourceRoleScopeId)
 
 	// Poll for AccessPackageResourceRoleScope
@@ -183,10 +214,24 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 		return tf.ErrorDiagF(errors.New("model was nil"), "Retrieving %s", accessPackageId)
 	}
 
-	catalogResourceAssociationId := parse.NewAccessPackageResourceCatalogAssociationID(accessPackage.CatalogId.GetOrZero(), resourceId.OriginId)
+	// Legacy 4-segment IDs carry originId/accessType directly. The 2-segment ID (used for
+	// AadApplication/SharePointOnline, whose role identifiers may contain "/") leaves them
+	// empty, so recover them from the role scope returned by the API.
+	accessType := resourceId.AccessType
+	resourceOriginId := resourceId.OriginId
+	if accessType == "" {
+		if roleScope.AccessPackageResourceRole != nil {
+			accessType = roleScope.AccessPackageResourceRole.OriginId.GetOrZero()
+		}
+		if roleScope.AccessPackageResourceScope != nil {
+			resourceOriginId = roleScope.AccessPackageResourceScope.OriginId.GetOrZero()
+		}
+	}
+
+	catalogResourceAssociationId := parse.NewAccessPackageResourceCatalogAssociationID(accessPackage.CatalogId.GetOrZero(), resourceOriginId)
 
 	tf.Set(d, "access_package_id", resourceId.AccessPackageId)
-	tf.Set(d, "access_type", resourceId.AccessType)
+	tf.Set(d, "access_type", accessType)
 	tf.Set(d, "catalog_resource_association_id", catalogResourceAssociationId.ID())
 
 	return nil

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -8,14 +8,19 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackage"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackageaccesspackageresourcerolescope"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackagecatalogaccesspackageresource"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/consistency"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf"
@@ -24,6 +29,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/parse"
 	"github.com/hashicorp/terraform-provider-azuread/internal/services/identitygovernance/validate"
 )
+
+const accessPackageResourcePackageAssociationResourceName = "azuread_access_package_resource_package_association"
 
 func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -57,22 +64,23 @@ func accessPackageResourcePackageAssociationResource() *pluginsdk.Resource {
 			},
 
 			"access_type": {
-				Description: "The role of access type to the specified resource, valid values are `Member` and `Owner`",
-				Type:        pluginsdk.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "Member",
-				ValidateFunc: validation.StringInSlice([]string{
-					"Member",
-					"Owner",
-				}, false),
+				// This is the resource role's originId or display name. The originId format is decided
+				// by the resource's origin system, which isn't known until the catalog resource is
+				// read during apply, so the value is matched against the roles the service reports
+				// for that resource rather than validated against a fixed list.
+				Description:  "The name or originId of the resource role to attach. For `AadGroup` resources this is `Member` or `Owner`, for `AadApplication` resources an app role ID, and for `SharePointOnline` resources the sequence number of the role in the site",
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "Member",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}
 }
 
 func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
-	client := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRoleScopeClient
+	resourceRoleScopeClient := meta.(*clients.Client).IdentityGovernance.AccessPackageResourceRoleScopeClient
 	accessPackageClient := meta.(*clients.Client).IdentityGovernance.AccessPackageClient
 	resourceClient := meta.(*clients.Client).IdentityGovernance.AccessPackageCatalogResourceClient
 
@@ -83,6 +91,9 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 
 	accessType := d.Get("access_type").(string)
 	accessPackageId := beta.NewIdentityGovernanceEntitlementManagementAccessPackageID(d.Get("access_package_id").(string))
+
+	tf.LockByName(accessPackageResourcePackageAssociationResourceName, catalogResourceAssociationId.ID())
+	defer tf.UnlockByName(accessPackageResourcePackageAssociationResourceName, catalogResourceAssociationId.ID())
 
 	catalogId := beta.NewIdentityGovernanceEntitlementManagementAccessPackageCatalogID(catalogResourceAssociationId.CatalogId)
 	options := entitlementmanagementaccesspackagecatalogaccesspackageresource.ListEntitlementManagementAccessPackageCatalogResourcesOperationOptions{
@@ -99,26 +110,42 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 
 	resource := pointer.To((*resourceResp.Model)[0])
 
-	properties := beta.AccessPackageResourceRoleScope{
-		AccessPackageResourceRole: &beta.AccessPackageResourceRole{
-			DisplayName:  nullable.NoZero(accessType),
-			OriginId:     nullable.Value(fmt.Sprintf("%s_%s", accessType, catalogResourceAssociationId.OriginId)),
-			OriginSystem: resource.OriginSystem,
-			AccessPackageResource: &beta.AccessPackageResource{
-				Id:           resource.Id,
-				ResourceType: resource.ResourceType,
-				OriginId:     resource.OriginId,
-			},
-		},
-		AccessPackageResourceScope: &beta.AccessPackageResourceScope{
-			OriginSystem: resource.OriginSystem,
-			OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
-		},
+	roles, err := listAccessPackageCatalogResourceRoles(ctx, resourceClient, catalogId, resource)
+	if err != nil {
+		log.Printf("[DEBUG] Roles for resource %q in %s could not be retrieved: %v", catalogResourceAssociationId.OriginId, catalogId, err)
+	} else {
+		resource.AccessPackageResourceRoles = roles
 	}
 
-	createMsg := `Creating Access Package Resource Association from resource %q@%q to access package %q`
+	createMsg := "Creating Access Package Resource Association from resource %q@%q to access package %q"
 
-	resp, err := client.CreateEntitlementManagementAccessPackageResourceRoleScope(ctx, accessPackageId, properties, entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultCreateEntitlementManagementAccessPackageResourceRoleScopeOperationOptions())
+	role, err := expandAccessPackageResourceRole(resource, accessType, catalogResourceAssociationId.OriginId)
+	if err != nil {
+		return tf.ErrorDiagPathF(err, "access_type", "Resolving access_type %q for %s", accessType, catalogId)
+	}
+
+	scope := beta.AccessPackageResourceScope{
+		OriginSystem: resource.OriginSystem,
+		OriginId:     nullable.Value(catalogResourceAssociationId.OriginId),
+	}
+
+	if resource.OriginSystem.GetOrZero() == "SharePointOnline" {
+		scope.IsRootScope = nullable.Value(true)
+		scope.DisplayName = nullable.Value("Root")
+		scope.Description = nullable.Value("Root Scope")
+	}
+
+	properties := beta.AccessPackageResourceRoleScope{
+		AccessPackageResourceRole:  role,
+		AccessPackageResourceScope: &scope,
+	}
+
+	createOptions := entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultCreateEntitlementManagementAccessPackageResourceRoleScopeOperationOptions()
+	createOptions.RetryFunc = func(resp *http.Response, o *odata.OData) (bool, error) {
+		return response.WasNotFound(resp) && o != nil && o.Error != nil && o.Error.Match("RoleNotFound"), nil
+	}
+
+	resp, err := resourceRoleScopeClient.CreateEntitlementManagementAccessPackageResourceRoleScope(ctx, accessPackageId, properties, createOptions)
 	if err != nil {
 		return tf.ErrorDiagF(err, createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
 	}
@@ -131,7 +158,16 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 		return tf.ErrorDiagF(errors.New("model has nil ID"), createMsg, catalogResourceAssociationId.OriginId, resource.OriginSystem.GetOrZero(), accessPackageId)
 	}
 
-	resourceId := parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	// For AadGroup the originId/accessType are "/"-free and kept in the legacy 4-segment ID.
+	// For every other origin system either may contain "/" (a SharePoint site is identified by
+	// its URL), so they're omitted from the ID and recovered from the API on read.
+	var resourceId parse.AccessPackageResourcePackageAssociationId
+	switch resource.OriginSystem.GetOrZero() {
+	case "AadGroup":
+		resourceId = parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, catalogResourceAssociationId.OriginId, accessType)
+	default:
+		resourceId = parse.NewAccessPackageResourcePackageAssociationID(accessPackageId.AccessPackageId, *resourceRoleScope.Id, "", "")
+	}
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageIdAccessPackageResourceRoleScopeID(resourceId.AccessPackageId, resourceId.ResourceRoleScopeId)
 
 	// Poll for AccessPackageResourceRoleScope
@@ -148,6 +184,149 @@ func accessPackageResourcePackageAssociationResourceCreate(ctx context.Context, 
 	d.SetId(resourceId.ID())
 
 	return accessPackageResourcePackageAssociationResourceRead(ctx, d, meta)
+}
+
+// listAccessPackageCatalogResourceRoles queries the catalog-level accessPackageResourceRoles collection
+// and returns the roles associated with the given resource. There is no generated SDK method for this
+// collection, so the request is built directly.
+func listAccessPackageCatalogResourceRoles(ctx context.Context, resourceClient *entitlementmanagementaccesspackagecatalogaccesspackageresource.EntitlementManagementAccessPackageCatalogAccessPackageResourceClient, catalogId beta.IdentityGovernanceEntitlementManagementAccessPackageCatalogId, resource *beta.AccessPackageResource) (*[]beta.AccessPackageResourceRole, error) {
+	if resource.OriginSystem.GetOrZero() == "" || resource.Id == nil {
+		return nil, errors.New("resource has no origin system or ID")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: listAccessPackageCatalogResourceRolesOperationOptions{
+			query: odata.Query{
+				Filter: fmt.Sprintf("originSystem eq '%s' and accessPackageResource/id eq '%s'", resource.OriginSystem.GetOrZero(), pointer.From(resource.Id)),
+				Expand: odata.Expand{Relationship: "accessPackageResource"},
+			},
+		},
+		Pager: &listAccessPackageCatalogResourceRolesCustomPager{},
+		Path:  fmt.Sprintf("%s/accessPackageResourceRoles", catalogId.ID()),
+	}
+
+	req, err := resourceClient.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %+v", err)
+	}
+
+	resp, err := req.ExecutePaged(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %+v", err)
+	}
+
+	var values struct {
+		Values *[]beta.AccessPackageResourceRole `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return nil, fmt.Errorf("unmarshalling response: %+v", err)
+	}
+
+	if values.Values == nil {
+		return nil, nil
+	}
+
+	roles := make([]beta.AccessPackageResourceRole, 0)
+	for _, role := range *values.Values {
+		if role.AccessPackageResource != nil && role.AccessPackageResource.Id != nil && pointer.From(role.AccessPackageResource.Id) == pointer.From(resource.Id) {
+			roles = append(roles, role)
+		}
+	}
+
+	return &roles, nil
+}
+
+type listAccessPackageCatalogResourceRolesOperationOptions struct {
+	query odata.Query
+}
+
+func (o listAccessPackageCatalogResourceRolesOperationOptions) ToHeaders() *client.Headers {
+	return &client.Headers{}
+}
+
+func (o listAccessPackageCatalogResourceRolesOperationOptions) ToOData() *odata.Query {
+	return &o.query
+}
+
+func (o listAccessPackageCatalogResourceRolesOperationOptions) ToQuery() *client.QueryParams {
+	return &client.QueryParams{}
+}
+
+type listAccessPackageCatalogResourceRolesCustomPager struct {
+	NextLink *odata.Link `json:"@odata.nextLink"`
+}
+
+func (p *listAccessPackageCatalogResourceRolesCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// expandAccessPackageResourceRole resolves accessType to one of the roles of a catalog
+// resource. A role is identified by its originId, the format of which is decided by the
+// origin system of the resource it belongs to: "<roleName>_<groupId>" for AadGroup, the app
+// role ID for AadApplication, and the sequence number of the role in the site for
+// SharePointOnline. Rather than construct that, the roles reported for the resource are
+// matched on either their originId or the display name they are shown under, so that any
+// role the service exposes can be named.
+//
+// The reported roles may not cover every role of the underlying application or site the
+// service keeps its own view of a catalog resource, which is why it offers a separate
+// refresh operation but a role it doesn't report can't be attached either, so matching
+// against them turns what would be a bare "RoleNotFound" into an error naming the roles
+// that are available.
+//
+// Should the service report no roles at all for the resource, the originId is constructed
+// as it was before the roles were expanded, and the service validates it.
+func expandAccessPackageResourceRole(resource *beta.AccessPackageResource, accessType, resourceOriginId string) (*beta.AccessPackageResourceRole, error) {
+	role := beta.AccessPackageResourceRole{
+		OriginId:     nullable.Value(accessType),
+		OriginSystem: resource.OriginSystem,
+		AccessPackageResource: &beta.AccessPackageResource{
+			Id:           resource.Id,
+			ResourceType: resource.ResourceType,
+			OriginId:     resource.OriginId,
+		},
+	}
+
+	if resource.AccessPackageResourceRoles == nil || len(*resource.AccessPackageResourceRoles) == 0 {
+		if resource.OriginSystem.GetOrZero() == "AadGroup" {
+			role.OriginId = nullable.Value(fmt.Sprintf("%s_%s", accessType, resourceOriginId))
+			role.DisplayName = nullable.Value(accessType)
+		}
+
+		return &role, nil
+	}
+
+	names := make([]string, 0, len(*resource.AccessPackageResourceRoles))
+
+	for _, resourceRole := range *resource.AccessPackageResourceRoles {
+		originId := resourceRole.OriginId.GetOrZero()
+		displayName := resourceRole.DisplayName.GetOrZero()
+
+		if accessType == originId || accessType == displayName {
+			role.OriginId = resourceRole.OriginId
+			role.DisplayName = resourceRole.DisplayName
+
+			return &role, nil
+		}
+
+		if displayName != "" && displayName != originId {
+			names = append(names, fmt.Sprintf("%q (%s)", originId, displayName))
+			continue
+		}
+
+		names = append(names, fmt.Sprintf("%q", originId))
+	}
+
+	return nil, fmt.Errorf("resource %q has no role matching %q, the roles of this resource are: %s", resourceOriginId, accessType, strings.Join(names, ", "))
 }
 
 func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
@@ -183,10 +362,30 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 		return tf.ErrorDiagF(errors.New("model was nil"), "Retrieving %s", accessPackageId)
 	}
 
-	catalogResourceAssociationId := parse.NewAccessPackageResourceCatalogAssociationID(accessPackage.CatalogId.GetOrZero(), resourceId.OriginId)
+	// Legacy 4-segment IDs carry originId/accessType directly. The 2-segment ID (used for
+	// AadApplication/SharePointOnline, whose role identifiers may contain "/") leaves them
+	// empty, so recover them from the role scope returned by the API.
+	accessType := resourceId.AccessType
+	resourceOriginId := resourceId.OriginId
+	if accessType == "" {
+		if roleScope.AccessPackageResourceRole != nil {
+			accessType = roleScope.AccessPackageResourceRole.OriginId.GetOrZero()
+
+			// A role can be named by either its originId or its display name, so where the
+			// configured value names this same role by its display name, keep it as-is.
+			if configured := d.Get("access_type").(string); configured != "" && configured == roleScope.AccessPackageResourceRole.DisplayName.GetOrZero() {
+				accessType = configured
+			}
+		}
+		if roleScope.AccessPackageResourceScope != nil {
+			resourceOriginId = roleScope.AccessPackageResourceScope.OriginId.GetOrZero()
+		}
+	}
+
+	catalogResourceAssociationId := parse.NewAccessPackageResourceCatalogAssociationID(accessPackage.CatalogId.GetOrZero(), resourceOriginId)
 
 	tf.Set(d, "access_package_id", resourceId.AccessPackageId)
-	tf.Set(d, "access_type", resourceId.AccessType)
+	tf.Set(d, "access_type", accessType)
 	tf.Set(d, "catalog_resource_association_id", catalogResourceAssociationId.ID())
 
 	return nil

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -6,6 +6,7 @@ package identitygovernance_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -30,6 +31,73 @@ func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Member"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeOwner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithAccessTypeOwner(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Owner"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithAccessTypeApplication(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// SharePointOnline resources can't be provisioned by the acceptance framework (they require a
+// pre-existing SharePoint site), so this test is skipped unless the environment supplies a site
+// URL and the role originId to attach. Set:
+//
+//	AZUREAD_TEST_SHAREPOINT_SITE_URL        e.g. https://contoso.sharepoint.com/sites/Example
+//	AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID  the role originId on that site (e.g. a numeric group id)
+//
+// It exercises the SharePoint-specific paths: non-Member/Owner access_type, a site-URL
+// catalog_resource_association_id, the 2-segment resource ID, and the root scope.
+func TestAccAccessPackageResourcePackageAssociation_completeWithSharePointSite(t *testing.T) {
+	siteURL := os.Getenv("AZUREAD_TEST_SHAREPOINT_SITE_URL")
+	roleOriginID := os.Getenv("AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID")
+	if siteURL == "" || roleOriginID == "" {
+		t.Skip("AZUREAD_TEST_SHAREPOINT_SITE_URL and AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID must be set for the SharePoint acceptance test")
+	}
+
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithSharePointSite(data, siteURL, roleOriginID),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue(roleOriginID),
 			),
 		},
 		data.ImportStep(),
@@ -83,6 +151,135 @@ resource "azuread_access_package" "test" {
 resource "azuread_access_package_resource_package_association" "test" {
   access_package_id               = azuread_access_package.test.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Member"
 }
 `, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "acctest-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Owner"
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeApplication(data acceptance.TestData) string {
+	// The application defines its own app role and that role's id is used as the
+	// access_type. This keeps the fixture self-contained: it doesn't read or update
+	// the well-known Microsoft Graph service principal (which needs privileges to
+	// patch a first-party SP), so it runs with Application.ReadWrite.All alone. It
+	// also mirrors reality: an AadApplication resource's roles are the application's
+	// own app roles. The role id is a fixed UUID reused as the access_type.
+	const appRoleId = "9f3c8e21-6b4d-4f2a-8d7c-1e5a9b0c3d4e"
+
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctest-packageAssociationResource-%[1]d"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Test role for access package resource association"
+    display_name         = "TestRole"
+    enabled              = true
+    id                   = "%[2]s"
+    value                = "Test.Role"
+  }
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+# Test-only: entitlement management can't find a service principal that was just
+# created until it has replicated. Real usage onboards a pre-existing application,
+# so this delay is an artifact of the test creating its own SP inline, not a
+# limitation of the resource.
+resource "time_sleep" "wait_for_sp" {
+  depends_on      = [azuread_service_principal.test]
+  create_duration = "60s"
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_service_principal.test.object_id
+  resource_origin_system = "AadApplication"
+
+  depends_on = [time_sleep.wait_for_sp]
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "%[2]s"
+}
+`, data.RandomInteger, appRoleId)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithSharePointSite(data acceptance.TestData, siteURL, roleOriginID string) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = %[2]q
+  resource_origin_system = "SharePointOnline"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = %[3]q
+}
+`, data.RandomInteger, siteURL, roleOriginID)
 }

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource_test.go
@@ -6,6 +6,7 @@ package identitygovernance_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -30,6 +31,86 @@ func TestAccAccessPackageResourcePackageAssociation_complete(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Member"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeOwner(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithAccessTypeOwner(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("Owner"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithAccessTypeApplication(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").IsUuid(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplicationRoleName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithAccessTypeApplicationRoleName(data),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue("TestRole"),
+			),
+		},
+		// An imported association has no configuration to compare against, so the role is read
+		// back under its originId rather than the display name the configuration named it by.
+		data.ImportStep("access_type"),
+	})
+}
+
+// A SharePoint site can't be provisioned by the acceptance tests, so this is skipped unless
+// AZUREAD_TEST_SHAREPOINT_SITE_URL and AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID name an existing
+// site and a role on it.
+func TestAccAccessPackageResourcePackageAssociation_completeWithSharePointSite(t *testing.T) {
+	siteURL := os.Getenv("AZUREAD_TEST_SHAREPOINT_SITE_URL")
+	roleOriginID := os.Getenv("AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID")
+	if siteURL == "" || roleOriginID == "" {
+		t.Skipf("Acceptance test skipped unless env 'AZUREAD_TEST_SHAREPOINT_SITE_URL' and 'AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID' set")
+	}
+
+	data := acceptance.BuildTestData(t, "azuread_access_package_resource_package_association", "test")
+	r := AccessPackageResourcePackageAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:  r.completeWithSharePointSite(data, siteURL, roleOriginID),
+			Destroy: false,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("access_type").HasValue(roleOriginID),
 			),
 		},
 		data.ImportStep(),
@@ -83,6 +164,193 @@ resource "azuread_access_package" "test" {
 resource "azuread_access_package_resource_package_association" "test" {
   access_package_id               = azuread_access_package.test.id
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Member"
 }
 `, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeOwner(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test_group" {
+  display_name     = "acctest-access-package-resource-catalog-association-%[1]d"
+  security_enabled = true
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_group.test_group.object_id
+  resource_origin_system = "AadGroup"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "Owner"
+}
+`, data.RandomInteger)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeApplication(data acceptance.TestData) string {
+	// The application defines its own app role and that role's id is used as the
+	// access_type. This keeps the fixture self-contained: it doesn't read or update
+	// the well-known Microsoft Graph service principal (which needs privileges to
+	// patch a first-party SP), so it runs with Application.ReadWrite.All alone. It
+	// also mirrors reality: an AadApplication resource's roles are the application's
+	// own app roles. The role id is a fixed UUID reused as the access_type.
+	const appRoleId = "9f3c8e21-6b4d-4f2a-8d7c-1e5a9b0c3d4e"
+
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctest-packageAssociationResource-%[1]d"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Test role for access package resource association"
+    display_name         = "TestRole"
+    enabled              = true
+    id                   = "%[2]s"
+    value                = "Test.Role"
+  }
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+# Test-only: entitlement management can't find a service principal that was just
+# created until it has replicated. Real usage onboards a pre-existing application,
+# so this delay is an artifact of the test creating its own SP inline, not a
+# limitation of the resource.
+resource "time_sleep" "wait_for_sp" {
+  depends_on      = [azuread_service_principal.test]
+  create_duration = "60s"
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_service_principal.test.object_id
+  resource_origin_system = "AadApplication"
+
+  depends_on = [time_sleep.wait_for_sp]
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "%[2]s"
+}
+`, data.RandomInteger, appRoleId)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithAccessTypeApplicationRoleName(data acceptance.TestData) string {
+	// The same app role as completeWithAccessTypeApplication, attached by the display name it is
+	// shown under instead of its ID.
+	const appRoleId = "9f3c8e21-6b4d-4f2a-8d7c-1e5a9b0c3d4e"
+
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctest-packageAssociationResource-%[1]d"
+
+  app_role {
+    allowed_member_types = ["User"]
+    description          = "Test role for access package resource association"
+    display_name         = "TestRole"
+    enabled              = true
+    id                   = "%[2]s"
+    value                = "Test.Role"
+  }
+}
+
+resource "azuread_service_principal" "test" {
+  client_id = azuread_application.test.client_id
+}
+
+# Entitlement management can't see a service principal until it has replicated.
+resource "time_sleep" "wait_for_sp" {
+  depends_on      = [azuread_service_principal.test]
+  create_duration = "60s"
+}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = azuread_service_principal.test.object_id
+  resource_origin_system = "AadApplication"
+
+  depends_on = [time_sleep.wait_for_sp]
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = "TestRole"
+}
+`, data.RandomInteger, appRoleId)
+}
+
+func (AccessPackageResourcePackageAssociationResource) completeWithSharePointSite(data acceptance.TestData, siteURL, roleOriginID string) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_access_package_catalog" "test_catalog" {
+  display_name = "acctest-catalog-%[1]d"
+  description  = "Test catalog %[1]d"
+}
+
+resource "azuread_access_package_resource_catalog_association" "test" {
+  catalog_id             = azuread_access_package_catalog.test_catalog.id
+  resource_origin_id     = %[2]q
+  resource_origin_system = "SharePointOnline"
+}
+
+resource "azuread_access_package" "test" {
+  display_name = "acctest-package-%[1]d"
+  description  = "Test Package %[1]d"
+  catalog_id   = azuread_access_package_catalog.test_catalog.id
+}
+
+resource "azuread_access_package_resource_package_association" "test" {
+  access_package_id               = azuread_access_package.test.id
+  catalog_resource_association_id = azuread_access_package_resource_catalog_association.test.id
+  access_type                     = %[3]q
+}
+`, data.RandomInteger, siteURL, roleOriginID)
 }

--- a/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_catalog_association_id.go
@@ -32,10 +32,14 @@ func AccessPackageResourceCatalogAssociationID(idString string) (*AccessPackageR
 		return nil, fmt.Errorf("ID should be in the format {catalogId}/{originId} - but got %q", idString)
 	}
 
-	for i, p := range parts {
-		if _, err := uuid.ParseUUID(p); err != nil {
-			return nil, fmt.Errorf("specified ID segment #%d (%q) is not a valid UUID: %s", i, p, err)
-		}
+	// Only the catalog id is a UUID. originId is the resource's origin identifier, whose format
+	// depends on the origin system (a UUID for AadGroup/AadApplication, but a site URL for
+	// SharePointOnline), so it is validated only as non-empty.
+	if _, err := uuid.ParseUUID(parts[0]); err != nil {
+		return nil, fmt.Errorf("specified ID segment #0 (%q) is not a valid UUID: %s", parts[0], err)
+	}
+	if parts[1] == "" {
+		return nil, fmt.Errorf("specified ID segment #1 (originId) must not be empty - got %q", idString)
 	}
 
 	return &AccessPackageResourceCatalogAssociationId{

--- a/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
+++ b/internal/services/identitygovernance/parse/access_package_resource_package_association_id.go
@@ -18,6 +18,13 @@ type AccessPackageResourcePackageAssociationId struct {
 }
 
 func (id AccessPackageResourcePackageAssociationId) ID() string {
+	// A role identified by a value containing "/" (e.g. a SharePointOnline role URL) cannot be
+	// encoded in the legacy 4-segment "/"-delimited ID. For those, originId/accessType are left
+	// empty and recovered from the API on read, so the ID is the 2-segment
+	// {accessPackageId}/{resourceRoleScopeId}.
+	if id.OriginId == "" && id.AccessType == "" {
+		return fmt.Sprintf("%s/%s", id.AccessPackageId, id.ResourceRoleScopeId)
+	}
 	return fmt.Sprintf("%s/%s/%s/%s", id.AccessPackageId, id.ResourceRoleScopeId, id.OriginId, id.AccessType)
 }
 
@@ -32,22 +39,38 @@ func NewAccessPackageResourcePackageAssociationID(catalogId, resourceRoleScopeId
 
 func AccessPackageResourcePackageAssociationID(idString string) (*AccessPackageResourcePackageAssociationId, error) {
 	parts := strings.Split(idString, "/")
-	if len(parts) != 4 {
-		return nil, fmt.Errorf("ID should be in the format {accessPackageId}/{resourcePackageAssociationId}/{originId}/{accessType} - but got %q", idString)
-	}
 
-	for i, p := range parts {
-		if i == 0 || i == 2 {
-			if _, err := uuid.ParseUUID(p); err != nil {
-				return nil, fmt.Errorf("specified ID segment #%d (%q) is not a valid UUID: %s", i, p, err)
+	switch len(parts) {
+	case 2:
+		// Current format: {accessPackageId}/{resourceRoleScopeId}. originId and accessType are
+		// recovered from the API on read, which supports role identifiers containing "/"
+		// (e.g. SharePointOnline role URLs).
+		if _, err := uuid.ParseUUID(parts[0]); err != nil {
+			return nil, fmt.Errorf("specified ID segment #0 (%q) is not a valid UUID: %s", parts[0], err)
+		}
+		return &AccessPackageResourcePackageAssociationId{
+			AccessPackageId:     parts[0],
+			ResourceRoleScopeId: parts[1],
+		}, nil
+
+	case 4:
+		// Legacy format: {accessPackageId}/{resourcePackageAssociationId}/{originId}/{accessType},
+		// still emitted for AadGroup associations whose segments never contain "/".
+		for i, p := range parts {
+			if i == 0 || i == 2 {
+				if _, err := uuid.ParseUUID(p); err != nil {
+					return nil, fmt.Errorf("specified ID segment #%d (%q) is not a valid UUID: %s", i, p, err)
+				}
 			}
 		}
-	}
+		return &AccessPackageResourcePackageAssociationId{
+			AccessPackageId:     parts[0],
+			ResourceRoleScopeId: parts[1],
+			OriginId:            parts[2],
+			AccessType:          parts[3],
+		}, nil
 
-	return &AccessPackageResourcePackageAssociationId{
-		AccessPackageId:     parts[0],
-		ResourceRoleScopeId: parts[1],
-		OriginId:            parts[2],
-		AccessType:          parts[3],
-	}, nil
+	default:
+		return nil, fmt.Errorf("ID should be {accessPackageId}/{resourceRoleScopeId} or the legacy {accessPackageId}/{resourcePackageAssociationId}/{originId}/{accessType} - but got %q", idString)
+	}
 }


### PR DESCRIPTION

## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

`azuread_access_package_resource_package_association` previously only supported `AadGroup` resources, where `access_type` is `Member` or `Owner`. This PR adds support for **`AadApplication`** (app role) and **`SharePointOnline`** (site role) resources, so the full set of catalog resource types can be attached to access packages natively.

It builds on and completes the closed #1782 (the original author invited reuse). That PR widened `access_type` validation but did not handle the resource ID encoding or the SharePoint root scope, so it only ever worked for application roles, not SharePoint.

Key changes:

- **`access_type` is resolved against the resource's actual roles.** The value is the resource role's `originId`, whose format is decided by the origin system (`Member`/`Owner` for `AadGroup`, the app role id for `AadApplication`, and per the [API docs](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageresourcerole) "the sequence number of the role in the site" for `SharePointOnline`). Rather than enumerate those formats in the provider, Create expands the roles from the catalog resource it already lists and matches `access_type` on either the role's `originId` or its display name; an unknown value fails with the roles that resource actually has. Schema validation stays `StringIsNotEmpty`, since the origin system isn't known until apply.
- **Create** branches by origin system: `AadGroup` keeps the existing `"<accessType>_<originId>"` role originId and `Member`/`Owner` display name; `SharePointOnline` sends a root scope (`isRootScope = true`) and lets the service derive the role display name; `AadApplication` uses the role id verbatim.
- **Resource ID**: `AadGroup` keeps the legacy 4-segment `{accessPackageId}/{resourceRoleScopeId}/{originId}/{accessType}` ID (no state change for existing resources). `AadApplication`/`SharePointOnline` use a 2-segment `{accessPackageId}/{resourceRoleScopeId}` ID because their `originId`/`access_type` can contain `/` (e.g. a SharePoint site URL); `Read` recovers those attributes from the API. The parser accepts both forms.
- **`catalog_resource_association_id` parser**: only the catalog id must be a UUID; the resource `originId` may be a site URL.
- **Acceptance test framework**: added the `time` provider to `externalProviders()` so the application test can wait for a newly-created service principal to replicate before onboarding it.
- Docs updated for `access_type`.

This is **non-breaking**: existing `AadGroup` configurations and state are unchanged `access_type` stays `Optional` (default `Member`), the AadGroup ID format is unchanged, and validation only widens.

**Why it also unblocks consumers:** today, modules that attach SharePoint (or app) roles to access packages can't use this resource and fall back to calling Graph directly (e.g. a `microsoft/msgraph` `msgraph_resource_action`). With this change the first-class resource covers all three origin systems, so those workarounds can be dropped in favour of true desired state.

**Microsoft Graph references** (the API contract this implements):
- [accessPackageResource](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageresource?view=graph-rest-1.0): the `originSystem` values (`AadGroup`, `AadApplication`, `SharePointOnline`) and `originId`.
- [accessPackageResourceRole](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageresourcerole?view=graph-rest-1.0): the role `originId` whose format varies per origin system.
- [Create accessPackageResourceRequest](https://learn.microsoft.com/en-us/graph/api/entitlementmanagement-post-resourcerequests?view=graph-rest-1.0): how each resource type is onboarded to a catalog.

i am excited to contribute, happy to make any adjusting in naming, structure, the test approach, whatever you'd like do please don't hold back. All feedback is genuinely welcome thank you for taking a look!

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

New acceptance tests in `access_package_resource_package_association_resource_test.go`:

- `TestAccAccessPackageResourcePackageAssociation_complete` (Member)
- `TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeOwner`
- `TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplication`
- `TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplicationRoleName`
- `TestAccAccessPackageResourcePackageAssociation_completeWithSharePointSite` (gated on `AZUREAD_TEST_SHAREPOINT_SITE_URL` and `AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID`, since the acceptance framework can't provision a SharePoint site)

All four pass against a live tenant:

```
--- PASS: TestAccAccessPackageResourcePackageAssociation_completeWithSharePointSite (102.76s)
--- PASS: TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeOwner (130.36s)
--- PASS: TestAccAccessPackageResourcePackageAssociation_complete (126.68s)
--- PASS: TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplicationRoleName (168.41s)
--- PASS: TestAccAccessPackageResourcePackageAssociation_completeWithAccessTypeApplication (169.81s)
```

The SharePoint case is not skipped above it was run end-to-end against a real dev-tenant site with `AZUREAD_TEST_SHAREPOINT_SITE_URL` and `AZUREAD_TEST_SHAREPOINT_ROLE_ORIGIN_ID` set. It only skips when those variables are absent (e.g. in CI, where no SharePoint site is provisioned).

## Change Log

* `azuread_access_package_resource_package_association` - support `AadApplication` and `SharePointOnline` resources via `access_type` [GH-00000]
* `azuread_access_package_resource_package_association` - `access_type` now accepts a resource role's display name as well as its origin ID, and an unknown role reports the roles available on that resource [GH-00000]
* `azuread_access_package_resource_catalog_association` - allow non-UUID resource origin IDs such as SharePoint site URLs [GH-00000]

This is a (please select all that apply):

- [x] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Closes #1066
Closes #1637

- **Closes #1066** `azuread_access_package_resource_package_association only supports groups`. The core feature request: the resource only accepted `AadGroup` (`Member`/`Owner`). This PR adds `AadApplication` (app role) and `SharePointOnline` (site role) support.
- **Closes #1637** `azuread_access_package_resource_catalog_association with SharePointOnline not usable`. The reported failure is the UUID validation on the resource origin ID, which for SharePoint is a site URL. This PR relaxes the `catalog_resource_association_id` parser so only the catalog ID must be a UUID.
- **Builds on #1782** the closed PR that first attempted application-role / SharePoint support. The author closed it after review feedback (prefer `CustomizeDiff` over making `access_type` required, to stay non-breaking) and invited reuse. This PR keeps `access_type` optional/non-breaking and additionally fixes the resource ID encoding and SharePoint root scope that #1782 didn't cover.
- **Unblocks #1776** (`...doesn't support eligible access_type`): the provider no longer hardcodes the set of role names, so any role the service exposes for a resource can be named. Note this does not _close_ #1776 — per the API docs, eligibility is the role's separate `type` property (`active`/`eligible`), not an `originId` value, so a full fix needs that property modelled. Not covered by the new tests.
- **Related: #1709** (`cannot add any AadApplication` → `ResourceNotFound`) is an eventual-consistency symptom when onboarding a *just-created* service principal, not a validation bug it's resolved by a wait/`depends_on` in user config (the new application acceptance test here uses a `time_sleep` for exactly this), so it isn't closed by this PR's code.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No. This adds support for additional resource types within an existing resource; it does not change access controls, encryption, or logging in the provider.