### PR TITLE
ci: typos spell check, reviewer assignment, size labeler tweak, depscheck on Go changes, pin all tooling and actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,7 +52,8 @@ Concretely:
   names** (`workflow_run` matches names, not filenames), downloads the artifact,
   and adds the `waiting-response` label.
 - The same pattern powers the review flow: `pr-reviewed.yaml` uploads the
-  reviewer/state artifact, `pr-waiting-response-on-review.yaml` applies it.
+  reviewer/state artifact; `pr-waiting-response-on-review.yaml` applies the
+  label and `pr-assign-reviewer.yaml` assigns the reviewer on changes-requested.
 
 **When adding a new PR check**: if its failure should mark the PR
 `waiting-response`, the check must (a) call `pr-save-artifacts.yaml` on failure
@@ -78,7 +79,7 @@ arbitrary PR number.
 
 - `workflow_run` triggers reference workflow **display names** — renaming a
   workflow's `name:` silently breaks its consumers (`pr-waiting-response-on-ci-fail.yaml`,
-  `pr-waiting-response-on-review.yaml`).
+  `pr-waiting-response-on-review.yaml`, `pr-assign-reviewer.yaml`).
 - Reusable workflows (`pr-save-artifacts.yaml`, `pr-comment-failure*.yaml`,
   `issue-remove-label.yaml`) are referenced by **file path** in `uses:` lines.
 - `teamcity-test.yaml` has a self-referencing `paths:` trigger that must be

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,6 @@ jobs:
           {
             echo "### What's next?"
             echo "#### For a release branch (see \`.release/ci.hcl\`)"
-            echo "After this \`build\` workflow run completes succesfully, you can expect the CRT \`prepare\` workflow to begin momentarily."
+            echo "After this \`build\` workflow run completes successfully, you can expect the CRT \`prepare\` workflow to begin momentarily."
             echo "To find the \`prepare\` workflow run, [view the checks for this commit]($github_dot_com/$owner_with_name/commits/$ref)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && endsWith(github.event.comment.body, '/wr')
     steps:
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/issue-lock-threads.yaml
+++ b/.github/workflows/issue-lock-threads.yaml
@@ -17,16 +17,16 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ github.token }}
-          issue-lock-comment: >
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '30'
-          pr-lock-comment: >
+          issue-inactive-days: '30'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active contributions.
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '30'
+          pr-inactive-days: '30'

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -15,7 +15,7 @@ jobs:
   issue_triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: github/issue-labeler@ccca1e16fcb66762200e616fc29b57b940c1cb67 # v3.5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/issue-remove-label.yaml
+++ b/.github/workflows/issue-remove-label.yaml
@@ -21,7 +21,7 @@ jobs:
   remove-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REMOVE_LABEL: ${{ inputs.label-name }}
         with:

--- a/.github/workflows/main-checks.yaml
+++ b/.github/workflows/main-checks.yaml
@@ -75,7 +75,8 @@ jobs:
           # golangci-lint version is sourced from scripts/.custom-gcl.yml - the single source of truth
           GOLANGCI_LINT_VERSION="$(sed -n 's/^version: *//p' scripts/.custom-gcl.yml)"
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "$GOLANGCI_LINT_VERSION"
-          go install github.com/katbyte/terrafmt@latest
+          # terrafmt version is pinned in the GNUmakefile (TERRAFMT_VERSION)
+          go install "github.com/katbyte/terrafmt@$(sed -n 's/^TERRAFMT_VERSION := //p' GNUmakefile)"
       - run: make quick-checks
 
   docs-lint:

--- a/.github/workflows/main-checks.yaml
+++ b/.github/workflows/main-checks.yaml
@@ -46,8 +46,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - name: Build Provider
@@ -56,8 +56,8 @@ jobs:
   depscheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -66,8 +66,8 @@ jobs:
   quick-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - name: Install tooling
@@ -81,8 +81,8 @@ jobs:
   docs-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -91,15 +91,15 @@ jobs:
   golint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       # The tfproviderlint module plugin requires a custom-built golangci-lint binary (see
       # scripts/.custom-gcl.yml); cache it so it is only rebuilt when the plugin config (which
       # pins the golangci-lint version) changes. The make target rebuilds the binary when it
       # is missing or its version is stale.
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: scripts/golangci-with-modules
           key: golangci-with-modules-${{ hashFiles('scripts/.custom-gcl.yml') }}
@@ -111,8 +111,8 @@ jobs:
   gencheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -121,8 +121,8 @@ jobs:
   unit-tests:
     runs-on: custom-linux-large
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make test
@@ -132,15 +132,26 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run ShellCheck
         run: make shellcheck
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Install typos
+        run: |
+          v="$(sed -n 's/^TYPOS_VERSION := //p' GNUmakefile)"
+          curl -sSfL "https://github.com/crate-ci/typos/releases/download/${v}/typos-${v}-x86_64-unknown-linux-musl.tar.gz" | tar -xz -C /usr/local/bin ./typos
+      - name: Run typos
+        run: make typos
 
   validate-examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -149,13 +160,13 @@ jobs:
   teamcity-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: zulu
           java-version: 21
           java-package: jdk
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/milestone-closed.yaml
+++ b/.github/workflows/milestone-closed.yaml
@@ -16,7 +16,7 @@ jobs:
   Comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: bflad/action-milestone-comment@ae6c9fdf5778064d4e09b4632604a16b7289096c # v1.0.2
