### PR TITLE
F/invitation user properties

### DIFF
--- a/docs/resources/invitation.md
+++ b/docs/resources/invitation.md
@@ -53,15 +53,40 @@ resource "azuread_invitation" "example" {
 }
 ```
 
+*Invitation with additional user properties*
+
+```terraform
+resource "azuread_invitation" "example" {
+  user_display_name  = "Bob Bobson"
+  user_email_address = "bbobson@hashicorp.com"
+  redirect_url       = "https://portal.azure.com"
+
+  company_name   = "Acme Inc."
+  department     = "Engineering"
+  given_name     = "Bob"
+  job_title      = "Consultant"
+  surname        = "Bobson"
+  usage_location = "GB"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
+* `company_name` - (Optional) The company name which the invited user is associated with. This property can be useful for describing the company that an external user comes from.
+* `department` - (Optional) The name for the department in which the invited user works.
+* `given_name` - (Optional) The given name (first name) of the user being invited.
+* `job_title` - (Optional) The invited user's job title.
 * `message` - (Optional) A `message` block as documented below, which configures the message being sent to the invited user. If this block is omitted, no message will be sent.
 * `redirect_url` - (Required) The URL that the user should be redirected to once the invitation is redeemed.
+* `surname` - (Optional) The invited user's surname (family name or last name).
+* `usage_location` - (Optional) The usage location of the user being invited. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: `NO`, `JP`, and `GB`. Cannot be reset to null once set.
 * `user_display_name` - (Optional) The display name of the user being invited.
 * `user_email_address` - (Required) The email address of the user being invited.
 * `user_type` - (Optional) The user type of the user being invited. Must be one of `Guest` or `Member`. Only Global Administrators can invite users as members. Defaults to `Guest`.
+
+~> **Note on user properties** The invited user object is created with a read-only reference by the invitation API, so these properties are applied to the guest user in a subsequent operation once the user has replicated in Azure AD.
 
 ---
 
@@ -84,6 +109,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 5 minutes) Used when creating the resource.
 * `read` - (Defaults to 5 minutes) Used when retrieving the resource.
+* `update` - (Defaults to 5 minutes) Used when updating the resource.
 * `delete` - (Defaults to 5 minutes) Used when deleting the resource.
 
 ## Import

--- a/internal/services/invitations/invitation_resource.go
+++ b/internal/services/invitations/invitation_resource.go
@@ -30,11 +30,13 @@ func invitationResource() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		CreateContext: invitationResourceCreate,
 		ReadContext:   invitationResourceRead,
