### PR TITLE
docs: fix import command format for service principals

### DIFF
--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -188,5 +188,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Service principals can be imported using their object ID, e.g.
 
 ```shell
-terraform import azuread_service_principal.example /servicePrincipals/00000000-0000-0000-0000-000000000000
+terraform import azuread_service_principal.example 00000000-0000-0000-0000-000000000000
 ```


### PR DESCRIPTION
## Description

Updated the import command for service principals to remove the leading '/servicePrincipals/'.  Using the full ID 
returns `Error: specified ID ("/servicePrincipals/00000....") is not valid: uuid string is wrong length`