+      - uses: bflad/action-milestone-comment@4618cbf8bf938d31af1c576beeaaa77f486f5af3 # v2.0.0
         with:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.

--- a/.github/workflows/milestone-increment.yaml
+++ b/.github/workflows/milestone-increment.yaml
@@ -17,7 +17,7 @@ jobs:
   increment-milestone:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/milestone-link.yaml
+++ b/.github/workflows/milestone-link.yaml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           # we cannot use go-version-file here because no repositories are checked out so there is no file to reference
           go-version: '1.25.3'

--- a/.github/workflows/milestone-link.yaml
+++ b/.github/workflows/milestone-link.yaml
@@ -25,7 +25,8 @@ jobs:
           # we cannot use go-version-file here because no repositories are checked out so there is no file to reference
           go-version: '1.25.3'
       - run: |
-          go install github.com/stephybun/link-milestone@latest
+          # link-milestone has no tagged releases, so pin to a commit
+          go install github.com/stephybun/link-milestone@1e48f06f81570d223831a9fca0fd8bb0ad11c7da
           link-milestone
         env:
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/pr-assign-reviewer.yaml
+++ b/.github/workflows/pr-assign-reviewer.yaml
@@ -1,0 +1,62 @@
+name: Assign Reviewer as Assignee
+
+# When a review requests changes, assigns the reviewer as a PR assignee. Runs via
+# workflow_run on the "Pull Request Reviewed" display name (pr-reviewed.yaml) and
+# reads its wr_actions artifact, since the review event itself has no write token
+# for fork PRs (see the artifact relay in README.md).
+
+on:
+  workflow_run:
+    workflows:
+      - "Pull Request Reviewed"
+    types:
+      - completed
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Artifact
+        id: get_artifact
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: env_vars
+        id: env_vars
+        if: steps.get_artifact.outcome == 'success'
+        run: |
+          {
+            echo "reviewer=$(cat artifact/reviewer.txt)"
+            echo "reviewState=$(cat artifact/reviewstate.txt)"
+            echo "prNumber=$(cat artifact/prnumber.txt)"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Assign the reviewer as assignee when changes are requested
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const reviewer = '${{ steps.env_vars.outputs.reviewer }}';
+            const prNumber = parseInt('${{ steps.env_vars.outputs.prNumber }}', 10);
+            const reviewState = '${{ steps.env_vars.outputs.reviewState }}';
+            const repo = '${{ github.event.repository.name }}';
+            const owner = '${{ github.event.repository.owner.login }}';
+
+            if (reviewState === 'changes_requested') {
+              console.log(`Assigning reviewer: ${reviewer} to PR #${prNumber} as changes were requested.`);
+              await github.rest.issues.addAssignees({
+                owner: owner,
+                repo: repo,
+                issue_number: prNumber,
+                assignees: [reviewer],
+              });
+            } else {
+              console.log(`No action taken. Review state is '${reviewState}'.`);
+            }

--- a/.github/workflows/pr-check-markdown.yaml
+++ b/.github/workflows/pr-check-markdown.yaml
@@ -24,7 +24,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Install markdownlint-cli2
         run: npm install -g markdownlint-cli2@0.23.2
       - run: make markdownlint

--- a/.github/workflows/pr-checks-combined.yaml
+++ b/.github/workflows/pr-checks-combined.yaml
@@ -53,7 +53,7 @@ jobs:
       examples: ${{ steps.filter.outputs.examples }}
       scripts: ${{ steps.filter.outputs.scripts }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         id: filter
         with:
@@ -80,11 +80,11 @@ jobs:
 
   depscheck:
     needs: paths-filter
-    if: needs.paths-filter.outputs.vendor == 'true'
+    if: needs.paths-filter.outputs.vendor == 'true' || needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -124,8 +124,8 @@ jobs:
     if: needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - name: Install tooling
@@ -170,8 +170,8 @@ jobs:
     if: needs.paths-filter.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -211,7 +211,7 @@ jobs:
     if: needs.paths-filter.outputs.scripts == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run ShellCheck
         run: make shellcheck
       - name: Guidance on failure
@@ -242,6 +242,46 @@ jobs:
     with:
       check_name: "ShellCheck Scripts"
 
+  # ------------------------------------------
+
+  typos:
+    needs: paths-filter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Install typos
+        run: |
+          v="$(sed -n 's/^TYPOS_VERSION := //p' GNUmakefile)"
+          curl -sSfL "https://github.com/crate-ci/typos/releases/download/${v}/typos-${v}-x86_64-unknown-linux-musl.tar.gz" | tar -xz -C /usr/local/bin ./typos
+      - name: Run typos
+        run: make typos
+      - name: Guidance on failure
+        if: failure()
+        run: |
+          echo "::error::typos found spelling errors."
+          echo ""
+          echo "Run 'make typos' locally to reproduce and 'make typos-fix' to fix them."
+          echo "False positives (Azure names, API enum values) go in .typos.toml."
+
+  typos-save-artifacts:
+    needs: typos
+    if: always() && needs.typos.result == 'failure'
+    uses: ./.github/workflows/pr-save-artifacts.yaml
+
+  typos-on-fail:
+    needs: typos
+    if: always() && needs.typos.result == 'failure'
+    uses: ./.github/workflows/pr-comment-failure.yaml
+    with:
+      check_name: "Typos"
+
+  typos-on-success:
+    needs: typos
+    if: always() && needs.typos.result == 'success'
+    uses: ./.github/workflows/pr-comment-failure-outdated.yaml
+    with:
+      check_name: "Typos"
+
   # ==========================================
   # Phase 2 & 3: Heavy Checks
   # ==========================================
@@ -257,8 +297,8 @@ jobs:
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - name: Build Provider
@@ -302,15 +342,15 @@ jobs:
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       # The tfproviderlint module plugin requires a custom-built golangci-lint binary (see
       # scripts/.custom-gcl.yml); cache it so it is only rebuilt when the plugin config (which
       # pins the golangci-lint version) changes. The make target rebuilds the binary when it
       # is missing or its version is stale.
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: scripts/golangci-with-modules
           key: golangci-with-modules-${{ hashFiles('scripts/.custom-gcl.yml') }}
@@ -362,8 +402,8 @@ jobs:
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -408,8 +448,8 @@ jobs:
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped')
     runs-on: custom-linux-large
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make test
@@ -457,8 +497,8 @@ jobs:
       (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: .go-version
       - run: make tools
@@ -521,15 +561,15 @@ jobs:
     if: needs.secrets-check.outputs.available == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ./.go-version
 
       - name: Azure CLI login (using OIDC)
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@a641126d1b8aa4d1fa005f4f92df94a3a4c4c906 # v3.1.0
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}

--- a/.github/workflows/pr-checks-combined.yaml
+++ b/.github/workflows/pr-checks-combined.yaml
@@ -133,7 +133,8 @@ jobs:
           # golangci-lint version is sourced from scripts/.custom-gcl.yml - the single source of truth
           GOLANGCI_LINT_VERSION="$(sed -n 's/^version: *//p' scripts/.custom-gcl.yml)"
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "$GOLANGCI_LINT_VERSION"
-          go install github.com/katbyte/terrafmt@latest
+          # terrafmt version is pinned in the GNUmakefile (TERRAFMT_VERSION)
+          go install "github.com/katbyte/terrafmt@$(sed -n 's/^TERRAFMT_VERSION := //p' GNUmakefile)"
       - run: make quick-checks
       - name: Guidance on failure
         if: failure()

--- a/.github/workflows/pr-comment-failure-outdated.yaml
+++ b/.github/workflows/pr-comment-failure-outdated.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Strike through fixed failure and clean up
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           retries: 3

--- a/.github/workflows/pr-comment-failure.yaml
+++ b/.github/workflows/pr-comment-failure.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           echo "gha_url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" >> "$GITHUB_ENV"
       - name: Add failure to unified build comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           retries: 3
@@ -49,6 +49,7 @@ jobs:
               'Generation Check': 'Run `make generate` locally to regenerate any auto-generated code, then commit the resulting changes.',
               'GoLang Compilation': 'Run `go build` or `make build` locally to reproduce and fix compilation errors.',
               'ShellCheck Scripts': 'Run `make shellcheck` locally to check shell scripts for issues and fix any warnings or errors.',
+              'Typos': 'Run `make typos` locally to find spelling errors in code, docs and examples, and `make typos-fix` to fix them. Add false positives (Azure names, API enum values) to `.typos.toml`.',
               'Unit Tests': 'Run `make test` locally to reproduce and fix the failing unit tests.',
               'Validate Examples': 'Run `make validate-examples` locally to check that your example Terraform configurations under `examples/` are valid.',
               'TeamCity Config Test': 'Run `make teamcity-test` locally (requires Java 21 and Maven) to validate the TeamCity Kotlin DSL under `.teamcity/`.',

--- a/.github/workflows/pr-label-size.yaml
+++ b/.github/workflows/pr-label-size.yaml
@@ -14,7 +14,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           configuration-path: .github/labeler-pull-request-triage.yaml
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -32,3 +32,6 @@ jobs:
           l_max_size: '300'
           xl_label: 'size/XL'
           message_if_xl: ''
+          files_to_ignore: |
+            "vendor/*"
+            "go.mod"

--- a/.github/workflows/pr-reviewed.yaml
+++ b/.github/workflows/pr-reviewed.yaml
@@ -3,9 +3,9 @@ name: "Pull Request Reviewed"
 
 # Untrusted half of the review relay (see README.md): on every submitted review,
 # uploads reviewer/state/PR-number as the wr_actions artifact. Consumed by
-# pr-waiting-response-on-review.yaml, whose workflow_run trigger matches this
-# workflow's display name ("Pull Request Reviewed") - renaming the name: above
-# breaks it.
+# pr-waiting-response-on-review.yaml and pr-assign-reviewer.yaml, whose
+# workflow_run triggers match this workflow's display name ("Pull Request
+# Reviewed") - renaming the name: above breaks both.
 
 on:
   pull_request_review:
@@ -18,27 +18,29 @@ jobs:
   add-or-remove-waiting-response:
     runs-on: ubuntu-latest
     steps:
-      - name: "Set Artifacts for add-waiting-response"
-        if: github.event.review.state != 'approved' && github.actor != github.event.pull_request.user.login
+      - name: "Set Artifacts"
         shell: bash
         run: |
           mkdir -p wr_actions
           echo ${{ github.repository_owner }} > wr_actions/ghowner.txt
           echo ${{ github.event.repository.name }} > wr_actions/ghrepo.txt
           echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
+          echo ${{ github.event.review.user.login }} > wr_actions/reviewer.txt
+          echo ${{ github.event.review.state }} > wr_actions/reviewstate.txt
+
+      - name: "Set Artifacts for add-waiting-response"
+        if: github.event.review.state != 'approved' && github.actor != github.event.pull_request.user.login
+        shell: bash
+        run: |
           echo "add-waiting-response" > wr_actions/action.txt
 
       - name: "Set Artifacts for remove-waiting-response"
         if: github.actor == github.event.pull_request.user.login
         shell: bash
         run: |
-          mkdir -p wr_actions
-          echo ${{ github.repository_owner }} > wr_actions/ghowner.txt
-          echo ${{ github.event.repository.name }} > wr_actions/ghrepo.txt
-          echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
           echo "remove-waiting-response" > wr_actions/action.txt
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact
           path: wr_actions

--- a/.github/workflows/pr-save-artifacts.yaml
+++ b/.github/workflows/pr-save-artifacts.yaml
@@ -24,7 +24,7 @@ jobs:
           echo ${{ github.repository_owner }} > wr_actions/ghowner.txt
           echo ${{ github.event.repository.name }} > wr_actions/ghrepo.txt
           echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact
           path: wr_actions

--- a/.github/workflows/pr-waiting-response-on-ci-fail.yaml
+++ b/.github/workflows/pr-waiting-response-on-ci-fail.yaml
@@ -39,7 +39,7 @@ jobs:
             echo "prnumber=$(cat artifact/prnumber.txt)"
           } >> "${GITHUB_OUTPUT}"
       - name: Add waiting-response on fail
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/pr-waiting-response-on-review.yaml
+++ b/.github/workflows/pr-waiting-response-on-review.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Get Artifact
         id: get_artifact
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           run_id: ${{ github.event.workflow_run.id }}
@@ -45,7 +45,7 @@ jobs:
             echo "artifact_outcome=success"
           } >> "${GITHUB_OUTPUT}"
 
