### PR TITLE
`azuread_app_role_assignment` - fix assignments orphaned by the create retry

### DIFF
--- a/internal/services/approleassignments/app_role_assignment_resource.go
+++ b/internal/services/approleassignments/app_role_assignment_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
 	"github.com/hashicorp/terraform-provider-azuread/internal/clients"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/consistency"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/validation"
@@ -108,6 +109,15 @@ func appRoleAssignmentResource() *pluginsdk.Resource {
 // app role and principal is already present on the resource service principal.
 const appRoleAssignmentExistsError = "Permission being assigned already exists on the object"
 
+// defaultAppRoleId assigns a principal to the resource app without any specific app role, and is
+// never present in the resource service principal's appRoles collection.
+const defaultAppRoleId = "00000000-0000-0000-0000-000000000000"
+
+// appRoleConsistencyTimeout bounds how long to wait for a newly created app role to replicate.
+// It is deliberately short: the wait is an optimisation, and an app role that never appears is
+// better reported by the API than by a timeout here.
+const appRoleConsistencyTimeout = 1 * time.Minute
+
 func appRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
 	client := meta.(*clients.Client).AppRoleAssignments.AppRoleAssignedToClient
 	servicePrincipalClient := meta.(*clients.Client).AppRoleAssignments.ServicePrincipalClient
@@ -123,6 +133,36 @@ func appRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.ResourceD
 			return tf.ErrorDiagPathF(err, "principal_object_id", "Service principal not found for resource (Object ID: %q)", resourceId)
 		}
 		return tf.ErrorDiagF(err, "Could not retrieve service principal for resource (Object ID: %q)", resourceId)
+	}
+
+	// An app role created moments ago is not yet visible on every Graph replica. Letting it
+	// settle first keeps the create request below off its retry path, which is where duplicate
+	// assignments come from. Best effort: if the role never appears the request is sent anyway,
+	// so an app_role_id that is simply wrong is still reported by the API rather than as a
+	// timeout here.
+	if appRoleId != defaultAppRoleId {
+		if _, err := consistency.WaitForUpdateWithTimeout(ctx, appRoleConsistencyTimeout, func(ctx context.Context) (*bool, error) {
+			resp, err := servicePrincipalClient.GetServicePrincipal(ctx, servicePrincipalId, serviceprincipal.DefaultGetServicePrincipalOperationOptions())
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return pointer.To(false), nil
+				}
+				return nil, err
+			}
+			if resp.Model == nil || resp.Model.AppRoles == nil {
+				return pointer.To(false), nil
+			}
+
+			for _, appRole := range *resp.Model.AppRoles {
+				if strings.EqualFold(pointer.From(appRole.Id), appRoleId) {
+					return pointer.To(true), nil
+				}
+			}
+
+			return pointer.To(false), nil
+		}); err != nil {
+			log.Printf("[DEBUG] App role %q not yet visible on service principal %q, continuing anyway: %v", appRoleId, resourceId, err)
+		}
 	}
 
 	properties := stable.AppRoleAssignment{

--- a/internal/services/approleassignments/app_role_assignment_resource.go
+++ b/internal/services/approleassignments/app_role_assignment_resource.go
@@ -6,8 +6,10 @@ package approleassignments
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -102,6 +104,10 @@ func appRoleAssignmentResource() *pluginsdk.Resource {
 	}
 }
 
+// appRoleAssignmentExistsError is returned by Microsoft Graph when an assignment for the same
+// app role and principal is already present on the resource service principal.
+const appRoleAssignmentExistsError = "Permission being assigned already exists on the object"
+
 func appRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
 	client := meta.(*clients.Client).AppRoleAssignments.AppRoleAssignedToClient
 	servicePrincipalClient := meta.(*clients.Client).AppRoleAssignments.ServicePrincipalClient
@@ -110,7 +116,9 @@ func appRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.ResourceD
 	principalId := d.Get("principal_object_id").(string)
 	resourceId := d.Get("resource_object_id").(string)
 
-	if resp, err := servicePrincipalClient.GetServicePrincipal(ctx, stable.NewServicePrincipalID(resourceId), serviceprincipal.DefaultGetServicePrincipalOperationOptions()); err != nil {
+	servicePrincipalId := stable.NewServicePrincipalID(resourceId)
+
+	if resp, err := servicePrincipalClient.GetServicePrincipal(ctx, servicePrincipalId, serviceprincipal.DefaultGetServicePrincipalOperationOptions()); err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return tf.ErrorDiagPathF(err, "principal_object_id", "Service principal not found for resource (Object ID: %q)", resourceId)
 		}
