### PR TITLE
teamcity: add AZUREAD_TEST_SKU_ID and AZUREAD_TEST_DISABLED_PLAN_ID test parameters

### DIFF
--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -8,7 +8,9 @@ import jetbrains.buildServer.configs.kotlin.ParametrizedWithType
 class ClientConfiguration(var clientId: String,
                           var clientSecret: String,
                           val tenantId : String,
-                          val vcsRootId : String)
+                          val vcsRootId : String,
+                          val skuId : String,
+                          val disabledPlanId : String)
 
 class LocationConfiguration(var primary : String, var secondary : String, var ternary : String, var rotate : Boolean)
 
@@ -21,4 +23,6 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenVariable("env.ARM_TEST_LOCATION", locationsForEnv.primary, "The Primary region which should be used for testing")
     hiddenVariable("env.ARM_TEST_LOCATION_ALT", locationsForEnv.secondary, "The Primary region which should be used for testing")
     hiddenVariable("env.ARM_TEST_LOCATION_ALT2", locationsForEnv.ternary, "The Primary region which should be used for testing")
+    hiddenVariable("env.AZUREAD_TEST_SKU_ID", config.skuId, "The license SKU ID used for azuread_user_license acceptance tests")
+    hiddenVariable("env.AZUREAD_TEST_DISABLED_PLAN_ID", config.disabledPlanId, "A service plan ID within the SKU, used for azuread_user_license disabled_plans acceptance tests")
 }

--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -23,6 +23,6 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenVariable("env.ARM_TEST_LOCATION", locationsForEnv.primary, "The Primary region which should be used for testing")
     hiddenVariable("env.ARM_TEST_LOCATION_ALT", locationsForEnv.secondary, "The Primary region which should be used for testing")
     hiddenVariable("env.ARM_TEST_LOCATION_ALT2", locationsForEnv.ternary, "The Primary region which should be used for testing")
-    hiddenVariable("env.AZUREAD_TEST_SKU_ID", config.skuId, "The license SKU ID used for azuread_user_license acceptance tests")
-    hiddenVariable("env.AZUREAD_TEST_DISABLED_PLAN_ID", config.disabledPlanId, "A service plan ID within the SKU, used for azuread_user_license disabled_plans acceptance tests")
+    hiddenVariable("env.AAD_TEST_LICENSE_SKU_ID", config.skuId, "The license SKU ID used for azuread_user_license acceptance tests")
+    hiddenVariable("env.AAD_TEST_LICENSE_DISABLED_PLAN_ID", config.disabledPlanId, "A service plan ID within the SKU, used for azuread_user_license disabled_plans acceptance tests")
 }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -14,7 +14,9 @@ var clientSecret = DslContext.getParameter("clientSecret", "")
 var tenantId = DslContext.getParameter("tenantId", "")
 var environment = DslContext.getParameter("environment", "public")
 var vcsRootId = DslContext.getParameter("vcsRootId", "TF_HashiCorp_AzureAD_Repository")
+var skuId = DslContext.getParameter("skuId", "")
+var disabledPlanId = DslContext.getParameter("disabledPlanId", "")
 
-var clientConfig = ClientConfiguration(clientId, clientSecret, tenantId, vcsRootId)
+var clientConfig = ClientConfiguration(clientId, clientSecret, tenantId, vcsRootId, skuId, disabledPlanId)
 
 project(AzureAD(environment, clientConfig))


### PR DESCRIPTION
## Description

Wires two new dynamic TeamCity DSL parameters, `skuId` and `disabledPlanId`, through to the environment as `AAD_TEST_LICENSE_SKU_ID` / `AAD_TEST_LICENSE_DISABLED_PLAN_ID`, following the exact pattern already used for `clientId`/`tenantId`/etc.

These are needed by the acceptance tests for the new `azuread_user_license` resource in #1879.

Split out of #1879 per review feedback.

## Related

Unblocks acceptance testing for #1879.