-  add-waiting-reponse:
+  add-waiting-response:
     needs: add-or-remove-waiting-response
     runs-on: ubuntu-latest
     if: needs.add-or-remove-waiting-response.outputs.artifact_outcome == 'success' && needs.add-or-remove-waiting-response.outputs.action == 'add-waiting-response'
@@ -53,7 +53,7 @@ jobs:
       - run: |
           curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ needs.add-or-remove-waiting-response.outputs.ghowner }}/${{ needs.add-or-remove-waiting-response.outputs.ghrepo }}/issues/${{ needs.add-or-remove-waiting-response.outputs.prnumber }}/labels" -d '{"labels":["waiting-response"]}'
 
-  remove-waiting-reponse:
+  remove-waiting-response:
     needs: add-or-remove-waiting-response
     if: needs.add-or-remove-waiting-response.outputs.artifact_outcome == 'success' && needs.add-or-remove-waiting-response.outputs.action == 'remove-waiting-response'
     uses: ./.github/workflows/issue-remove-label.yaml

--- a/.github/workflows/teamcity-remove-label-on-commit.yaml
+++ b/.github/workflows/teamcity-remove-label-on-commit.yaml
@@ -22,7 +22,7 @@ jobs:
       PASSED_LABEL: teamcity-passed
     steps:
       - name: Check for TeamCity labels and apply outdated label
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/teamcity-run-tests-on-comment.yaml
+++ b/.github/workflows/teamcity-run-tests-on-comment.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Check team membership
         id: check-membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_MEMEBERSHIP_CHECK_TOKEN }}
           script: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check allowed users list
         id: check-allowed-user
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TCTEST_ALLOWED_USERS: ${{ secrets.TCTEST_ALLOWED_USERS }}
         with:
@@ -109,13 +109,13 @@ jobs:
       TCTEST_REPO: terraform-providers/terraform-provider-azuread
     steps:
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.26'
 
       - name: Cache tctest binary
         id: cache-tctest
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/go/bin/tctest
           # keep this key in sync with the pinned version installed below
@@ -128,7 +128,7 @@ jobs:
 
       - name: Get PR commit SHA
         id: get-pr-sha
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -241,7 +241,7 @@ jobs:
 
       - name: Comment on success
         if: success()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILDS_JSON: ${{ steps.run-tctest.outputs.builds }}
         with:
@@ -307,7 +307,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TCTEST_ERRORS: ${{ steps.run-tctest.outputs.errors }}
         with:
@@ -354,7 +354,7 @@ jobs:
     if: needs.check-team-membership.outputs.is-team-member == 'false' && needs.check-team-membership.outputs.is-allowed-user == 'false'
     steps:
       - name: Comment unauthorized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/teamcity-test.yaml
+++ b/.github/workflows/teamcity-test.yaml
@@ -27,13 +27,13 @@ jobs:
   teamcity-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: zulu
           java-version: 21
           java-package: jdk
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/workflow-actionlint.yml
+++ b/.github/workflows/workflow-actionlint.yml
@@ -25,8 +25,8 @@ jobs:
   workflow-actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ./.go-version
           cache: false