@@ -123,19 +131,52 @@ func appRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.ResourceD
 		ResourceId:  nullable.Value(resourceId),
 	}
 
+	// Graph reports a service principal or app role that has not finished replicating as missing,
+	// so the request below is retried. That request is a POST and is not idempotent, which means
+	// an attempt that did land can be replayed and answered with appRoleAssignmentExistsError.
+	// Track whether a retry happened so the two ways of reaching that error stay distinguishable.
+	retried := false
+
 	options := approleassignedto.CreateAppRoleAssignedToOperationOptions{
 		RetryFunc: func(resp *http.Response, o *odata.OData) (bool, error) {
+			retry := false
 			if response.WasNotFound(resp) {
-				return true, nil
+				retry = true
 			} else if response.WasBadRequest(resp) && o != nil && o.Error != nil {
-				return o.Error.Match("Not a valid reference update"), nil
+				retry = o.Error.Match("Not a valid reference update")
 			}
-			return false, nil
+			if retry {
+				retried = true
+			}
+			return retry, nil
 		},
 	}
 
-	resp, err := client.CreateAppRoleAssignedTo(ctx, stable.NewServicePrincipalID(resourceId), properties, options)
+	resp, err := client.CreateAppRoleAssignedTo(ctx, servicePrincipalId, properties, options)
 	if err != nil {
+		if response.WasBadRequest(resp.HttpResponse) && resp.OData != nil && resp.OData.Error != nil && resp.OData.Error.Match(appRoleAssignmentExistsError) {
+			existingId, findErr := findAppRoleAssignment(ctx, client, servicePrincipalId, appRoleId, principalId)
+			if findErr != nil {
+				return tf.ErrorDiagF(findErr, "Could not create app role assignment")
+			}
+
+			if existingId != nil {
+				if !retried {
+					// Nothing this provider did created the assignment, so it needs importing
+					// rather than adopting.
+					return tf.ImportAsExistsDiag("azuread_app_role_assignment", existingId.ID())
+				}
+
+				// A retried attempt landed after all. Adopting it is the only way the caller can
+				// end up managing the assignment, since the ID is server generated and an
+				// assignment left unmanaged here fails every subsequent apply the same way.
+				log.Printf("[DEBUG] Adopting %s, which a retried create request had already made", existingId)
+				d.SetId(existingId.ID())
+
+				return appRoleAssignmentResourceRead(ctx, d, meta)
+			}
+		}
+
 		return tf.ErrorDiagF(err, "Could not create app role assignment")
 	}
 
@@ -204,4 +245,32 @@ func appRoleAssignmentResourceDelete(ctx context.Context, d *pluginsdk.ResourceD
 	}
 
 	return nil
+}
+
+// findAppRoleAssignment returns the ID of the assignment of appRoleId to principalId on the given
+// resource service principal, or nil when no such assignment exists. Graph does not support
+// filtering appRoleAssignedTo on appRoleId or principalId, so the collection is matched locally.
+func findAppRoleAssignment(ctx context.Context, client *approleassignedto.AppRoleAssignedToClient, servicePrincipalId stable.ServicePrincipalId, appRoleId, principalId string) (*stable.ServicePrincipalIdAppRoleAssignedToId, error) {
+	resp, err := client.ListAppRoleAssignedTosComplete(ctx, servicePrincipalId, approleassignedto.DefaultListAppRoleAssignedTosOperationOptions())
+	if err != nil {
+		return nil, fmt.Errorf("listing app role assignments for %s: %+v", servicePrincipalId, err)
+	}
+
+	for _, assignment := range resp.Items {
+		if assignment.Id == nil || *assignment.Id == "" {
+			continue
+		}
+		if !strings.EqualFold(pointer.From(assignment.AppRoleId), appRoleId) {
+			continue
+		}
+		if !strings.EqualFold(assignment.PrincipalId.GetOrZero(), principalId) {
+			continue
+		}
+
+		id := stable.NewServicePrincipalIdAppRoleAssignedToID(servicePrincipalId.ServicePrincipalId, *assignment.Id)
+
+		return &id, nil
+	}
+
+	return nil, nil
 }

