### PR TITLE
azuread_group: fix mail_nickname validation failing when value is unknown at plan time

### DIFF
--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -378,7 +378,7 @@ func groupResourceCustomizeDiff(ctx context.Context, diff *pluginsdk.ResourceDif
 		return fmt.Errorf("`mail_enabled` must be true for unified groups")
 	}
 
-	if mailNickname := diff.Get("mail_nickname").(string); mailEnabled && mailNickname == "" {
+	if mailNickname := diff.Get("mail_nickname").(string); mailEnabled && mailNickname == "" && diff.NewValueKnown("mail_nickname") {
 		return fmt.Errorf("`mail_nickname` is required for mail-enabled groups")
 	}
 

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -52,6 +52,22 @@ func TestAccGroup_basicUnified(t *testing.T) {
 	})
 }
 
+func TestAccGroup_mailNicknameFromUnknownValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_group", "test")
+	r := GroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.mailNicknameFromUnknownValue(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("display_name").HasValue(fmt.Sprintf("acctestGroup-%d", data.RandomInteger)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccGroup_completeUnified(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_group", "test")
 	r := GroupResource{}
@@ -637,6 +653,26 @@ resource "azuread_group" "test" {
   types            = ["Unified"]
   mail_enabled     = true
   mail_nickname    = "acctest.Group-%[1]d"
+  security_enabled = false
+}
+`, data.RandomInteger)
+}
+
+func (GroupResource) mailNicknameFromUnknownValue(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+provider "random" {}
+
+resource "random_string" "test" {
+  length  = 8
+  special = false
+}
+
+resource "azuread_group" "test" {
+  display_name     = "acctestGroup-%[1]d"
+  types            = ["Unified"]
+  mail_enabled     = true
+  mail_nickname    = "acctest.Group-%[1]d-${random_string.test.result}"
   security_enabled = false
 }
 `, data.RandomInteger)


### PR DESCRIPTION
## Summary

`groupResourceCustomizeDiff` reads `mail_nickname` with `diff.Get`, which collapses an unresolved computed value (e.g. interpolated from another resource that hasn't been applied yet, such as a `random_string` result) to an empty string. This causes plan/preview to fail with `` `mail_nickname` is required for mail-enabled groups `` even though the value would be populated by apply time.

This matches the behavior reported in [pulumi/pulumi-azuread#426](https://github.com/pulumi/pulumi-azuread/issues/426), which also reproduces directly in Terraform.

The fix skips the empty-value check when `diff.NewValueKnown("mail_nickname")` reports the value isn't known yet, following the same pattern already used for the duplicate `display_name` check earlier in the same function.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/services/groups/...`
- [x] `gofmt -l` clean on changed files
- [ ] `TestAccGroup_mailNicknameFromUnknownValue` (new acceptance test added, reproduces the reported scenario using the `random` provider; requires a live Azure AD tenant to run, consistent with other acceptance tests in this file)