### PR TITLE
`identitygovernance` - handle missing parents and already-deleted children for entitlement management child resources

### DIFF
--- a/internal/services/identitygovernance/access_package_catalog_role_assignment_resource.go
+++ b/internal/services/identitygovernance/access_package_catalog_role_assignment_resource.go
@@ -142,7 +142,12 @@ func accessPackageCatalogRoleAssignmentResourceDelete(ctx context.Context, d *pl
 
 	id := beta.NewRoleManagementEntitlementManagementRoleAssignmentID(d.Id())
 
-	if _, err := client.DeleteEntitlementManagementRoleAssignment(ctx, id, entitlementmanagementroleassignment.DefaultDeleteEntitlementManagementRoleAssignmentOperationOptions()); err != nil {
+	resp, err := client.DeleteEntitlementManagementRoleAssignment(ctx, id, entitlementmanagementroleassignment.DefaultDeleteEntitlementManagementRoleAssignmentOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[DEBUG] %s already deleted", id)
+			return nil
+		}
 		return tf.ErrorDiagF(err, "Deleting %s", id)
 	}
 

--- a/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_catalog_association_resource.go
@@ -158,6 +158,8 @@ func accessPackageResourceCatalogAssociationResourceRead(ctx context.Context, d 
 		resource = pointer.To((*resp.Model)[0])
 	}
 
+	// Note: this endpoint returns an empty collection rather than a 404 when the parent
+	// catalog does not exist, so this branch also covers a deleted catalog.
 	if resource == nil {
 		log.Printf("[DEBUG] Access Package Resource Catalog Associations was not found - removing from state!")
 		d.SetId("")
@@ -194,8 +196,11 @@ func accessPackageResourceCatalogAssociationResourceDelete(ctx context.Context, 
 		resource = pointer.To((*resp.Model)[0])
 	}
 
+	// The association is already gone, so there is nothing to remove. As above, this also
+	// covers the case where the parent catalog itself has been deleted.
 	if resource == nil {
-		return tf.ErrorDiagF(errors.New("model was nil"), "Retrieving Access Package Resource Catalog Association")
+		log.Printf("[DEBUG] Access Package Resource Catalog Association was not found - already deleted")
+		return nil
 	}
 
 	properties := beta.AccessPackageResourceRequest{

--- a/internal/services/identitygovernance/access_package_resource_package_association_resource.go
+++ b/internal/services/identitygovernance/access_package_resource_package_association_resource.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackage"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackageaccesspackageresourcerolescope"
@@ -175,6 +176,11 @@ func accessPackageResourcePackageAssociationResourceRead(ctx context.Context, d 
 
 	accessPackageResp, err := accessPackageClient.GetEntitlementManagementAccessPackage(ctx, accessPackageId, entitlementmanagementaccesspackage.DefaultGetEntitlementManagementAccessPackageOperationOptions())
 	if err != nil {
+		if response.WasNotFound(accessPackageResp.HttpResponse) {
+			log.Printf("[DEBUG] %s was not found - removing from state!", accessPackageId)
+			d.SetId("")
+			return nil
+		}
 		return tf.ErrorDiagF(err, "Retrieving %s", accessPackageId)
 	}
 
@@ -202,7 +208,12 @@ func accessPackageResourcePackageAssociationResourceDelete(ctx context.Context, 
 
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageIdAccessPackageResourceRoleScopeID(resourceId.AccessPackageId, resourceId.ResourceRoleScopeId)
 
-	if _, err = client.DeleteEntitlementManagementAccessPackageResourceRoleScope(ctx, id, entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultDeleteEntitlementManagementAccessPackageResourceRoleScopeOperationOptions()); err != nil {
+	resp, err := client.DeleteEntitlementManagementAccessPackageResourceRoleScope(ctx, id, entitlementmanagementaccesspackageaccesspackageresourcerolescope.DefaultDeleteEntitlementManagementAccessPackageResourceRoleScopeOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[DEBUG] %s already deleted", id)
+			return nil
+		}
 		return tf.ErrorDiagPathF(err, "id", "Deleting %s", id)
 	}
 

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/common-types/beta"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/identitygovernance/beta/entitlementmanagementaccesspackage"
 	"github.com/hashicorp/go-azure-sdk/sdk/nullable"
@@ -26,6 +27,10 @@ func GetAccessPackageResourcesRoleScope(ctx context.Context, client *entitlement
 	}
 	resp, err := client.GetEntitlementManagementAccessPackage(ctx, accessPackageId, options)
 	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			// The parent access package is gone, so the role scope cannot exist
+			return nil, nil
+		}
 		return nil, fmt.Errorf("retrieving %s: %v", accessPackageId, err)
 	}
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Three entitlement management child resources fail with a hard error when their parent access package or catalog no longer exists, instead of treating the child as gone. Once that happens the resource cannot be removed from state without `terraform state rm`.

Each of the three already contained a correct "not found" branch — the problem was consistently that the absence was turned into an error before it could reach that branch.

* **`azuread_access_package_resource_package_association`** — `Read` and `Delete` now treat a `404` on the parent access package as gone. The role scope is looked up by expanding its parent access package, so `GetAccessPackageResourcesRoleScope` converted the `404` into an error and the existing `roleScope == nil` branch in `Read` was unreachable. The helper now returns `(nil, nil)` on `404`, which is what its trailing `return nil, nil` already means, and `Delete` treats a `404` as a successful delete.

* **`azuread_access_package_resource_catalog_association`** — `Delete` now treats an absent association as already-deleted, matching what its own `Read` already does with the identical condition. Previously the same state that `Read` correctly reported as gone made `Delete` fail with `model was nil`. This one needs no `404` to trigger: deleting an association that has already been removed from the catalog errors out.

* **`azuread_access_package_catalog_role_assignment`** — `Delete` now treats a `404` as a successful delete, consistent with its `Read`, which already did this and is the reference implementation the other changes follow.

One side effect worth flagging: `GetAccessPackageResourcesRoleScope` is also used by the `consistency.WaitForUpdate` poll in the package association's `Create`. A `404` there now returns "not yet present" and keeps polling, rather than failing immediately, so a genuinely missing access package would surface as a `Waiting for creation of ...` timeout instead of the raw `404`. Since `Create` has just succeeded against that access package, a `404` during the poll is a replication artifact and retrying seems the better behaviour — this is adjacent to the replication delay in #1277, though not the same code path. Happy to scope the change to `Read`/`Delete` only if you'd rather not alter `Create`.

Terraform's dependency graph usually hides the first two, because `terraform destroy` tears down in reverse dependency order and the children are destroyed while their parents still exist. They surface when a parent is removed out of band, and on *every* teardown under Crossplane ([crossplane-contrib/provider-upjet-azuread](https://github.com/crossplane-contrib/provider-upjet-azuread), which wraps this provider via upjet), because Crossplane deletes managed resources concurrently with no ordering guarantee. There the child is left with a finalizer that is never removed, since the reconciler's observe never returns "does not exist".

### One correction to the issue as filed

The issue claims `azuread_access_package_resource_catalog_association`'s **`Read`** is also broken by a `404` on the parent catalog. Testing showed that is not the case, so this PR does not change it.

`GET /beta/identityGovernance/entitlementManagement/accessPackageCatalogs/{id}/accessPackageResources` returns **`200` with an empty `value` array** when the catalog does not exist — confirmed including for a catalog GUID that never existed. It does not `404`. That `Read` already handled a deleted parent correctly via its `resource == nil` branch, verified passing against unmodified `main`.

A `response.WasNotFound` guard on that call would therefore be dead code, and worse than inert: it would convert any future `404` from that endpoint into a silent removal from state. I've left a comment at each of the two `resource == nil` branches recording why absence is detected from the empty collection rather than from a status code.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

No documentation changes are needed — this restores the documented/expected provider contract for resources removed outside of Terraform rather than changing any schema or behaviour that is documented today.

**On new tests:** I verified every path below against a real tenant, but with a throwaway harness rather than a committed test, so this PR adds no automated regression coverage. Covering these paths properly needs a "disappears"-style step that deletes a parent out of band mid-test, which the acceptance framework here has no helper for. I did not want to invent that pattern unilaterally in a bug fix. **I'm happy to add it in this PR if you tell me what shape you'd like** — a `data.DisappearsStep`-style helper in `internal/acceptance`, or per-resource `PreConfig` steps using `ResourceTestIgnoreRecreate`.


## Testing

Verified against a live Entra tenant with `EntitlementManagement.ReadWrite.All`, by driving the provider's own Create/Read/Delete functions against real objects. Each scenario was run against unmodified `main`, then against this branch, with nothing else changed.

| Scenario | `main` | This PR |
| --- | --- | --- |
| Role assignment `Delete`, assignment already gone | ❌ `404 EntitlementManagementRoleAssignmentNotFound` | ✅ |
| Package association `Read`, parent access package gone | ❌ `404 AccessPackageNotFound` | ✅ removed from state |
| Package association `Delete`, parent access package gone | ❌ `404 AccessPackageNotFound` | ✅ |
| Catalog association `Delete`, association already removed | ❌ `model was nil` | ✅ |
| Catalog association `Delete`, parent catalog gone | ❌ `model was nil` | ✅ |
| Catalog association `Read`, parent catalog gone | ✅ already correct | ✅ unchanged |

The reproduced errors match those reported in #1923 verbatim.

Existing acceptance tests for the affected resources, run against this branch:

```
--- PASS: TestAccAccessPackageCatalogRoleAssignmentResource_group (49.33s)
--- PASS: TestAccAccessPackageCatalogRoleAssignmentResource_servicePrincipal (26.49s)
--- PASS: TestAccAccessPackageResourceCatalogAssociation_complete (71.88s)
--- PASS: TestAccAccessPackageResourceCatalogAssociation_requiresImport (72.50s)
--- PASS: TestAccAccessPackageResourcePackageAssociation_complete (114.84s)
--- FAIL: TestAccAccessPackageCatalogRoleAssignmentResource_user (49.92s)
```

`_user` fails in post-test destroy with `403` deleting the test user, because the service principal in my test tenant lacks `User.ReadWrite.All`. This is unrelated to these changes — I confirmed it fails identically on unmodified `main`.


## Change Log

* `azuread_access_package_resource_package_association` - treat a missing parent access package as the resource no longer existing during `Read` and `Delete` [GH-1923]
* `azuread_access_package_resource_catalog_association` - treat an already-removed association as a successful `Delete` [GH-1923]
* `azuread_access_package_catalog_role_assignment` - treat a `404` during `Delete` as a successful delete [GH-1923]

I have not touched `CHANGELOG.md`, since entries in this repo appear to be added by maintainers in separate commits.


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1923

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No. These changes only affect how an already-authorized `404`/empty response is interpreted during `Read` and `Delete`. No access controls, encryption, or logging behaviour is changed, and no new API calls are introduced.
