### PR TITLE
provider: use the Plugin SDK default Terraform User-Agent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ For more advanced scenarios, the following additional arguments are supported:
 
 It's also possible to use multiple Provider blocks within a single Terraform configuration, for example to work with resources across multiple Azure Active Directory Tenants or Environments - more information can be found [in the documentation for Providers](https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations).
 
+The value of the `TF_APPEND_USER_AGENT` environment variable is appended to the User-Agent header sent with each request to Microsoft Graph, in addition to the Terraform, Plugin SDK and provider versions which are always sent. This is useful for identifying requests made by a particular automation or tooling.
+
 ---
 
 ## Logging and Tracing

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -16,11 +16,14 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/client/msgraph"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azuread/version"
 )
 
 type contextKey string
+
+// providerName is the reporting name of this provider, as sent in the User-Agent header.
+const providerName = "terraform-provider-azuread"
 
 type ClientOptions struct {
 	Environment environments.Environment
@@ -106,8 +109,11 @@ Request ID: %s
 }
 
 func (o ClientOptions) userAgent(sdkUserAgent string) (userAgent string) {
-	tfUserAgent := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", o.TerraformVersion, meta.SDKVersionString()) //nolint:staticcheck
-	providerUserAgent := fmt.Sprintf("%s terraform-provider-azuread/%s", tfUserAgent, version.ProviderVersion)
+	// Defer to the Plugin SDK for the Terraform, SDK and provider versions, which also appends the
+	// value of the TF_APPEND_USER_AGENT environment variable when set. Provider.UserAgent reads only
+	// the TerraformVersion field, so a bare Provider suffices here and this remains valid for the
+	// acceptance test client, which builds clients without instantiating the provider.
+	providerUserAgent := (&schema.Provider{TerraformVersion: o.TerraformVersion}).UserAgent(providerName, version.ProviderVersion)
 	userAgent = strings.TrimSpace(fmt.Sprintf("%s %s", providerUserAgent, sdkUserAgent))
 
 	// append the CloudShell version to the user agent if it exists

--- a/internal/common/client_options_test.go
+++ b/internal/common/client_options_test.go
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
+	"github.com/hashicorp/terraform-provider-azuread/version"
+)
+
+func TestUserAgent(t *testing.T) {
+	baseUserAgent := fmt.Sprintf("Terraform/1.2.3 (+https://www.terraform.io) Terraform-Plugin-SDK/%s terraform-provider-azuread/%s", meta.SDKVersionString(), version.ProviderVersion) //nolint:staticcheck
+
+	testCases := []struct {
+		name         string
+		options      ClientOptions
+		sdkUserAgent string
+		env          map[string]string
+		expected     string
+	}{
+		{
+			name:     "no additions",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			expected: baseUserAgent,
+		},
+		{
+			name:         "sdk user agent",
+			options:      ClientOptions{TerraformVersion: "1.2.3"},
+			sdkUserAgent: "HashiCorp/go-azure-sdk (Go-http-client/1.1)",
+			expected:     fmt.Sprintf("%s HashiCorp/go-azure-sdk (Go-http-client/1.1)", baseUserAgent),
+		},
+		{
+			name:     "appended user agent",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			env:      map[string]string{"TF_APPEND_USER_AGENT": "my-custom-agent/1.0"},
+			expected: fmt.Sprintf("%s my-custom-agent/1.0", baseUserAgent),
+		},
+		{
+			name:     "appended user agent is trimmed",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			env:      map[string]string{"TF_APPEND_USER_AGENT": "  my-custom-agent/1.0  "},
+			expected: fmt.Sprintf("%s my-custom-agent/1.0", baseUserAgent),
+		},
+		{
+			name:     "empty appended user agent is ignored",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			env:      map[string]string{"TF_APPEND_USER_AGENT": "   "},
+			expected: baseUserAgent,
+		},
+		{
+			name:     "cloudshell agent",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			env:      map[string]string{"AZURE_HTTP_USER_AGENT": "cloud-shell/1.0"},
+			expected: fmt.Sprintf("%s cloud-shell/1.0", baseUserAgent),
+		},
+		{
+			name:     "empty cloudshell agent is ignored",
+			options:  ClientOptions{TerraformVersion: "1.2.3"},
+			env:      map[string]string{"AZURE_HTTP_USER_AGENT": ""},
+			expected: baseUserAgent,
+		},
+		{
+			name:         "cloudshell agent follows go-azure-sdk agent and precedes partner id",
+			options:      ClientOptions{TerraformVersion: "1.2.3", PartnerID: "222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6"},
+			sdkUserAgent: "HashiCorp/go-azure-sdk (Go-http-client/1.1)",
+			env:          map[string]string{"AZURE_HTTP_USER_AGENT": "cloud-shell/1.0"},
+			expected:     fmt.Sprintf("%s HashiCorp/go-azure-sdk (Go-http-client/1.1) cloud-shell/1.0 pid-222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6", baseUserAgent),
+		},
+		{
+			name:         "appended user agent precedes go-azure-sdk agent, cloudshell agent and partner id",
+			options:      ClientOptions{TerraformVersion: "1.2.3", PartnerID: "222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6"},
+			sdkUserAgent: "HashiCorp/go-azure-sdk (Go-http-client/1.1)",
+			env: map[string]string{
+				"TF_APPEND_USER_AGENT":  "my-custom-agent/1.0",
+				"AZURE_HTTP_USER_AGENT": "cloud-shell/1.0",
+			},
+			expected: fmt.Sprintf("%s my-custom-agent/1.0 HashiCorp/go-azure-sdk (Go-http-client/1.1) cloud-shell/1.0 pid-222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6", baseUserAgent),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("TF_APPEND_USER_AGENT", "")
+			t.Setenv("AZURE_HTTP_USER_AGENT", "")
+			for k, v := range testCase.env {
+				t.Setenv(k, v)
+			}
+
+			if actual := testCase.options.userAgent(testCase.sdkUserAgent); actual != testCase.expected {
+				t.Fatalf("expected user agent %q but got %q", testCase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUserAgentAppendedValueIsNotDuplicated(t *testing.T) {
+	t.Setenv("TF_APPEND_USER_AGENT", "my-custom-agent/1.0")
+
+	o := ClientOptions{TerraformVersion: "1.2.3"}
+	userAgent := o.userAgent("")
+
+	if count := strings.Count(userAgent, "my-custom-agent/1.0"); count != 1 {
+		t.Fatalf("expected appended user agent to appear once, but it appeared %d times in %q", count, userAgent)
+	}
+}


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The provider built the Terraform / Plugin SDK / provider portion of its `User-Agent` header by hand in `ClientOptions.userAgent`, rather than using the Plugin SDK's `(*schema.Provider).UserAgent` helper. Two things followed from that: the value of the `TF_APPEND_USER_AGENT` environment variable was ignored, and the emitted format drifted from the SDK default.

This PR delegates that portion of the header to the SDK helper, which appends `TF_APPEND_USER_AGENT` when set. `UserAgent` reads only the `TerraformVersion` field of its receiver, so a bare `schema.Provider` produces the same string the live provider instance would — this keeps a single code path covering both the provider and the acceptance test client, which builds clients without instantiating the provider.

**This changes the format of the header**, which is worth a reviewer's attention: the `HashiCorp ` prefix is dropped and `Terraform Plugin SDK` becomes `Terraform-Plugin-SDK` (the SDK's own spelling). The `AZURE_HTTP_USER_AGENT` (Cloud Shell) value and the `pid-<uuid>` partner ID token are untouched and still trail the header, so partner attribution is unaffected. If any Microsoft-side telemetry depends on the current spelling, the narrower alternative is to keep the existing prefix and append `os.Getenv("TF_APPEND_USER_AGENT")` explicitly — happy to switch to that instead.

Before:

```
HashiCorp Terraform/1.14.0 (+https://www.terraform.io) Terraform Plugin SDK/2.40.1 terraform-provider-azuread/3.9.0 HashiCorp/go-azure-sdk (Go-http-client/1.1) pid-222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6
```

After, with `TF_APPEND_USER_AGENT="my-platform/1.0"`:

```
Terraform/1.14.0 (+https://www.terraform.io) Terraform-Plugin-SDK/2.40.1 terraform-provider-azuread/3.9.0 my-platform/1.0 HashiCorp/go-azure-sdk (Go-http-client/1.1) pid-222b7c9b-8f2c-4b8c-9b3f-a1b2c3d4e5f6
```


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

No resource or data source schemas change. The `User-Agent` is set once on the shared Microsoft Graph client in `ClientOptions.Configure`, so this affects every resource and data source at the transport layer only.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Added `TestUserAgent` in `internal/common/client_options_test.go`, a table test covering the base string, the go-azure-sdk agent, `TF_APPEND_USER_AGENT` (set, whitespace-trimmed, empty), `AZURE_HTTP_USER_AGENT` (set, empty), and the ordering of all four components alongside the partner ID. `TestUserAgentAppendedValueIsNotDuplicated` guards against the appended value being added twice.

```
$ go test ./internal/common/...
ok  	github.com/hashicorp/terraform-provider-azuread/internal/common	0.814s
```

These are unit tests requiring no credentials. No acceptance tests were run, as this change does not touch resource behaviour.


## Change Log

* provider: the `User-Agent` header now uses the Terraform Plugin SDK default and honours the `TF_APPEND_USER_AGENT` environment variable [GH-1921]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Closes https://github.com/hashicorp/terraform-provider-azuread/issues/1920

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to access controls, encryption, or logging. The `User-Agent` header gains the contents of an environment variable the operator sets themselves; the existing request/response DEBUG logging is unchanged, including the redaction of the `Authorization` header.
