### PR TITLE
azuread_user data source: fix mail lookup error message referencing wrong variable

### DIFF
--- a/internal/services/users/user_data_source.go
+++ b/internal/services/users/user_data_source.go
@@ -382,9 +382,9 @@ func userDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta int
 
 		count := len(*resp.Model)
 		if count > 1 {
-			return tf.ErrorDiagPathF(nil, "mail", "More than one user found with mail: %q", upn)
+			return tf.ErrorDiagPathF(nil, "mail", "More than one user found with mail: %q", mail)
 		} else if count == 0 {
-			return tf.ErrorDiagPathF(err, "mail", "User not found with mail: %q", upn)
+			return tf.ErrorDiagPathF(err, "mail", "User not found with mail: %q", mail)
 		}
 
 		foundObjectId = (*resp.Model)[0].Id


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `mail` lookup branch of the `azuread_user` data source's error handling (`internal/services/users/user_data_source.go`) references the `upn` variable from the earlier `user_principal_name` if/else-if branch instead of the local `mail` variable, in both the "more than one user found" and "user not found" error messages. Since `upn` is unset when looking up by `mail`, these errors always print an empty string, e.g.:

```
Error: User not found with mail: ""
```

regardless of the actual mail address that was searched, which makes troubleshooting failed lookups harder than it needs to be. This seems to be a copy-paste bug — a very similar issue in the neighboring `mail_nickname` branch was already fixed in #995.

This PR simply swaps `upn` for `mail` in those two format arguments. No behavioural change beyond the text of the error messages.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

This change only corrects the text of two error messages (no schema, filter, or control-flow changes), so no new test coverage was added.  Existing acceptance tests for the `mail` lookup path are unaffected since they don't assert on error message content.

I validated the change with `gofmt -l` / `gofmt -d` (no issues). I was not able to run the full module `go vet`/test suite locally.

Happy to address any CI feedback.


## Change Log

* `azuread_user` data source - fix `mail` lookup error messages so they report the actual mail value instead of an empty string


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
N/A - no existing issue was filed for this; found and traced to this copy-paste bug while troubleshooting an unrelated `mail` lookup failure.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this PR — it only corrects the text of an error message.
