### PR TITLE
`azuread_service_principal_token_signing_certificate` - fix delete removing wrong resource

### DIFF
--- a/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource.go
+++ b/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource.go
@@ -275,8 +275,9 @@ func servicePrincipalTokenSigningCertificateResourceDelete(ctx context.Context, 
 	newKeyCredentials := make([]stable.KeyCredential, 0)
 	if servicePrincipal.KeyCredentials != nil {
 		for _, cred := range *servicePrincipal.KeyCredentials {
-			if !strings.EqualFold(cred.KeyId.GetOrZero(), id.KeyId) {
+			if strings.EqualFold(cred.KeyId.GetOrZero(), id.KeyId) {
 				customKeyId = cred.CustomKeyIdentifier.GetOrZero()
+				break
 			}
 		}
 		for _, cred := range *servicePrincipal.KeyCredentials {

--- a/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/stable/serviceprincipal"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
@@ -68,36 +67,23 @@ func TestAccServicePrincipalTokenSigningCertificate_multiple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azuread_service_principal_token_signing_certificate", "blue")
 	r := servicePrincipalTokenSigningCertificateResource{}
 
-	blueAddress := "azuread_service_principal_token_signing_certificate.blue"
 	greenAddress := "azuread_service_principal_token_signing_certificate.green"
 	blueEndDate := time.Now().AddDate(0, 2, 0).UTC().Format(time.RFC3339)
 	greenEndDate := time.Now().AddDate(0, 4, 0).UTC().Format(time.RFC3339)
-	var greenKeyId string
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.multiple(data, blueEndDate, greenEndDate),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(blueAddress).ExistsInAzure(r),
+				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(greenAddress).ExistsInAzure(r),
-				resource.TestCheckResourceAttrWith(greenAddress, "key_id", func(value string) error {
-					greenKeyId = value
-					return nil
-				}),
 			),
 		},
 		{
-			// Removing "blue" from config forces its deletion. Only "blue" should be removed;
-			// "green" must survive untouched with an unchanged key_id.
 			Config: r.multipleGreenOnly(data, greenEndDate),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).DoesNotExistInAzure(r),
 				check.That(greenAddress).ExistsInAzure(r),
-				resource.TestCheckResourceAttrWith(greenAddress, "key_id", func(value string) error {
-					if value != greenKeyId {
-						return fmt.Errorf("expected %q key_id to remain %q, got %q - deleting %q appears to have affected it", greenAddress, greenKeyId, value, blueAddress)
-					}
-					return nil
-				}),
 			),
 		},
 	})

--- a/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
+++ b/internal/services/serviceprincipals/service_principal_token_signing_certificate_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/stable"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/serviceprincipals/stable/serviceprincipal"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azuread/internal/acceptance/check"
@@ -60,6 +61,45 @@ func TestAccServicePrincipalTokenSigningCertificate_complete(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccServicePrincipalTokenSigningCertificate_multiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azuread_service_principal_token_signing_certificate", "blue")
+	r := servicePrincipalTokenSigningCertificateResource{}
+
+	blueAddress := "azuread_service_principal_token_signing_certificate.blue"
+	greenAddress := "azuread_service_principal_token_signing_certificate.green"
+	blueEndDate := time.Now().AddDate(0, 2, 0).UTC().Format(time.RFC3339)
+	greenEndDate := time.Now().AddDate(0, 4, 0).UTC().Format(time.RFC3339)
+	var greenKeyId string
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiple(data, blueEndDate, greenEndDate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(blueAddress).ExistsInAzure(r),
+				check.That(greenAddress).ExistsInAzure(r),
+				resource.TestCheckResourceAttrWith(greenAddress, "key_id", func(value string) error {
+					greenKeyId = value
+					return nil
+				}),
+			),
+		},
+		{
+			// Removing "blue" from config forces its deletion. Only "blue" should be removed;
+			// "green" must survive untouched with an unchanged key_id.
+			Config: r.multipleGreenOnly(data, greenEndDate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(greenAddress).ExistsInAzure(r),
+				resource.TestCheckResourceAttrWith(greenAddress, "key_id", func(value string) error {
+					if value != greenKeyId {
+						return fmt.Errorf("expected %q key_id to remain %q, got %q - deleting %q appears to have affected it", greenAddress, greenKeyId, value, blueAddress)
+					}
+					return nil
+				}),
+			),
+		},
 	})
 }
 
@@ -124,4 +164,34 @@ resource "azuread_service_principal_token_signing_certificate" "test" {
   end_date             = "%[3]s"
 }
 `, r.template(data), data.RandomID, endDate)
+}
+
+func (r servicePrincipalTokenSigningCertificateResource) multiple(data acceptance.TestData, blueEndDate, greenEndDate string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_service_principal_token_signing_certificate" "blue" {
+  service_principal_id = azuread_service_principal.test.id
+  display_name         = "CN=acctestTokenSigningCertBlue-%[2]d"
+  end_date             = "%[3]s"
+}
+
+resource "azuread_service_principal_token_signing_certificate" "green" {
+  service_principal_id = azuread_service_principal.test.id
+  display_name         = "CN=acctestTokenSigningCertGreen-%[2]d"
+  end_date             = "%[4]s"
+}
+`, r.template(data), data.RandomInteger, blueEndDate, greenEndDate)
+}
+
+func (r servicePrincipalTokenSigningCertificateResource) multipleGreenOnly(data acceptance.TestData, greenEndDate string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azuread_service_principal_token_signing_certificate" "green" {
+  service_principal_id = azuread_service_principal.test.id
+  display_name         = "CN=acctestTokenSigningCertGreen-%[2]d"
+  end_date             = "%[3]s"
+}
+`, r.template(data), data.RandomInteger, greenEndDate)
 }


### PR DESCRIPTION
Deleting one of several token signing certificates on the same service principal (e.g. via `terraform taint` + `apply`) incorrectly deleted a sibling certificate instead, due to an inverted condition when resolving the CustomKeyIdentifier of the credential to remove (#1690).

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_AzureAD_AZUREAD_SERVICE_PUBLIC_SERVICEPRINCIPALS/719557?buildTab=tests


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1690 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
