### PR TITLE
New data source `azuread_authentication_strength_policy`

### DIFF
--- a/docs/data-sources/authentication_strength_policy.md
+++ b/docs/data-sources/authentication_strength_policy.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Policies"
+---
+
+# Data Source: azuread_authentication_strength_policy
+
+Use this data source to retrieve information about an authentication strength policy within Azure Active Directory. This can be used to read either the built-in policies supplied by Microsoft, or custom policies created in the tenant.
+
+## API Permissions
+
+The following API permissions are required in order to use this data source.
+
+When authenticated with a service principal, this data source requires one of the following application roles: `Policy.Read.AuthenticationMethod` or `Policy.Read.All`
+
+When authenticated with a user principal, this data source requires one of the following directory roles: `Conditional Access Administrator`, `Security Administrator`, `Security Reader` or `Global Administrator`
+
+## Example Usage
+
+*Look up a built-in policy*
+
+```terraform
+data "azuread_authentication_strength_policy" "example" {
+  display_name = "Multifactor authentication"
+}
+```
+
+The display names of the built-in policies supplied by Microsoft are:
+
+* `Multifactor authentication`
+* `Passwordless MFA`
+* `Phishing resistant MFA`
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) The display name of the authentication strength policy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `allowed_combinations` - A set of allowed authentication methods combinations for this authentication strength policy.
+* `description` - The description of this authentication strength policy.
+* `id` - The ID of this authentication strength policy.

--- a/docs/data-sources/authentication_strength_policy.md
+++ b/docs/data-sources/authentication_strength_policy.md
@@ -40,6 +40,6 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `allowed_combinations` - A set of allowed authentication methods combinations for this authentication strength policy.
+* `allowed_combinations` - A list of allowed authentication methods combinations for this authentication strength policy.
 * `description` - The description of this authentication strength policy.
 * `id` - The ID of this authentication strength policy.