--- a/internal/services/approleassignments/app_role_assignment_resource_test.go
+++ b/internal/services/approleassignments/app_role_assignment_resource_test.go
@@ -66,6 +66,21 @@ func TestAccAppRoleAssignment_groupForTenantApp(t *testing.T) {
 	})
 }
 
+func TestAccAppRoleAssignment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_app_role_assignment", "test")
+	r := AppRoleAssignmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.groupForTenantApp(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport(data)),
+	})
+}
+
 func TestAccAppRoleAssignment_groupForTenantAppWithoutRole(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_app_role_assignment", "test")
 	r := AppRoleAssignmentResource{}
@@ -248,6 +263,18 @@ resource "azuread_app_role_assignment" "test" {
   resource_object_id  = azuread_service_principal.internal.object_id
 }
 `, r.tenantAppTemplate(data), data.RandomInteger)
+}
+
+func (r AppRoleAssignmentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_app_role_assignment" "import" {
+  app_role_id         = azuread_app_role_assignment.test.app_role_id
+  principal_object_id = azuread_app_role_assignment.test.principal_object_id
+  resource_object_id  = azuread_app_role_assignment.test.resource_object_id
+}
+`, r.groupForTenantApp(data))
 }
 
 func (r AppRoleAssignmentResource) groupForTenantAppWithoutRole(data acceptance.TestData) string {


### PR DESCRIPTION
## Description

`azuread_app_role_assignment` can create an assignment in Entra and then fail, leaving it
unmanaged and the configuration permanently unappliable.

The create request carries a `RetryFunc` that replays the request when Graph reports the service
principal or app role as not found, or answers `Not a valid reference update`. Both happen while a
newly created object replicates, so the retry is doing useful work.

The problem is that the request is a `POST` and is not idempotent. When an attempt has actually
landed, the replay is answered with:

```
Error: Could not create app role assignment

unexpected status 400 (400 Bad Request) with error: Request_BadRequest:
Permission being assigned already exists on the object
```

That is returned before `d.SetId()`, so the assignment exists in Entra but not in state. Because
the assignment ID is server generated, there is nothing the practitioner can import without
querying Graph by hand. Every subsequent apply plans the same create and fails identically.

This reproduces reliably when the app role and the assignment are created in the same apply, which
is the common case for `azuread_application_app_role` plus a `for_each` over a set of groups. We hit
it building ephemeral environments: one assignment out of ~25 is orphaned, and that environment can
never be applied again.

Fixes #763

## Changes

**`recover from duplicate assignments created by the create retry`** — the actual fix.

`RetryFunc` now records whether it fired. On `Permission being assigned already exists on the
object` the assignment is looked up on the resource service principal, and:

- if a retry happened, the provider created it, so it is adopted
- if no retry happened, it pre-dates this request, so `tf.ImportAsExistsDiag` is returned — now
  with a usable ID, which it previously was not possible to obtain

The lookup pages `appRoleAssignedTo` and matches locally, since Graph does not support `$filter` on
`appRoleId` or `principalId`. It only runs on the error path.

Adopting is deliberately limited to the case the provider caused. A blanket adopt-on-conflict would
silently take over assignments made outside Terraform, which is not how this provider behaves
elsewhere.

**`wait for the app role to replicate before assigning it`** — prevention, separable.

Waits for the app role to appear in the resource service principal's `appRoles` before sending the
request, using the existing `consistency` helper, in the spirit of #1844 and #1845. Bounded at one
minute and non-fatal on purpose: an `app_role_id` that is simply wrong should be reported by the
API, not as a timeout here. Skipped for the default all-zeros role, which never appears in
`appRoles`.

This is the second commit and can be dropped without affecting the fix.

**`add a requiresImport acceptance test`**

## Testing

```
make fmtcheck        # pass
make test            # pass
golangci-lint run    # clean
scripts/terrafmt-acctests.sh  # clean
```

The new `TestAccAppRoleAssignment_requiresImport` covers the branch where the assignment already
existed and no retry occurred.

I could not construct a deterministic test for the adopt branch — it needs Graph to accept a write
and then report it as missing, which I have no way to force. It is reached by reasoning about the
retry path rather than by a repro, and I would rather flag that than imply coverage that is not
there. Happy to take a suggestion if there is an established way to fake the transport in this
repo.