+		UpdateContext: invitationResourceUpdate,
 		DeleteContext: invitationResourceDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(5 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(5 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
@@ -61,6 +63,42 @@ func invitationResource() *pluginsdk.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"company_name": {
+				Description: "The company name which the user is associated. This property can be useful for describing the company that an external user comes from",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"department": {
+				Description: "The name for the department in which the user works",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"given_name": {
+				Description: "The given name (first name) of the user being invited",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"job_title": {
+				Description: "The user's job title",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"surname": {
+				Description: "The user's surname (family name or last name)",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
+			},
+
+			"usage_location": {
+				Description: "The usage location of the user being invited. Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries. The usage location is a two letter country code (ISO standard 3166). Examples include: `NO`, `JP`, and `GB`. Cannot be reset to null once set",
+				Type:        pluginsdk.TypeString,
+				Optional:    true,
 			},
 
 			"message": {
@@ -194,9 +232,7 @@ func invitationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, me
 		return tf.ErrorDiagF(err, "Failed to patch guest user (1) after creating invitation")
 	}
 
-	userResp, err = userClient.UpdateUser(ctx, userId, stable.User{
-		CompanyName: nullable.NoZero(""),
-	}, user.DefaultUpdateUserOperationOptions())
+	userResp, err = userClient.UpdateUser(ctx, userId, expandInvitationUser(d), user.DefaultUpdateUserOperationOptions())
 	if err != nil {
 		if response.WasNotFound(userResp.HttpResponse) {
 			return tf.ErrorDiagF(err, "Timed out whilst waiting for new guest user to be replicated in Azure AD")
@@ -222,7 +258,19 @@ func invitationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta
 	client := meta.(*clients.Client).Invitations.UserClient
 	userId := stable.NewUserID(d.Get("user_id").(string))
 
-	resp, err := client.GetUser(ctx, userId, user.DefaultGetUserOperationOptions())
+	options := user.GetUserOperationOptions{
+		Select: &[]string{
+			"companyName",
+			"department",
+			"givenName",
+			"jobTitle",
+			"mail",
+			"surname",
+			"usageLocation",
+		},
+	}
+
+	resp, err := client.GetUser(ctx, userId, options)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[DEBUG] Invited %s was not found - removing from state!", userId)
@@ -238,8 +286,25 @@ func invitationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta
 
 	tf.Set(d, "user_id", userId.UserId)
 	tf.Set(d, "user_email_address", resp.Model.Mail.GetOrZero())
+	tf.Set(d, "company_name", resp.Model.CompanyName.GetOrZero())
+	tf.Set(d, "department", resp.Model.Department.GetOrZero())
+	tf.Set(d, "given_name", resp.Model.GivenName.GetOrZero())
+	tf.Set(d, "job_title", resp.Model.JobTitle.GetOrZero())
+	tf.Set(d, "surname", resp.Model.Surname.GetOrZero())
+	tf.Set(d, "usage_location", resp.Model.UsageLocation.GetOrZero())
 
 	return nil
+}
+
+func invitationResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {
+	userClient := meta.(*clients.Client).Invitations.UserClient
+	userId := stable.NewUserID(d.Get("user_id").(string))
+
+	if _, err := userClient.UpdateUser(ctx, userId, expandInvitationUser(d), user.DefaultUpdateUserOperationOptions()); err != nil {
+		return tf.ErrorDiagF(err, "Updating invited %s", userId)
+	}
+
+	return invitationResourceRead(ctx, d, meta)
 }
 
 func invitationResourceDelete(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) pluginsdk.Diagnostics {

--- a/internal/services/invitations/invitation_resource.go
+++ b/internal/services/invitations/invitation_resource.go
@@ -260,6 +260,7 @@ func invitationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta
 
 	options := user.GetUserOperationOptions{
 		Select: &[]string{
+			"id",
 			"companyName",
 			"department",
 			"givenName",

--- a/internal/services/invitations/invitation_resource_test.go
+++ b/internal/services/invitations/invitation_resource_test.go
@@ -125,6 +125,40 @@ func TestAccInvitation_messageWithLanguage(t *testing.T) {
 	})
 }
 
+func TestAccInvitation_userProperties(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_invitation", "test")
+	r := InvitationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userProperties(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("user_id").Exists(),
+				check.That(data.ResourceName).Key("company_name").HasValue("Acme Inc."),
+				check.That(data.ResourceName).Key("department").HasValue("Engineering"),
+				check.That(data.ResourceName).Key("given_name").HasValue("Bob"),
+				check.That(data.ResourceName).Key("job_title").HasValue("Consultant"),
+				check.That(data.ResourceName).Key("surname").HasValue("Bobson"),
+				check.That(data.ResourceName).Key("usage_location").HasValue("GB"),
+			),
+		},
+		{
+			Config: r.userPropertiesUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("user_id").Exists(),
+				check.That(data.ResourceName).Key("company_name").HasValue("Globex Corp."),
+				check.That(data.ResourceName).Key("department").HasValue("Research"),
+				check.That(data.ResourceName).Key("given_name").HasValue("Robert"),
+				check.That(data.ResourceName).Key("job_title").HasValue("Principal Consultant"),
+				check.That(data.ResourceName).Key("surname").HasValue("Bobson"),
+				check.That(data.ResourceName).Key("usage_location").HasValue("US"),
+			),
+		},
+	})
+}
+
 func TestAccInvitation_withGroupMembership(t *testing.T) {
 	count := 10
 	data := acceptance.BuildTestData(t, "azuread_invitation", fmt.Sprintf("test.%d", count-1))
@@ -170,6 +204,40 @@ resource "azuread_invitation" "test" {
   redirect_url       = "https://portal.azure.com"
   user_email_address = "acctest-user-%[1]s@test.com"
   user_type          = "Member"
+}
+`, data.RandomString)
+}
+
+func (InvitationResource) userProperties(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_invitation" "test" {
+  redirect_url       = "https://portal.azure.com"
+  user_email_address = "acctest-user-%[1]s@test.com"
+  user_display_name  = "Test user"
+
+  company_name   = "Acme Inc."
+  department     = "Engineering"
+  given_name     = "Bob"
+  job_title      = "Consultant"
+  surname        = "Bobson"
+  usage_location = "GB"
+}
+`, data.RandomString)
+}
+
+func (InvitationResource) userPropertiesUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azuread_invitation" "test" {
+  redirect_url       = "https://portal.azure.com"
+  user_email_address = "acctest-user-%[1]s@test.com"
+  user_display_name  = "Test user"
+
+  company_name   = "Globex Corp."
+  department     = "Research"
+  given_name     = "Robert"
+  job_title      = "Principal Consultant"
+  surname        = "Bobson"
+  usage_location = "US"
 }
 `, data.RandomString)
 }

--- a/internal/services/invitations/invitations.go
+++ b/internal/services/invitations/invitations.go
@@ -6,7 +6,22 @@ package invitations
 import (
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
+	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
 )
+
+// expandInvitationUser builds the user properties applied to the guest user after the
+// invitation is created. CompanyName is always set (to the configured value or empty) to
+// clear the temporary value used during creation to detect replication of the new user.
+func expandInvitationUser(d *pluginsdk.ResourceData) stable.User {
+	return stable.User{
+		CompanyName:   nullable.Value(d.Get("company_name").(string)),
+		Department:    nullable.NoZero(d.Get("department").(string)),
+		GivenName:     nullable.NoZero(d.Get("given_name").(string)),
+		JobTitle:      nullable.NoZero(d.Get("job_title").(string)),
+		Surname:       nullable.NoZero(d.Get("surname").(string)),
+		UsageLocation: nullable.NoZero(d.Get("usage_location").(string)),
+	}
+}
 
 func expandInvitedUserMessageInfo(in []interface{}) *stable.InvitedUserMessageInfo {
 	if len(in) == 0 || in[0] == nil {

--- a/internal/services/invitations/invitations.go
+++ b/internal/services/invitations/invitations.go
@@ -10,11 +10,11 @@ import (
 )
 
 // expandInvitationUser builds the user properties applied to the guest user after the
-// invitation is created. CompanyName is always set (to the configured value or empty) to
-// clear the temporary value used during creation to detect replication of the new user.
+// invitation is created. When company_name is empty, CompanyName is sent as null to clear
+// the temporary value used during replication detection.
 func expandInvitationUser(d *pluginsdk.ResourceData) stable.User {
 	return stable.User{
-		CompanyName:   nullable.Value(d.Get("company_name").(string)),
+		CompanyName:   nullable.NoZero(d.Get("company_name").(string)),
 		Department:    nullable.NoZero(d.Get("department").(string)),
 		GivenName:     nullable.NoZero(d.Get("given_name").(string)),
 		JobTitle:      nullable.NoZero(d.Get("job_title").(string)),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for configuring additional guest user properties directly on the `azuread_invitation` resource, matching the "Properties" step shown when inviting an external (B2B) user through the Azure Portal.

The following optional arguments are added:

* `company_name`
* `department`
* `given_name`
* `job_title`
* `surname`
* `usage_location`

The Microsoft Graph invitation API's `invitedUser` container is read-only and only returns the new user's object ID, so these properties cannot be sent on the invitation payload itself. Instead they are applied to the resulting guest user via a `PATCH` to the user object once it has replicated in Azure AD. The resource already performs a post-invitation patch to detect replication of the new guest user, and this change reuses that flow to apply the configured properties.

The new properties are updatable in place: an `Update` operation has been added that patches the existing guest user, so changing a value does not delete and re-invite the user.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_invitation` - support for the `company_name`, `department`, `given_name`, `job_title`, `surname` and `usage_location` properties [GH-1893]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1893

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
