### PR TITLE
Add ProvisionSiteOnDemand constant for group behavior options

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -119,7 +119,7 @@ The following arguments are supported:
 
 ~> **Known Permissions Issue** The `auto_subscribe_new_members` property can only be set when authenticating as a Member user of the tenant and _not_ when authenticating as a Guest user or as a service principal. Please see the [Microsoft Graph Known Issues](https://docs.microsoft.com/en-us/graph/known-issues#groups) documentation.
 
-* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
+* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `CalendarMemberReadOnly`, `ConnectorsDisabled`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers`, `WelcomeEmailDisabled` and `ProvisionSiteOnDemand`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
 * `description` - (Optional) The description for the group.
 * `display_name` - (Required) The display name for the group.
 * `dynamic_membership` - (Optional) A `dynamic_membership` block as documented below. Required when `types` contains `DynamicMembership`. Cannot be used with the `members` property.

--- a/docs/resources/group_without_members.md
+++ b/docs/resources/group_without_members.md
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 ~> **Known Permissions Issue** The `auto_subscribe_new_members` property can only be set when authenticating as a Member user of the tenant and _not_ when authenticating as a Guest user or as a service principal. Please see the [Microsoft Graph Known Issues](https://docs.microsoft.com/en-us/graph/known-issues#groups) documentation.
 
-* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers` and `WelcomeEmailDisabled`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
+* `behaviors` - (Optional) A set of behaviors for a Microsoft 365 group. Possible values are `AllowOnlyMembersToPost`, `CalendarMemberReadOnly`, `ConnectorsDisabled`, `HideGroupInOutlook`, `SkipExchangeInstantOn`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers`, `WelcomeEmailDisabled` and `ProvisionSiteOnDemand`. See [official documentation](https://docs.microsoft.com/en-us/graph/group-set-options) for more details. Changing this forces a new resource to be created.
 * `description` - (Optional) The description for the group.
 * `display_name` - (Required) The display name for the group.
 * `dynamic_membership` - (Optional) A `dynamic_membership` block as documented below. Required when `types` contains `DynamicMembership`. Cannot be used with the `members` property.

--- a/internal/services/groups/constants.go
+++ b/internal/services/groups/constants.go
@@ -24,6 +24,7 @@ const (
 	GroupResourceBehaviorOptionSubscribeMembersToCalendarEventsDisabled = "SubscribeMembersToCalendarEventsDisabled"
 	GroupResourceBehaviorOptionSubscribeNewGroupMembers                 = "SubscribeNewGroupMembers"
 	GroupResourceBehaviorOptionWelcomeEmailDisabled                     = "WelcomeEmailDisabled"
+	GroupResourceBehaviorOptionProvisionSiteOnDemand                    = "ProvisionSiteOnDemand"
 )
 
 var possibleValuesForGroupResourceBehaviorOptions = []string{
@@ -35,6 +36,7 @@ var possibleValuesForGroupResourceBehaviorOptions = []string{
 	GroupResourceBehaviorOptionSubscribeMembersToCalendarEventsDisabled,
 	GroupResourceBehaviorOptionSubscribeNewGroupMembers,
 	GroupResourceBehaviorOptionWelcomeEmailDisabled,
+	GroupResourceBehaviorOptionProvisionSiteOnDemand,
 }
 
 const (

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -770,13 +770,13 @@ resource "azuread_group" "test" {
 
   behaviors = [
     "AllowOnlyMembersToPost",
-	"CalendarMemberReadOnly",
-	"ConnectorsDisabled",
+    "CalendarMemberReadOnly",
+    "ConnectorsDisabled",
     "HideGroupInOutlook",
-	"SubscribeMembersToCalendarEventsDisabled",
+    "SubscribeMembersToCalendarEventsDisabled",
     "SubscribeNewGroupMembers",
     "WelcomeEmailDisabled",
-	"ProvisionSiteOnDemand"
+    "ProvisionSiteOnDemand"
   ]
 }
 `, data.RandomInteger)

--- a/internal/services/groups/group_resource_test.go
+++ b/internal/services/groups/group_resource_test.go
@@ -770,9 +770,13 @@ resource "azuread_group" "test" {
 
   behaviors = [
     "AllowOnlyMembersToPost",
+	"CalendarMemberReadOnly",
+	"ConnectorsDisabled",
     "HideGroupInOutlook",
+	"SubscribeMembersToCalendarEventsDisabled",
     "SubscribeNewGroupMembers",
-    "WelcomeEmailDisabled"
+    "WelcomeEmailDisabled",
+	"ProvisionSiteOnDemand"
   ]
 }
 `, data.RandomInteger)

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -658,13 +658,13 @@ resource "azuread_group_without_members" "test" {
 
   behaviors = [
     "AllowOnlyMembersToPost",
-	"CalendarMemberReadOnly",
-	"ConnectorsDisabled",
+    "CalendarMemberReadOnly",
+    "ConnectorsDisabled",
     "HideGroupInOutlook",
-	"SubscribeMembersToCalendarEventsDisabled",
+    "SubscribeMembersToCalendarEventsDisabled",
     "SubscribeNewGroupMembers",
     "WelcomeEmailDisabled",
-	"ProvisionSiteOnDemand"
+    "ProvisionSiteOnDemand"
   ]
 }
 `, data.RandomInteger)

--- a/internal/services/groups/group_without_members_resource_test.go
+++ b/internal/services/groups/group_without_members_resource_test.go
@@ -658,9 +658,13 @@ resource "azuread_group_without_members" "test" {
 
   behaviors = [
     "AllowOnlyMembersToPost",
+	"CalendarMemberReadOnly",
+	"ConnectorsDisabled",
     "HideGroupInOutlook",
+	"SubscribeMembersToCalendarEventsDisabled",
     "SubscribeNewGroupMembers",
-    "WelcomeEmailDisabled"
+    "WelcomeEmailDisabled",
+	"ProvisionSiteOnDemand"
   ]
 }
 `, data.RandomInteger)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
This PR makes the `ProvisionSiteOnDemand` option available to use within the `behaviors` field of `azuread_group` and `azuread_group_without_members` resources.

This option is documented as available here https://learn.microsoft.com/en-us/graph/group-set-options#resource-behavior-options

Issue #1867 requires this change.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azuread_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #1867 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to Security Controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