--- a/.github/workflows/workflow-yamllint.yml
+++ b/.github/workflows/workflow-yamllint.yml
@@ -24,5 +24,5 @@ jobs:
   workflow-yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - run: make yamllint

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,54 @@
+# Configuration for typos (https://github.com/crate-ci/typos), run by `make typos` and the typos job in
+# .github/workflows/pr-checks-combined.yaml. It checks every file type and splits identifiers, so
+# misspelled function and variable names are caught as well as prose. It stays on the default locale
+# because UK and US spellings both appear in the provider.
+
+[files]
+ignore-hidden = false # the default skips dotfiles, which would leave .github/ workflows unchecked
+extend-exclude = [
+  ".git/",
+  ".idea/",
+  "**/vendor/",
+  "**/go.sum",
+]
+
+[default]
+extend-ignore-re = [
+  '[A-Za-z0-9+/=_-]{30,}', # base64 blobs, certificates, storage ids
+  '`[A-Z]{2}`',            # ISO country / region codes listed in docs
+]
+
+[default.extend-words]
+# names and abbreviations typos would otherwise "correct"
+aks = "aks"             # Azure Kubernetes Service (workload identity auth)
+hdinsight = "hdinsight" # misspell ignore entry in .golangci.yml / GNUmakefile
+hashi = "hashi"
+decorder = "decorder"   # golangci linter name
+copywrite = "copywrite" # .copywrite.hcl, the tool's own name
+
+# corrections typos' dictionary lacks but codespell caught in this repo: contractions written without
+# the apostrophe, run-together words and a few plain misspellings
+doesnt = "doesn't"
+dont = "don't"
+isnt = "isn't"
+cant = "can't"
+wont = "won't"
+couldt = "couldn't"
+theres = "there's"
+everytime = "every time"
+forthe = "for the"
+loner = "longer"
+manged = "managed"
+manger = "manager"
+followings = "following"
+implementor = "implementer"
+scrips = "scripts"
+dependant = "dependent"
+existant = "existent"
+tthe = "the"
+
+[default.extend-identifiers]
+# misspelled field name in the plugin SDK that the provider has to use as-is
+ContinuousTargetOccurence = "ContinuousTargetOccurence"
+# the GitHub Actions secret is named with this typo in the repository settings (shared with azurerm)
+GH_MEMEBERSHIP_CHECK_TOKEN = "GH_MEMEBERSHIP_CHECK_TOKEN"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ BUG FIXES:
 FEATURES:
 * **New Resource:** `azuread_flexible_federated_identity_credential`  ([#1788](https://github.com/hashicorp/terraform-provider-azuread/issues/1788))
 
-EHANCEMENTS:
+ENHANCEMENTS:
 
 * Dependencies: `go-azure-sdk` updated to `v0.20251029.1173336` ([#1787](https://github.com/hashicorp/terraform-provider-azuread/issues/1787))
 * Dependencies: `Go` updated to `v1.25.3` ([#1792](https://github.com/hashicorp/terraform-provider-azuread/issues/1792))
@@ -1372,7 +1372,7 @@ IMPROVEMENTS:
 * validation: adding validation to all fields ([#30](https://github.com/hashicorp/terraform-provider-azuread/issues/30))
 * `azuread_application` - support for `required_resource_access` property ([#23](https://github.com/hashicorp/terraform-provider-azuread/issues/23))
 * `azuread_service_principal` - support for the `tags` property ([#31](https://github.com/hashicorp/terraform-provider-azuread/issues/31))
-* `azuread_service_principal_password` - support for realitive ends dates with the `end_date_relative` property ([#53](https://github.com/hashicorp/terraform-provider-azuread/issues/53))
+* `azuread_service_principal_password` - support for relative ends dates with the `end_date_relative` property ([#53](https://github.com/hashicorp/terraform-provider-azuread/issues/53))
 
 BUG FIXES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,8 @@ TF_SCHEMA_PANIC_ON_ERROR=1
 # else, including the CI workflows, derives it from that file.
 GOLANGCI_LINT_VERSION := $(shell sed -n 's/^version: *//p' scripts/.custom-gcl.yml)
 
+TYPOS_VERSION := v1.50.1
+
 # The single source of truth for the actionlint version is the go install pin
 # in .github/workflows/workflow-actionlint.yml.
 ACTIONLINT_VERSION := $(shell sed -n 's/.*actionlint\/cmd\/actionlint@//p' .github/workflows/workflow-actionlint.yml)
@@ -115,6 +117,16 @@ tfproviderlint: golangci-with-modules ## Check terraform schema definitions with
 	@echo "==> Checking terraform schemas with tfproviderlint (via golangci-lint)..."
 	@./scripts/golangci-with-modules run -v --enable-only tfproviderlint ./...
 
+typos: ## Check spelling in code, docs and examples with typos (config in .typos.toml)
+	@command -v typos >/dev/null || (echo "typos not installed. Install via: brew install typos-cli (macOS) or see https://github.com/crate-ci/typos/releases/tag/$(TYPOS_VERSION)" && exit 1)
+	@echo "==> Checking spelling with typos..."
+	@typos || \
+		(echo; echo "Spelling errors found. Fix them with 'make typos-fix', or add false positives (Azure names, enum values) to .typos.toml."; exit 1)
+
+typos-fix: ## Fix spelling errors found by typos
+	@command -v typos >/dev/null || (echo "typos not installed. Install via: brew install typos-cli (macOS) or see https://github.com/crate-ci/typos/releases/tag/$(TYPOS_VERSION)" && exit 1)
+	@typos --write-changes
+
 yamllint: ## Check YAML files with yamllint (config in .yamllint.yml)
 	@command -v yamllint >/dev/null || (echo "yamllint not installed. Install via: brew install yamllint (macOS) or pip install yamllint" && exit 1)
 	@echo "==> Checking YAML files with yamllint..."
@@ -186,4 +198,4 @@ todo: ## List all TODOs in the codebase
 
 pr-check: generate build test lint docs-lint ## Run the same set of checks CI runs against a PR
 
-.PHONY: default help tools build debug fmt goimports quick-checks fmtcheck terrafmt generate lint lint-fix golangci-with-modules actionlint yamllint markdownlint shellcheck depscheck gencheck tfproviderlint tflint test testacc acctests debugacc docs-lint validate-examples teamcity-test todo pr-check
+.PHONY: default help tools build debug fmt goimports quick-checks fmtcheck terrafmt generate lint lint-fix golangci-with-modules actionlint yamllint markdownlint typos typos-fix shellcheck depscheck gencheck tfproviderlint tflint test testacc acctests debugacc docs-lint validate-examples teamcity-test todo pr-check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,6 +9,13 @@ GOLANGCI_LINT_VERSION := $(shell sed -n 's/^version: *//p' scripts/.custom-gcl.y
 
 TYPOS_VERSION := v1.50.1
 
+# Go tools installed by 'make tools'. terrafmt is also installed by the quick-checks CI
+# jobs, which sed its version out of this file.
+MISSPELL_VERSION := v0.3.4
+TFPROVIDERDOCS_VERSION := v0.12.1
+TERRAFMT_VERSION := v1.0.1
+GOFUMPT_VERSION := v0.12.0
+
 # The single source of truth for the actionlint version is the go install pin
 # in .github/workflows/workflow-actionlint.yml.
 ACTIONLINT_VERSION := $(shell sed -n 's/.*actionlint\/cmd\/actionlint@//p' .github/workflows/workflow-actionlint.yml)
@@ -32,10 +39,10 @@ tflint: ## renamed to tfproviderlint
 ##@ Build & Generate
 tools: ## Install the tools required to develop the provider
 	@echo "==> installing required tooling..."
-	go install github.com/client9/misspell/cmd/misspell@latest
-	go install github.com/bflad/tfproviderdocs@latest
-	go install github.com/katbyte/terrafmt@latest
-	go install mvdan.cc/gofumpt@latest
+	go install github.com/client9/misspell/cmd/misspell@$(MISSPELL_VERSION)
+	go install github.com/bflad/tfproviderdocs@$(TFPROVIDERDOCS_VERSION)
+	go install github.com/katbyte/terrafmt@$(TERRAFMT_VERSION)
+	go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 	go install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 	@$(MAKE) golangci-with-modules

--- a/docs/data-sources/group_role_management_policy.md
+++ b/docs/data-sources/group_role_management_policy.md
@@ -31,7 +31,7 @@ data "azuread_group_role_management_policy" "owners_policy" {
 ## Argument Reference
 
 * `group_id` - (Required) The ID of the Azure AD group for which the policy applies.
-* `role_id` - (Required) The type of assignment this policy coveres. Can be either `member` or `owner`.
+* `role_id` - (Required) The type of assignment this policy covers. Can be either `member` or `owner`.
 
 ## Attributes Reference
 

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 * `ignore_missing` - (Optional) Ignore missing groups and return groups that were found. The data source will still fail if no groups are found. Cannot be specified with `return_all`. Defaults to `false`.
 * `mail_enabled` - (Optional) Whether the returned groups should be mail-enabled. By itself this does not exclude security-enabled groups. Setting this to `true` ensures all groups are mail-enabled, and setting to `false` ensures that all groups are _not_ mail-enabled. To ignore this filter, omit the property or set it to null. Cannot be specified together with `object_ids`.
 * `object_ids` - (Optional) The object IDs of the groups.
-* `return_all` - (Optional) A flag to denote if all groups should be fetched and returned. Cannot be specified wth `ignore_missing`. Defaults to `false`.
+* `return_all` - (Optional) A flag to denote if all groups should be fetched and returned. Cannot be specified with `ignore_missing`. Defaults to `false`.
 * `security_enabled` - (Optional) Whether the returned groups should be security-enabled. By itself this does not exclude mail-enabled groups. Setting this to `true` ensures all groups are security-enabled, and setting to `false` ensures that all groups are _not_ security-enabled. To ignore this filter, omit the property or set it to null. Cannot be specified together with `object_ids`.
 
 ~> One of `display_names`, `display_name_prefix`, `object_ids` or `return_all` should be specified. Either `display_name` or `object_ids` _may_ be specified as an empty list, in which case no results will be returned.

--- a/docs/resources/group_role_management_policy.md
+++ b/docs/resources/group_role_management_policy.md
@@ -63,7 +63,7 @@ resource "azuread_group_role_management_policy" "example" {
 * `eligible_assignment_rules` - (Optional) An `eligible_assignment_rules` block as defined below.
 * `group_id` - (Required) The ID of the Azure AD group for which the policy applies.
 * `notification_rules` - (Optional) A `notification_rules` block as defined below.
-* `role_id` - (Required) The type of assignment this policy coveres. Can be either `member` or `owner`.
+* `role_id` - (Required) The type of assignment this policy covers. Can be either `member` or `owner`.
 
 ---
 
@@ -74,7 +74,7 @@ An `activation_rules` block supports the following:
 * `require_approval` - (Optional) Is approval required for activation. If `true` an `approval_stage` block must be provided.
 * `require_justification` - (Optional) Is a justification required during activation of the role.
 * `require_multifactor_authentication` - (Optional) Is multi-factor authentication required to activate the role. Conflicts with `required_conditional_access_authentication_context`.
-* `require_ticket_info` - (Optional) Is ticket information requrired during activation of the role.
+* `require_ticket_info` - (Optional) Is ticket information required during activation of the role.
 * `required_conditional_access_authentication_context` - (Optional) The Entra ID Conditional Access context that must be present for activation (e.g `c1`). Conflicts with `require_multifactor_authentication`.
 
 ---
@@ -108,7 +108,7 @@ One of `expiration_required` or `expire_after` must be provided.
 
 A `notification_rules` block supports the following:
 
-* `active_assignments` - (Optional) A `notification_target` block as defined below to configure notfications on active role assignments.
+* `active_assignments` - (Optional) A `notification_target` block as defined below to configure notifications on active role assignments.
 * `eligible_activations` - (Optional) A `notification_target` block as defined below for configuring notifications on activation of eligible role.
 * `eligible_assignments` - (Optional) A `notification_target` block as defined below to configure notification on eligible role assignments.
 

--- a/docs/resources/privileged_access_group_assignment_schedule.md
+++ b/docs/resources/privileged_access_group_assignment_schedule.md
@@ -49,7 +49,7 @@ resource "azuread_privileged_access_group_assignment_schedule" "example" {
 * `start_date` (Optional) The date from which this assignment is valid, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z). If not provided, the assignment is immediately valid.
 * `expiration_date` (Optional) The date that this assignment expires, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z).
 * `duration` (Optional) The duration that this assignment is valid for, formatted as an ISO8601 duration (e.g. P30D for 30 days, PT3H for three hours).
-* `permanent_assignment` (Optional) Is this assigment permanently valid.
+* `permanent_assignment` (Optional) Is this assignment permanently valid.
 
 At least one of `expiration_date`, `duration`, or `permanent_assignment` must be supplied. The role policy may limit the maximum duration which can be supplied.
 

--- a/docs/resources/privileged_access_group_eligibility_schedule.md
+++ b/docs/resources/privileged_access_group_eligibility_schedule.md
@@ -49,7 +49,7 @@ resource "azuread_privileged_access_group_eligibility_schedule" "example" {
 * `start_date` (Optional) The date from which this assignment is valid, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z). If not provided, the assignment is immediately valid.
 * `expiration_date` (Optional) The date that this assignment expires, formatted as an RFC3339 date string (e.g. 2018-01-01T01:02:03Z).
 * `duration` (Optional) The duration that this assignment is valid for, formatted as an ISO8601 duration (e.g. P30D for 30 days, PT3H for three hours).
-* `permanent_assignment` (Optional) Is this assigment permanently valid.
+* `permanent_assignment` (Optional) Is this assignment permanently valid.
 
 At least one of `expiration_date`, `duration`, or `permanent_assignment` must be supplied. The role policy may limit the maximum duration which can be supplied.
 

--- a/internal/services/applications/application_template_data_source.go
+++ b/internal/services/applications/application_template_data_source.go
@@ -131,7 +131,7 @@ func applicationTemplateDataSourceRead(ctx context.Context, d *pluginsdk.Resourc
 
 		template = &(*resp.Model)[0]
 		if templateDisplayName := template.DisplayName.GetOrZero(); !strings.EqualFold(templateDisplayName, displayName) {
-			return tf.ErrorDiagF(fmt.Errorf("DisplayName does not match (%q != %q) for application tempate matching filter: %q", templateDisplayName, displayName, *options.Filter), "Bad API Response")
+			return tf.ErrorDiagF(fmt.Errorf("DisplayName does not match (%q != %q) for application template matching filter: %q", templateDisplayName, displayName, *options.Filter), "Bad API Response")
 		}
 	}
 

--- a/internal/services/identitygovernance/parse/privileged_access_group_schedule.go
+++ b/internal/services/identitygovernance/parse/privileged_access_group_schedule.go
@@ -71,5 +71,5 @@ func (id *PrivilegedAccessGroupScheduleId) ID() string {
 }
 
 func (id *PrivilegedAccessGroupScheduleId) String() string {
-	return fmt.Sprintf("Privileged Access Group Assigment Schedule ID: %q", id.ID())
+	return fmt.Sprintf("Privileged Access Group Assignment Schedule ID: %q", id.ID())
 }

--- a/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_assignment_schedule_resource_test.go
@@ -152,7 +152,7 @@ resource "azuread_group" "pam" {
   }
 }
 
-resource "azuread_user" "eligibile_owner" {
+resource "azuread_user" "eligible_owner" {
   user_principal_name = "pam-eligible-owner-eligible-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
   display_name        = "acctest PAM Owner (Eligible) %[1]s"
   password            = "%[2]s"
@@ -160,7 +160,7 @@ resource "azuread_user" "eligibile_owner" {
 
 resource "azuread_privileged_access_group_assignment_schedule" "owner" {
   group_id        = azuread_group.pam.object_id
-  principal_id    = azuread_user.eligibile_owner.object_id
+  principal_id    = azuread_user.eligible_owner.object_id
   assignment_type = "owner"
   duration        = "%[3]s"
   justification   = "%[4]s"

--- a/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
+++ b/internal/services/identitygovernance/privileged_access_group_eligiblity_schedule_resource_test.go
@@ -152,16 +152,16 @@ resource "azuread_group" "pam" {
   }
 }
 
-resource "azuread_user" "eligibile_owner" {
-  user_principal_name = "pam-eligible-owner-eligibile-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
-  display_name        = "acctest PAM Owner (Eligibile) %[1]s"
+resource "azuread_user" "eligible_owner" {
+  user_principal_name = "pam-eligible-owner-eligible-%[1]s@${data.azuread_domains.test.domains.0.domain_name}"
+  display_name        = "acctest PAM Owner (Eligible) %[1]s"
   password            = "%[2]s"
 }
 
 
 resource "azuread_privileged_access_group_eligibility_schedule" "owner" {
   group_id        = azuread_group.pam.object_id
-  principal_id    = azuread_user.eligibile_owner.object_id
+  principal_id    = azuread_user.eligible_owner.object_id
   assignment_type = "owner"
   duration        = "%[3]s"
   justification   = "%[4]s"


### PR DESCRIPTION
Fifth PR in the CI alignment series with terraform-provider-azurerm. Stacked on #1939 (base is `kt/ci-golangci-plugins`); rebase onto `main` after that merges.

### typos spell check

- `.typos.toml`: azurerm's config with its azurerm-only excludes and word list trimmed to what azuread needs, plus `GH_MEMEBERSHIP_CHECK_TOKEN` as an accepted identifier since that is the secret's actual name in the repository settings.
- `make typos` / `make typos-fix` (`TYPOS_VERSION` pinned in the GNUmakefile, installed from the release tarball in CI as azurerm does), a `typos` job in the combined PR checks (phase 1, no path filter) and in main-checks, and a guidance entry in the failure comment.
- Fixes the 22 findings: prose in docs and the changelog, two misspelled job ids in `pr-waiting-response-on-review.yaml`, a word in the CRT summary step, two Go display strings, and the `eligibile_owner` test resource labels.

### Tooling pins

Every remaining unpinned tool install now has a version. `make tools` installed misspell, tfproviderdocs, terrafmt and gofumpt at `@latest`; the quick-checks CI jobs installed terrafmt the same way, and the milestone workflow installed link-milestone at `@latest`. The Go tools are pinned via `MISSPELL_VERSION` / `TFPROVIDERDOCS_VERSION` / `TERRAFMT_VERSION` / `GOFUMPT_VERSION` in the GNUmakefile (the CI jobs sed `TERRAFMT_VERSION` out of it, matching how golangci-lint and typos are handled), and link-milestone is pinned to a commit since it has no tagged releases. Each pinned version was verified to resolve and build. No `@latest` remains in the GNUmakefile, workflows, scripts or TeamCity config.

### Other

- **`pr-assign-reviewer.yaml`** (verbatim from azurerm): assigns a reviewer who requests changes as a PR assignee. Rides on the existing review relay; `pr-reviewed.yaml` now always uploads `reviewer.txt` / `reviewstate.txt` in an unconditional first step, with the two conditional steps only writing `action.txt`.
- **`pr-label-size`**: ignores `vendor/*` and `go.mod` when computing PR size.
- **depscheck** now triggers on Go changes as well as vendor changes.
- **Action pin bumps** to the majors azurerm uses, each at its current patch release with the exact version in the comment: checkout v6.1.0, setup-go v6.5.0, setup-java v5.7.0, cache v5.1.0, github-script v9.0.0, upload-artifact v7.0.1, labeler v6.2.0, download-artifact v21, lock-threads v6.0.2, milestone-comment v2.0.0, azure/login v3.1.0. Every SHA was resolved from the tag via the GitHub API. `lock-threads` v6 renamed its inputs (`issue-comment`, `issue-inactive-days`, `pr-comment`, `pr-inactive-days`) and the workflow is updated to match. The CRT-managed `build.yml` and `provider-release.yml` are untouched; dependabot handles those.

`make typos`, yamllint, actionlint, markdownlint and `go build` all pass.