--- a/internal/services/policies/authentication_strength_policy_data_source.go
+++ b/internal/services/policies/authentication_strength_policy_data_source.go
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package policies
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
+	"github.com/hashicorp/go-azure-sdk/microsoft-graph/policies/stable/authenticationstrengthpolicy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/validation"
+	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
+)
+
+var _ sdk.DataSource = AuthenticationStrengthPolicyDataSource{}
+
+type AuthenticationStrengthPolicyDataSourceModel struct {
+	DisplayName         string   `tfschema:"display_name"`
+	Description         string   `tfschema:"description"`
+	AllowedCombinations []string `tfschema:"allowed_combinations"`
+}
+
+type AuthenticationStrengthPolicyDataSource struct{}
+
+func (r AuthenticationStrengthPolicyDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"display_name": {
+			Description:  "The display name for the authentication strength policy",
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r AuthenticationStrengthPolicyDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"description": {
+			Description: "The description for the authentication strength policy",
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+		},
+
+		"allowed_combinations": {
+			Description: "The allowed MFA methods for this policy",
+			Type:        pluginsdk.TypeSet,
+			Computed:    true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (r AuthenticationStrengthPolicyDataSource) ModelObject() interface{} {
+	return &AuthenticationStrengthPolicyDataSourceModel{}
+}
+
+func (r AuthenticationStrengthPolicyDataSource) ResourceType() string {
+	return "azuread_authentication_strength_policy"
+}
+
+func (r AuthenticationStrengthPolicyDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Policies.AuthenticationStrengthPolicyClient
+
+			var model AuthenticationStrengthPolicyDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.ListAuthenticationStrengthPolicies(ctx, authenticationstrengthpolicy.DefaultListAuthenticationStrengthPoliciesOperationOptions())
+			if err != nil {
+				return fmt.Errorf("listing authentication strength policies: %+v", err)
+			}
+			if resp.Model == nil {
+				return fmt.Errorf("listing authentication strength policies: API error, result was nil")
+			}
+
+			var matches []stable.AuthenticationStrengthPolicy
+			for _, policy := range *resp.Model {
+				if pointer.From(policy.DisplayName) == model.DisplayName {
+					matches = append(matches, policy)
+				}
+			}
+
+			switch len(matches) {
+			case 0:
+				return fmt.Errorf("no authentication strength policy found with display name %q", model.DisplayName)
+			case 1:
+				// Expected, continue below
+			default:
+				return fmt.Errorf("multiple authentication strength policies found with display name %q, please ensure the display name is unique", model.DisplayName)
+			}
+
+			policy := matches[0]
+			if policy.Id == nil {
+				return fmt.Errorf("retrieving authentication strength policy with display name %q: API error, ID was nil", model.DisplayName)
+			}
+
+			id := stable.NewPolicyAuthenticationStrengthPolicyID(*policy.Id)
+
+			allowedCombinations := make([]string, 0)
+			for _, v := range pointer.From(policy.AllowedCombinations) {
+				allowedCombinations = append(allowedCombinations, string(v))
+			}
+
+			state := AuthenticationStrengthPolicyDataSourceModel{
+				DisplayName:         pointer.From(policy.DisplayName),
+				Description:         policy.Description.GetOrZero(),
+				AllowedCombinations: allowedCombinations,
+			}
+
+			metadata.ResourceData.SetId(id.ID())
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/policies/authentication_strength_policy_data_source.go
+++ b/internal/services/policies/authentication_strength_policy_data_source.go
@@ -47,7 +47,7 @@ func (r AuthenticationStrengthPolicyDataSource) Attributes() map[string]*schema.
 
 		"allowed_combinations": {
 			Description: "The allowed MFA methods for this policy",
-			Type:        pluginsdk.TypeSet,
+			Type:        pluginsdk.TypeList,
 			Computed:    true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,

--- a/internal/services/policies/authentication_strength_policy_data_source.go
+++ b/internal/services/policies/authentication_strength_policy_data_source.go
@@ -74,16 +74,13 @@ func (r AuthenticationStrengthPolicyDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
-			resp, err := client.ListAuthenticationStrengthPolicies(ctx, authenticationstrengthpolicy.DefaultListAuthenticationStrengthPoliciesOperationOptions())
+			resp, err := client.ListAuthenticationStrengthPoliciesComplete(ctx, authenticationstrengthpolicy.DefaultListAuthenticationStrengthPoliciesOperationOptions())
 			if err != nil {
 				return fmt.Errorf("listing authentication strength policies: %+v", err)
 			}
-			if resp.Model == nil {
-				return fmt.Errorf("listing authentication strength policies: API error, result was nil")
-			}
 
 			var matches []stable.AuthenticationStrengthPolicy
-			for _, policy := range *resp.Model {
+			for _, policy := range resp.Items {
 				if pointer.From(policy.DisplayName) == model.DisplayName {
 					matches = append(matches, policy)
 				}

--- a/internal/services/policies/authentication_strength_policy_data_source_test.go
+++ b/internal/services/policies/authentication_strength_policy_data_source_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package policies_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
+)
+
+type AuthenticationStrengthPolicyDataSource struct{}
+
+func TestAccAuthenticationStrengthPolicyDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_authentication_strength_policy", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: AuthenticationStrengthPolicyDataSource{}.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").Exists(),
+				check.That(data.ResourceName).Key("description").Exists(),
+				check.That(data.ResourceName).Key("allowed_combinations.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func TestAccAuthenticationStrengthPolicyDataSource_builtIn(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azuread_authentication_strength_policy", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: AuthenticationStrengthPolicyDataSource{}.builtIn(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("display_name").HasValue("Multifactor authentication"),
+				check.That(data.ResourceName).Key("allowed_combinations.#").Exists(),
+			),
+		},
+	})
+}
+
+func (AuthenticationStrengthPolicyDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "azuread_authentication_strength_policy" "test" {
+  display_name = azuread_authentication_strength_policy.test.display_name
+}
+`, AuthenticationStrengthPolicyResource{}.basic(data))
+}
+
+func (AuthenticationStrengthPolicyDataSource) builtIn() string {
+	return `
+provider "azuread" {}
+
+data "azuread_authentication_strength_policy" "test" {
+  display_name = "Multifactor authentication"
+}
+`
+}

--- a/internal/services/policies/registration.go
+++ b/internal/services/policies/registration.go
@@ -43,6 +43,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 // DataSources returns the typed DataSources supported by this service
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		AuthenticationStrengthPolicyDataSource{},
 		GroupRoleManagementPolicyDataSource{},
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->
Depends on #1881.

This PR should wait for #1881 to merge first and incorporate the schema changes in the `Read()` so that both the data source and resource are in sync.

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_AzureAD_AZUREAD_SERVICE_PUBLIC_POLICIES/704726?buildTab=tests

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_authentication_strength_policy` - New data source [GH-1887]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1385

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
