### PR TITLE
`azuread_group_member` - add eventual consistency check for `Create`

### DIFF
--- a/internal/services/groups/group_member_resource.go
+++ b/internal/services/groups/group_member_resource.go
@@ -101,7 +101,20 @@ func groupMemberResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 		return tf.ErrorDiagF(err, "Adding %s", id)
 	}
 
+	// Set the ID before waiting, so that a timeout below does not orphan the membership we just created
 	d.SetId(resourceId.String())
+
+	// Wait for membership link to be created
+	if err := consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+		if member, err := groupGetMember(ctx, memberClient, id); err != nil {
+			return nil, err
+		} else if member == nil {
+			return pointer.To(false), nil
+		}
+		return pointer.To(true), nil
+	}); err != nil {
+		return tf.ErrorDiagF(err, "Waiting for creation of %s", id)
+	}
 
 	return groupMemberResourceRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`azuread_group_member` was missing the eventual consistency check that the two sibling member resources already perform after adding a member ref. This adds it.

The added block is the same shape as the shipped code, and can be verified by diffing against it:

* `directory_role_member_resource.go` L115-124
* `administrative_unit_member_resource.go` L112-121
* `group_member_resource.go` L149-158 — this resource's own `Delete`, which already has the mirrored `consistency.WaitForDeletion`

One intentional difference: the two `Create` functions above call `d.SetId` after the wait, this one sets it before. On a wait timeout, setting it first leaves a tainted resource in state, setting it last leaves a membership that exists in Azure with nothing in state, which is the condition that makes the *next* run fail with `A resource with the ID already exists`.

Without the check, `Create` adds the member and reads it back immediately. Graph is eventually consistent, so that read can miss it, `Read` treats the membership as removed and clears the ID, and Terraform reports `Provider produced inconsistent result after apply`.

Fixes #793 (open since 2022, reproduces with `for_each` over a set of members). #1810 looks like a duplicate.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

This change adds a read-back poll to an existing write path, with no schema, filter or control-flow changes, so no new test coverage was added. The bug it fixes is a race against Graph replication delay, which a test could only reproduce intermittently. `consistency.WaitForUpdate` is already covered where the sibling resources use it, and the existing `TestAccGroupMember_*` tests exercise the modified `Create` path unchanged, including `TestAccGroupMember_requiresImport`.

All CI checks pass locally: `quick-checks`, `lint`, `tfproviderlint`, `docs-lint`, `validate-examples`, `depscheck`, `generate`, `test`.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_group_member` - add eventual consistency check for `Create`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #793


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. The change polls an existing membership with the same client and permissions the resource already requires.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
