### PR TITLE
lint: enable azproviderlint and fix all findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ terraform-provider-azuread
 
 # terraform version
 .terraform-version
+
+# golangci-lint custom binary with plugins, built from scripts/.custom-gcl.yml
+scripts/golangci-with-modules

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
 # Copyright IBM Corp. 2023, 2026
 # SPDX-License-Identifier: MPL-2.0
 
+# NOTE: this config enables the azproviderlint module plugin, which only exists in the
+# custom-built binary produced by 'golangci-lint custom' (see scripts/.custom-gcl.yml) - run
+# lints via './scripts/golangci-with-modules run', not stock golangci-lint.
 version: "2"
 run:
   modules-download-mode: vendor
@@ -9,6 +12,7 @@ linters:
   enable:
     - asasalint
     - asciicheck
+    - azproviderlint            # custom azure provider checks (AZG/AZR/AZS/AZT), module plugin - see scripts/.custom-gcl.yml
     - bidichk
     - decorder
     - dupword
@@ -49,6 +53,33 @@ linters:
         - json
         - tfschema
         - computed
+    custom:
+      azproviderlint:
+        type: module
+        settings:
+          disable:
+            - AZR002 # split create and update - no findings in azuread, kept in step with azurerm
+            - AZT002 # tests should not obtain credentials via os.Getenv - 3 findings, investigate in a later pr
+            - AZR004 # Resource IDs should not be compared with == or != - no findings in azuread, kept in step with azurerm
+            - AZR003 # d.Get should not be used within a Delete function as it does not work as expected during deletion - no findings in azuread, kept in step with azurerm
+            - AZR007 # StateChangeConf should be replaced with a custom poller implementing pollers.PollerType - 10 findings, to migrate over time
+            - AZS003 # TypeList blocks where every property is optional with no default allow empty blocks - 33 findings to fix later
+            - AZS005 # resources with no corresponding data source - 45 findings, to determine if to be fixed later
+            - AZS006 # data sources missing properties that exist on the resource - 6 findings, todo later
+            - AZS007 # Optional+Computed fields missing a '// Note: O+C because ...' comment - 121 findings to fix later
+          AZG002:
+            use: pointer.To # rather than the go1.26 new(<expr>) builtin
+          AZG006:
+            # only inline temporaries into calls whose other arguments are all basic literals
+            # (e.g. d.Set("key", x)) - among identifier/expression siblings the name adds context
+            only-when-literals: true
+          AZS004:
+            # exact-match only: report hand-written lists that exactly match the enum (a pure
+            # PossibleValuesFor<Enum>() swap); deliberate subsets/supersets are left alone
+            allow-missing-values: true
+            allow-extra-values: true
+          AZS007:
+            exclude-packages: "migrations"
   exclusions:
     generated: lax
     presets:

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2023, 2026
 // SPDX-License-Identifier: MPL-2.0
 // NOTE: this is Generated from the Service Definitions - manual changes will be lost
 //       to re-generate this file, run 'make generate' in the root of the repository

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,11 @@ TF_SCHEMA_PANIC_ON_ERROR=1
 # in .github/workflows/workflow-actionlint.yml.
 ACTIONLINT_VERSION := $(shell sed -n 's/.*actionlint\/cmd\/actionlint@//p' .github/workflows/workflow-actionlint.yml)
 
+# The single source of truth for the golangci-lint version is the 'version:' field in
+# scripts/.custom-gcl.yml (it is required to live there for the plugin build); everything
+# else derives it from that file.
+GOLANGCI_LINT_VERSION := $(shell sed -n 's/^version: *//p' scripts/.custom-gcl.yml)
+
 .EXPORT_ALL_VARIABLES:
 
 default: build
@@ -31,7 +36,8 @@ tools: ## Install the tools required to develop the provider
 	go install github.com/katbyte/terrafmt@latest
 	go install mvdan.cc/gofumpt@latest
 	go install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v2.12.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	@$(MAKE) golangci-with-modules
 
 build: quick-checks generate ## Run the quick checks, generate code, and compile the provider
 	go install
@@ -79,13 +85,34 @@ terrafmt: ## Fix terraform blocks in acceptance tests and docs
 	@terrafmt fmt -p "*.md" ./docs
 
 ##@ Linting & Dependencies
-lint: ## Check source code with the golangci linters
-	@echo "==> Checking source code with golangci-lint..."
-	@golangci-lint run -v ./...
+# golangci-lint module plugins (azproviderlint) only exist in a custom-built binary, so lint
+# targets use scripts/golangci-with-modules, rebuilt automatically whenever the config (which
+# pins the golangci-lint version) changes. The pinned version is installed before building so
+# the host binary running 'golangci-lint custom' always matches the pin. The config filename
+# and its living in the build cwd are both fixed by golangci-lint, hence the cd into scripts/.
+scripts/golangci-with-modules: scripts/.custom-gcl.yml
+	@echo "==> Building golangci-lint with plugins (scripts/golangci-with-modules)..."
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	@cd scripts && $$(go env GOPATH)/bin/golangci-lint custom
 
-lint-fix: ## Fix source code with all golangci linters
+golangci-with-modules: ## Build golangci-lint with plugins (automatic when the config or pinned version changes)
+	@if [ -x scripts/golangci-with-modules ] && ! ./scripts/golangci-with-modules version 2>/dev/null | grep -qF -- "$(GOLANGCI_LINT_VERSION:v%=%)"; then \
+		echo "==> scripts/golangci-with-modules is not $(GOLANGCI_LINT_VERSION), rebuilding..."; \
+		rm -f scripts/golangci-with-modules; \
+	fi
+	@$(MAKE) scripts/golangci-with-modules
+
+lint: golangci-with-modules ## Check source code with the golangci linters
+	@echo "==> Checking source code with golangci-lint..."
+	@./scripts/golangci-with-modules run -v ./...
+
+lint-fix: golangci-with-modules ## Fix source code with all golangci linters
 	@echo "==> Fixing source code with all golangci linters..."
-	@golangci-lint run ./... --fix
+	@./scripts/golangci-with-modules run ./... --fix
+
+azproviderlint: golangci-with-modules ## Check source code with only the azproviderlint checks
+	@echo "==> Checking source code with azproviderlint (via golangci-lint)..."
+	@./scripts/golangci-with-modules run -v --enable-only azproviderlint ./...
 
 tfproviderlint: ## Check terraform schema definitions with tfproviderlint
 	@echo "==> Checking terraform schemas with tfproviderlint..."

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -63,10 +63,6 @@ func Build(tenantId string) (*clients.Client, error) {
 
 			EnableAuthenticatingUsingClientCertificate: true,
 			EnableAuthenticatingUsingClientSecret:      true,
-			EnableAuthenticatingUsingAzureCLI:          false,
-			EnableAuthenticatingUsingManagedIdentity:   false,
-			EnableAuthenticationUsingOIDC:              false,
-			EnableAuthenticationUsingGitHubOIDC:        false,
 		}
 
 		builder := clients.ClientBuilder{

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -44,6 +44,9 @@ func Build(tenantId string) (*clients.Client, error) {
 		} else if env, err = environments.FromName(envName); err != nil {
 			return nil, fmt.Errorf("building test client: %+v", err)
 		}
+		if env == nil {
+			return nil, fmt.Errorf("building test client: environment was nil")
+		}
 
 		if tenantId == "" {
 			tenantId = os.Getenv("ARM_TENANT_ID")

--- a/internal/acceptance/testing.go
+++ b/internal/acceptance/testing.go
@@ -80,10 +80,6 @@ func GetAuthConfig(t *testing.T) *auth.Credentials {
 
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
-		EnableAuthenticatingUsingAzureCLI:          false,
-		EnableAuthenticatingUsingManagedIdentity:   false,
-		EnableAuthenticationUsingOIDC:              false,
-		EnableAuthenticationUsingGitHubOIDC:        false,
 	}
 }
 

--- a/internal/acceptance/testing.go
+++ b/internal/acceptance/testing.go
@@ -64,6 +64,10 @@ func GetAuthConfig(t *testing.T) *auth.Credentials {
 		t.Fatalf("building test client: %+v", err)
 		return nil
 	}
+	if env == nil {
+		t.Fatalf("building test client: environment was nil")
+		return nil
+	}
 
 	return &auth.Credentials{
 		Environment: *env,

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -168,7 +168,7 @@ func (client *Client) build(ctx context.Context, o *common.ClientOptions) error 
 				return fmt.Errorf("attempting to discover object ID for authenticated service principal: %+v", err)
 			}
 
-			if resp.Model != nil && len(*resp.Model) != 1 {
+			if resp.Model == nil || len(*resp.Model) != 1 {
 				respLen := "nil"
 				if resp.Model != nil {
 					respLen = strconv.Itoa(len(*resp.Model))

--- a/internal/helpers/applications/applications.go
+++ b/internal/helpers/applications/applications.go
@@ -90,14 +90,11 @@ func FlattenAppRoleIDs(in *[]stable.AppRole) map[string]string {
 
 func FlattenAppRoles(in *[]stable.AppRole) (result []map[string]interface{}) {
 	if in == nil {
-		return //nolint:nakedret
+		return []map[string]interface{}{} //nolint:nakedret
 	}
 
 	for _, role := range *in {
-		roleId := ""
-		if role.Id != nil {
-			roleId = *role.Id
-		}
+		roleId := pointer.From(role.Id)
 
 		allowedMemberTypes := make([]interface{}, 0)
 		if v := role.AllowedMemberTypes; v != nil {
@@ -197,7 +194,7 @@ func FlattenOAuth2PermissionScopeIDs(in *[]stable.PermissionScope) map[string]st
 
 func FlattenOAuth2PermissionScopes(in *[]stable.PermissionScope) (result []map[string]interface{}) {
 	if in == nil {
-		return //nolint:nakedret
+		return []map[string]interface{}{} //nolint:nakedret
 	}
 
 	for _, p := range *in {

--- a/internal/helpers/tf/pluginsdk/customize_diff.go
+++ b/internal/helpers/tf/pluginsdk/customize_diff.go
@@ -44,8 +44,7 @@ func CustomDiffWithAll(funcs ...CustomizeDiffFunc) schema.CustomizeDiffFunc {
 func CustomDiffInSequence(funcs ...CustomizeDiffFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 		for _, f := range funcs {
-			err := f(ctx, d, meta)
-			if err != nil {
+			if err := f(ctx, d, meta); err != nil {
 				return err
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -317,7 +317,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			}
 		}
 
-		if env.MicrosoftGraph == nil {
+		if env == nil {
+			return nil, pluginsdk.DiagErrorf("cloud environment could not be determined")
+		} else if env.MicrosoftGraph == nil {
 			return nil, pluginsdk.DiagErrorf("Microsoft Graph was not configured for the specified environment")
 		} else if endpoint, ok := env.MicrosoftGraph.Endpoint(); !ok || *endpoint == "" {
 			return nil, pluginsdk.DiagErrorf("Microsoft Graph endpoint could not be determined for the specified environment")

--- a/internal/services/administrativeunits/administrative_unit_data_source.go
+++ b/internal/services/administrativeunits/administrative_unit_data_source.go
@@ -111,6 +111,9 @@ func administrativeUnitDataSourceRead(ctx context.Context, d *pluginsdk.Resource
 			}
 			return tf.ErrorDiagF(err, "Retrieving administrative unit with object ID: %q", d.Id())
 		}
+		if resp.Model == nil {
+			return tf.ErrorDiagF(fmt.Errorf("model was nil"), "Retrieving administrative unit with object ID: %q", objectId)
+		}
 
 		administrativeUnit = *resp.Model
 	}

--- a/internal/services/administrativeunits/administrative_unit_data_source.go
+++ b/internal/services/administrativeunits/administrative_unit_data_source.go
@@ -122,7 +122,7 @@ func administrativeUnitDataSourceRead(ctx context.Context, d *pluginsdk.Resource
 		return tf.ErrorDiagF(fmt.Errorf("API returned administrative unit with nil object ID"), "Bad API response")
 	}
 
-	d.SetId(stable.NewDirectoryAdministrativeUnitID(*administrativeUnit.Id).ID())
+	d.SetId(*administrativeUnit.Id) //nolint:azproviderlint // AZR001: the data source ID is the bare object ID and is relied upon by users
 
 	tf.Set(d, "description", administrativeUnit.Description.GetOrZero())
 	tf.Set(d, "display_name", administrativeUnit.DisplayName.GetOrZero())

--- a/internal/services/administrativeunits/administrative_unit_data_source.go
+++ b/internal/services/administrativeunits/administrative_unit_data_source.go
@@ -122,7 +122,7 @@ func administrativeUnitDataSourceRead(ctx context.Context, d *pluginsdk.Resource
 		return tf.ErrorDiagF(fmt.Errorf("API returned administrative unit with nil object ID"), "Bad API response")
 	}
 
-	d.SetId(*administrativeUnit.Id)
+	d.SetId(stable.NewDirectoryAdministrativeUnitID(*administrativeUnit.Id).ID())
 
 	tf.Set(d, "description", administrativeUnit.Description.GetOrZero())
 	tf.Set(d, "display_name", administrativeUnit.DisplayName.GetOrZero())

--- a/internal/services/administrativeunits/administrative_unit_member_resource.go
+++ b/internal/services/administrativeunits/administrative_unit_member_resource.go
@@ -51,7 +51,6 @@ func administrativeUnitMemberResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceAdministrativeUnitMemberInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceAdministrativeUnitMemberInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/administrativeunits/administrative_unit_resource.go
+++ b/internal/services/administrativeunits/administrative_unit_resource.go
@@ -64,7 +64,6 @@ func administrativeUnitResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceAdministrativeUnitInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceAdministrativeUnitInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/administrativeunits/administrative_unit_role_member_resource.go
+++ b/internal/services/administrativeunits/administrative_unit_role_member_resource.go
@@ -49,7 +49,6 @@ func administrativeUnitRoleMemberResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceAdministrativeUnitRoleMemberInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceAdministrativeUnitRoleMemberInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/applications/application_api_access_resource.go
+++ b/internal/services/applications/application_api_access_resource.go
@@ -130,7 +130,7 @@ func (r ApplicationApiAccessResource) Create() sdk.ResourceFunc {
 
 			// Check for existing API
 			for _, api := range newApis {
-				if strings.EqualFold(*api.ResourceAppId, id.ApiClientId) {
+				if strings.EqualFold(pointer.From(api.ResourceAppId), id.ApiClientId) {
 					return metadata.ResourceRequiresImport(r.ResourceType(), id)
 				}
 			}
@@ -205,7 +205,7 @@ func (r ApplicationApiAccessResource) Read() sdk.ResourceFunc {
 			// Identify the API
 			var api *stable.RequiredResourceAccess
 			for _, existingApi := range *app.RequiredResourceAccess {
-				if strings.EqualFold(*existingApi.ResourceAppId, id.ApiClientId) {
+				if strings.EqualFold(pointer.From(existingApi.ResourceAppId), id.ApiClientId) {
 					api = &existingApi
 					break
 				}
@@ -295,7 +295,7 @@ func (r ApplicationApiAccessResource) Update() sdk.ResourceFunc {
 			newApis := make([]stable.RequiredResourceAccess, 0)
 			found := false
 			for _, existingApi := range *app.RequiredResourceAccess {
-				if strings.EqualFold(*existingApi.ResourceAppId, id.ApiClientId) {
+				if strings.EqualFold(pointer.From(existingApi.ResourceAppId), id.ApiClientId) {
 					newApis = append(newApis, api)
 					found = true
 				} else {
@@ -356,7 +356,7 @@ func (r ApplicationApiAccessResource) Delete() sdk.ResourceFunc {
 			newApis := make([]stable.RequiredResourceAccess, 0)
 			found := false
 			for _, existingApi := range *app.RequiredResourceAccess {
-				if strings.EqualFold(*existingApi.ResourceAppId, id.ApiClientId) {
+				if strings.EqualFold(pointer.From(existingApi.ResourceAppId), id.ApiClientId) {
 					found = true
 				} else {
 					newApis = append(newApis, existingApi)

--- a/internal/services/applications/application_api_access_resource_test.go
+++ b/internal/services/applications/application_api_access_resource_test.go
@@ -154,7 +154,7 @@ func (r ApplicationApiAccessResource) Exists(ctx context.Context, clients *clien
 	}
 
 	for _, api := range *app.RequiredResourceAccess {
-		if strings.EqualFold(*api.ResourceAppId, id.ApiClientId) {
+		if strings.EqualFold(pointer.From(api.ResourceAppId), id.ApiClientId) {
 			return pointer.To(true), nil
 		}
 	}

--- a/internal/services/applications/application_app_role_resource.go
+++ b/internal/services/applications/application_app_role_resource.go
@@ -143,7 +143,7 @@ func (r ApplicationAppRoleResource) Create() sdk.ResourceFunc {
 
 			// Check for existing role ID
 			for _, role := range newRoles {
-				if strings.EqualFold(*role.Id, id.RoleID) {
+				if strings.EqualFold(pointer.From(role.Id), id.RoleID) {
 					return metadata.ResourceRequiresImport(r.ResourceType(), id)
 				}
 			}
@@ -208,7 +208,7 @@ func (r ApplicationAppRoleResource) Read() sdk.ResourceFunc {
 			// Identify the role by ID
 			var role *stable.AppRole
 			for _, existingRole := range *app.AppRoles {
-				if strings.EqualFold(*existingRole.Id, id.RoleID) {
+				if strings.EqualFold(pointer.From(existingRole.Id), id.RoleID) {
 					role = &existingRole
 					break
 				}
@@ -277,7 +277,7 @@ func (r ApplicationAppRoleResource) Update() sdk.ResourceFunc {
 			newRoles := make([]stable.AppRole, 0)
 			found := false
 			for _, existingRole := range *app.AppRoles {
-				if strings.EqualFold(*existingRole.Id, id.RoleID) {
+				if strings.EqualFold(pointer.From(existingRole.Id), id.RoleID) {
 					newRoles = append(newRoles, role)
 					found = true
 				} else {
@@ -343,7 +343,7 @@ func (r ApplicationAppRoleResource) Delete() sdk.ResourceFunc {
 			newRoles := make([]stable.AppRole, 0)
 			found := false
 			for _, existingRole := range *app.AppRoles {
-				if strings.EqualFold(*existingRole.Id, id.RoleID) {
+				if strings.EqualFold(pointer.From(existingRole.Id), id.RoleID) {
 					found = true
 				} else {
 					newRoles = append(newRoles, existingRole)

--- a/internal/services/applications/application_app_role_resource_test.go
+++ b/internal/services/applications/application_app_role_resource_test.go
@@ -154,7 +154,7 @@ func (r ApplicationAppRoleResource) Exists(ctx context.Context, clients *clients
 	}
 
 	for _, role := range *app.AppRoles {
-		if strings.EqualFold(*role.Id, id.RoleID) {
+		if strings.EqualFold(pointer.From(role.Id), id.RoleID) {
 			return pointer.To(true), nil
 		}
 	}

--- a/internal/services/applications/application_data_source.go
+++ b/internal/services/applications/application_data_source.go
@@ -553,14 +553,15 @@ func applicationDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, m
 			return tf.ErrorDiagF(err, "Listing applications for filter %q", *options.Filter)
 		}
 
+		apps := pointer.From(resp.Model)
 		switch {
-		case resp.Model == nil || len(*resp.Model) == 0:
+		case len(apps) == 0:
 			return tf.ErrorDiagF(fmt.Errorf("no applications found matching filter: %q", *options.Filter), "Application not found")
-		case len(*resp.Model) > 1:
-			return tf.ErrorDiagF(fmt.Errorf("dound multiple applications matching filter: %q", *options.Filter), "Multiple applications found")
+		case len(apps) > 1:
+			return tf.ErrorDiagF(fmt.Errorf("found multiple applications matching filter: %q", *options.Filter), "Multiple applications found")
 		}
 
-		app = &(*resp.Model)[0]
+		app = &apps[0]
 		switch fieldName {
 		case "appId":
 			if appId := app.AppId.GetOrZero(); !strings.EqualFold(appId, fieldValue) {

--- a/internal/services/applications/application_data_source.go
+++ b/internal/services/applications/application_data_source.go
@@ -245,26 +245,25 @@ func applicationDataSource() *pluginsdk.Resource {
 						"custom_single_sign_on": {
 							Description: "Whether this application principal represents a custom SAML application for linked service principals",
 							Type:        pluginsdk.TypeBool,
-							Optional:    true,
+							Computed:    true,
 						},
 
 						"enterprise": {
 							Description: "Whether this application represents an Enterprise Application for linked service principals",
 							Type:        pluginsdk.TypeBool,
-							Optional:    true,
+							Computed:    true,
 						},
 
 						"gallery": {
 							Description: "Whether this application represents a gallery application for linked service principals",
 							Type:        pluginsdk.TypeBool,
-							Optional:    true,
+							Computed:    true,
 						},
 
 						"hide": {
 							Description: "Whether this app is invisible to users in My Apps and Office 365 Launcher",
 							Type:        pluginsdk.TypeBool,
-							Optional:    true,
-							Default:     true,
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/services/applications/application_from_template_resource.go
+++ b/internal/services/applications/application_from_template_resource.go
@@ -119,11 +119,11 @@ func (r ApplicationFromTemplateResource) Create() sdk.ResourceFunc {
 			if resp.Model == nil {
 				return fmt.Errorf("creating %s: model was nil", templateId)
 			}
-			if resp.Model.Application == nil {
-				return fmt.Errorf("creating %s: application was nil", templateId)
+			if resp.Model.Application == nil || resp.Model.Application.Id == nil {
+				return fmt.Errorf("creating %s: application or its ID was nil", templateId)
 			}
-			if resp.Model.ServicePrincipal == nil {
-				return fmt.Errorf("creating %s: servicePrincipal was nil", templateId)
+			if resp.Model.ServicePrincipal == nil || resp.Model.ServicePrincipal.Id == nil {
+				return fmt.Errorf("creating %s: servicePrincipal or its ID was nil", templateId)
 			}
 
 			id := parse.NewFromTemplateID(model.TemplateId, *resp.Model.Application.Id, *resp.Model.ServicePrincipal.Id)

--- a/internal/services/applications/application_password_resource.go
+++ b/internal/services/applications/application_password_resource.go
@@ -43,7 +43,6 @@ func applicationPasswordResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceApplicationPasswordInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceApplicationPasswordInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/applications/application_permission_scope_resource.go
+++ b/internal/services/applications/application_permission_scope_resource.go
@@ -156,7 +156,7 @@ func (r ApplicationPermissionScopeResource) Create() sdk.ResourceFunc {
 
 			// Check for existing scope ID
 			for _, scope := range newScopes {
-				if strings.EqualFold(*scope.Id, id.ScopeID) {
+				if strings.EqualFold(pointer.From(scope.Id), id.ScopeID) {
 					return metadata.ResourceRequiresImport(r.ResourceType(), id)
 				}
 			}
@@ -223,7 +223,7 @@ func (r ApplicationPermissionScopeResource) Read() sdk.ResourceFunc {
 			// Identify the scope by ID
 			var scope *stable.PermissionScope
 			for _, existingScope := range *app.Api.OAuth2PermissionScopes {
-				if strings.EqualFold(*existingScope.Id, id.ScopeID) {
+				if strings.EqualFold(pointer.From(existingScope.Id), id.ScopeID) {
 					scope = &existingScope
 					break
 				}
@@ -295,7 +295,7 @@ func (r ApplicationPermissionScopeResource) Update() sdk.ResourceFunc {
 			newScopes := make([]stable.PermissionScope, 0)
 			found := false
 			for _, existingScope := range *app.Api.OAuth2PermissionScopes {
-				if strings.EqualFold(*existingScope.Id, id.ScopeID) {
+				if strings.EqualFold(pointer.From(existingScope.Id), id.ScopeID) {
 					newScopes = append(newScopes, scope)
 					found = true
 				} else {
@@ -361,7 +361,7 @@ func (r ApplicationPermissionScopeResource) Delete() sdk.ResourceFunc {
 			newScopes := make([]stable.PermissionScope, 0)
 			found := false
 			for _, existingScope := range *app.Api.OAuth2PermissionScopes {
-				if strings.EqualFold(*existingScope.Id, id.ScopeID) {
+				if strings.EqualFold(pointer.From(existingScope.Id), id.ScopeID) {
 					found = true
 				} else {
 					newScopes = append(newScopes, existingScope)

--- a/internal/services/applications/application_permission_scope_resource_test.go
+++ b/internal/services/applications/application_permission_scope_resource_test.go
@@ -206,7 +206,7 @@ func (r ApplicationPermissionScopeResource) Exists(ctx context.Context, clients 
 	}
 
 	for _, scope := range *app.Api.OAuth2PermissionScopes {
-		if strings.EqualFold(*scope.Id, id.ScopeID) {
+		if strings.EqualFold(pointer.From(scope.Id), id.ScopeID) {
 			return pointer.To(true), nil
 		}
 	}

--- a/internal/services/applications/application_registration_resource.go
+++ b/internal/services/applications/application_registration_resource.go
@@ -36,7 +36,7 @@ type ApplicationRegistrationModel struct {
 	ObjectId                           string   `tfschema:"object_id"`
 	PrivacyStatementUrl                string   `tfschema:"privacy_statement_url"`
 	PublisherDomain                    string   `tfschema:"publisher_domain"`
-	RequestedAccessTokenVersion        int      `tfschema:"requested_access_token_version"`
+	RequestedAccessTokenVersion        int64    `tfschema:"requested_access_token_version"`
 	ServiceManagementReference         string   `tfschema:"service_management_reference"`
 	SignInAudience                     string   `tfschema:"sign_in_audience"`
 	SupportUrl                         string   `tfschema:"support_url"`
@@ -219,7 +219,7 @@ func (r ApplicationRegistrationResource) Create() sdk.ResourceFunc {
 				SignInAudience:             nullable.Value(model.SignInAudience),
 
 				Api: &stable.ApiApplication{
-					RequestedAccessTokenVersion: nullable.Value(int64(model.RequestedAccessTokenVersion)),
+					RequestedAccessTokenVersion: nullable.Value(model.RequestedAccessTokenVersion),
 				},
 
 				Info: &stable.InformationalUrl{
@@ -246,12 +246,11 @@ func (r ApplicationRegistrationResource) Create() sdk.ResourceFunc {
 			}
 
 			app := resp.Model
-			if app == nil || pointer.From(app.Id) == "" {
+			if app == nil || app.Id == nil || *app.Id == "" {
 				return errors.New("creating application: object ID returned for application is nil/empty")
 			}
 
-			id := stable.NewApplicationID(*app.Id)
-			metadata.SetID(id)
+			metadata.SetID(stable.NewApplicationID(*app.Id))
 
 			return nil
 		},
@@ -295,7 +294,7 @@ func (r ApplicationRegistrationResource) Read() sdk.ResourceFunc {
 			}
 
 			if api := app.Api; api != nil {
-				state.RequestedAccessTokenVersion = int(api.RequestedAccessTokenVersion.GetOrZero())
+				state.RequestedAccessTokenVersion = api.RequestedAccessTokenVersion.GetOrZero()
 			}
 
 			if info := app.Info; info != nil {
@@ -364,7 +363,7 @@ func (r ApplicationRegistrationResource) Update() sdk.ResourceFunc {
 
 			if rd.HasChange("requested_access_token_version") {
 				properties.Api = &stable.ApiApplication{
-					RequestedAccessTokenVersion: nullable.Value(int64(model.RequestedAccessTokenVersion)),
+					RequestedAccessTokenVersion: nullable.Value(model.RequestedAccessTokenVersion),
 				}
 			}
 

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1652,25 +1652,30 @@ func applicationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, met
 		tf.Set(d, "terms_of_service_url", app.Info.TermsOfServiceUrl.GetOrZero())
 	}
 
-	currentPassword := d.Get("password").(*pluginsdk.Set).List()
-	passwordToSave := make([]interface{}, 0)
+	// The nil check is deliberate: when the API omits passwordCredentials the existing state is retained
+	if app.PasswordCredentials != nil {
+		currentPassword := d.Get("password").(*pluginsdk.Set).List()
+		passwordToSave := make([]interface{}, 0)
 
-	if len(currentPassword) == 1 {
-		keyIdToMatch := currentPassword[0].(map[string]interface{})["key_id"].(string)
-		existingValue := currentPassword[0].(map[string]interface{})["value"].(string)
+		var keyIdToMatch, existingValue string
 
-		for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) {
-			// Match against the known key ID, or select the first returned password if not present in state
-			if credential["key_id"] == keyIdToMatch {
-				// Retain the value from state, if known
-				credential["value"] = existingValue
-				passwordToSave = append(passwordToSave, credential)
-				break
+		if len(currentPassword) == 1 {
+			keyIdToMatch = currentPassword[0].(map[string]interface{})["key_id"].(string)
+			existingValue = currentPassword[0].(map[string]interface{})["value"].(string)
+
+			for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) { //nolint:azproviderlint // AZR010: the outer nil check intentionally retains state, see above
+				// Match against the known key ID, or select the first returned password if not present in state
+				if credential["key_id"] == keyIdToMatch {
+					// Retain the value from state, if known
+					credential["value"] = existingValue
+					passwordToSave = append(passwordToSave, credential)
+					break
+				}
 			}
 		}
-	}
 
-	tf.Set(d, "password", passwordToSave)
+		tf.Set(d, "password", passwordToSave)
+	}
 
 	// API bug: the v1.0 API does not return the `oauth2RequiredPostResponse` field, so retrieve it using the beta API
 	// See https://github.com/microsoftgraph/msgraph-metadata/issues/273

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -69,7 +69,6 @@ func applicationResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceApplicationInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceApplicationInstanceStateUpgradeV0,
-				Version: 0,
 			},
 			{
 				Type:    migrations.ResourceApplicationInstanceResourceV1().CoreConfigSchema().ImpliedType(),
@@ -484,26 +483,22 @@ func applicationResource() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"resource_app_id": {
-							Description: "",
-							Type:        pluginsdk.TypeString,
-							Required:    true,
+							Type:     pluginsdk.TypeString,
+							Required: true,
 						},
 
 						"resource_access": {
-							Description: "",
-							Type:        pluginsdk.TypeList,
-							Required:    true,
+							Type:     pluginsdk.TypeList,
+							Required: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"id": {
-										Description:  "",
 										Type:         pluginsdk.TypeString,
 										Required:     true,
 										ValidateFunc: validation.IsUUID,
 									},
 
 									"type": {
-										Description:  "",
 										Type:         pluginsdk.TypeString,
 										Required:     true,
 										ValidateFunc: validation.StringInSlice(possibleValuesForResourceAccessType, false),

--- a/internal/services/applications/application_resource.go
+++ b/internal/services/applications/application_resource.go
@@ -1226,14 +1226,12 @@ func applicationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, m
 	d.SetId(id.ID())
 
 	// Save the password key ID and generated value to state
-	if app.PasswordCredentials != nil {
-		if password := d.Get("password").(*pluginsdk.Set).List(); len(password) == 1 {
-			pw := password[0].(map[string]interface{})
-			if creds := flattenApplicationPasswordCredentials(app.PasswordCredentials); len(creds) == 1 {
-				pw["key_id"] = creds[0]["key_id"]
-				pw["value"] = creds[0]["value"]
-				tf.Set(d, "password", []interface{}{pw})
-			}
+	if password := d.Get("password").(*pluginsdk.Set).List(); len(password) == 1 {
+		pw := password[0].(map[string]interface{})
+		if creds := flattenApplicationPasswordCredentials(app.PasswordCredentials); len(creds) == 1 {
+			pw["key_id"] = creds[0]["key_id"]
+			pw["value"] = creds[0]["value"]
+			tf.Set(d, "password", []interface{}{pw})
 		}
 	}
 
@@ -1659,29 +1657,25 @@ func applicationResourceRead(ctx context.Context, d *pluginsdk.ResourceData, met
 		tf.Set(d, "terms_of_service_url", app.Info.TermsOfServiceUrl.GetOrZero())
 	}
 
-	if app.PasswordCredentials != nil {
-		currentPassword := d.Get("password").(*pluginsdk.Set).List()
-		passwordToSave := make([]interface{}, 0)
+	currentPassword := d.Get("password").(*pluginsdk.Set).List()
+	passwordToSave := make([]interface{}, 0)
 
-		var keyIdToMatch, existingValue string
+	if len(currentPassword) == 1 {
+		keyIdToMatch := currentPassword[0].(map[string]interface{})["key_id"].(string)
+		existingValue := currentPassword[0].(map[string]interface{})["value"].(string)
 
-		if len(currentPassword) == 1 {
-			keyIdToMatch = currentPassword[0].(map[string]interface{})["key_id"].(string)
-			existingValue = currentPassword[0].(map[string]interface{})["value"].(string)
-
-			for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) {
-				// Match against the known key ID, or select the first returned password if not present in state
-				if credential["key_id"] == keyIdToMatch {
-					// Retain the value from state, if known
-					credential["value"] = existingValue
-					passwordToSave = append(passwordToSave, credential)
-					break
-				}
+		for _, credential := range flattenApplicationPasswordCredentials(app.PasswordCredentials) {
+			// Match against the known key ID, or select the first returned password if not present in state
+			if credential["key_id"] == keyIdToMatch {
+				// Retain the value from state, if known
+				credential["value"] = existingValue
+				passwordToSave = append(passwordToSave, credential)
+				break
 			}
 		}
-
-		tf.Set(d, "password", passwordToSave)
 	}
+
+	tf.Set(d, "password", passwordToSave)
 
 	// API bug: the v1.0 API does not return the `oauth2RequiredPostResponse` field, so retrieve it using the beta API
 	// See https://github.com/microsoftgraph/msgraph-metadata/issues/273

--- a/internal/services/applications/application_template_data_source.go
+++ b/internal/services/applications/application_template_data_source.go
@@ -122,14 +122,15 @@ func applicationTemplateDataSourceRead(ctx context.Context, d *pluginsdk.Resourc
 			return tf.ErrorDiagF(err, "Listing application templates for filter %q", *options.Filter)
 		}
 
+		templates := pointer.From(resp.Model)
 		switch {
-		case resp.Model == nil || len(*resp.Model) == 0:
+		case len(templates) == 0:
 			return tf.ErrorDiagF(fmt.Errorf("no application templates found matching filter: %q", *options.Filter), "Application template not found")
-		case len(*resp.Model) > 1:
+		case len(templates) > 1:
 			return tf.ErrorDiagF(fmt.Errorf("found multiple application templates matching filter: %q", *options.Filter), "Multiple application templates found")
 		}
 
-		template = &(*resp.Model)[0]
+		template = &templates[0]
 		if templateDisplayName := template.DisplayName.GetOrZero(); !strings.EqualFold(templateDisplayName, displayName) {
 			return tf.ErrorDiagF(fmt.Errorf("DisplayName does not match (%q != %q) for application tempate matching filter: %q", templateDisplayName, displayName, *options.Filter), "Bad API Response")
 		}

--- a/internal/services/applications/application_template_data_source.go
+++ b/internal/services/applications/application_template_data_source.go
@@ -144,7 +144,7 @@ func applicationTemplateDataSourceRead(ctx context.Context, d *pluginsdk.Resourc
 		return tf.ErrorDiagF(fmt.Errorf("ID returned for application template is nil"), "Bad API Response")
 	}
 
-	d.SetId(stable.NewApplicationTemplateID(*template.Id).ID())
+	d.SetId(*template.Id) //nolint:azproviderlint // AZR001: the data source ID is the bare template ID and is relied upon by users
 
 	tf.Set(d, "categories", tf.FlattenStringSlicePtr(template.Categories))
 	tf.Set(d, "display_name", template.DisplayName.GetOrZero())

--- a/internal/services/applications/application_template_data_source.go
+++ b/internal/services/applications/application_template_data_source.go
@@ -144,7 +144,7 @@ func applicationTemplateDataSourceRead(ctx context.Context, d *pluginsdk.Resourc
 		return tf.ErrorDiagF(fmt.Errorf("ID returned for application template is nil"), "Bad API Response")
 	}
 
-	d.SetId(*template.Id)
+	d.SetId(stable.NewApplicationTemplateID(*template.Id).ID())
 
 	tf.Set(d, "categories", tf.FlattenStringSlicePtr(template.Categories))
 	tf.Set(d, "display_name", template.DisplayName.GetOrZero())

--- a/internal/services/applications/applications.go
+++ b/internal/services/applications/applications.go
@@ -111,7 +111,7 @@ func applicationDisableAppRoles(ctx context.Context, client *application.Applica
 	for i, existing := range existingRoles {
 		found := false
 		for _, newRole := range *newRoles {
-			if existing.Id != nil && *newRole.Id == *existing.Id {
+			if existing.Id != nil && newRole.Id != nil && *newRole.Id == *existing.Id {
 				found = true
 				break
 			}
@@ -226,7 +226,7 @@ func applicationDisableOauth2PermissionScopes(ctx context.Context, client *appli
 	for i, existing := range existingScopes {
 		found := false
 		for _, newScope := range *newScopes {
-			if existing.Id != nil && *newScope.Id == *existing.Id {
+			if existing.Id != nil && newScope.Id != nil && *newScope.Id == *existing.Id {
 				found = true
 				break
 			}

--- a/internal/services/applications/applications.go
+++ b/internal/services/applications/applications.go
@@ -80,10 +80,7 @@ func applicationDisableAppRoles(ctx context.Context, client *application.Applica
 		return fmt.Errorf("retrieving %s: model was nil", applicationId)
 	}
 
-	var existingRoles []stable.AppRole
-	if app.AppRoles != nil {
-		existingRoles = *app.AppRoles
-	}
+	existingRoles := pointer.From(app.AppRoles)
 
 	// Shortcut: don't update if no changes to be made
 	if reflect.DeepEqual(existingRoles, *newRoles) {
@@ -138,7 +135,7 @@ func applicationDisableAppRoles(ctx context.Context, client *application.Applica
 			return fmt.Errorf("context has no deadline")
 		}
 		timeout := time.Until(deadline)
-		_, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
+		if _, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
 			Pending:    []string{"Waiting"},
 			Target:     []string{"Disabled"},
 			Timeout:    timeout,
@@ -167,8 +164,7 @@ func applicationDisableAppRoles(ctx context.Context, client *application.Applica
 				}
 				return actualRoles, "Disabled", nil
 			},
-		}).WaitForStateContext(ctx)
-		if err != nil {
+		}).WaitForStateContext(ctx); err != nil {
 			return fmt.Errorf("waiting for App Roles to be disabled for %s: %v", applicationId, err)
 		}
 	}
@@ -254,7 +250,7 @@ func applicationDisableOauth2PermissionScopes(ctx context.Context, client *appli
 			return fmt.Errorf("context has no deadline")
 		}
 		timeout := time.Until(deadline)
-		_, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
+		if _, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
 			Pending:    []string{"Waiting"},
 			Target:     []string{"Disabled"},
 			Timeout:    timeout,
@@ -283,8 +279,7 @@ func applicationDisableOauth2PermissionScopes(ctx context.Context, client *appli
 				}
 				return actualScopes, "Disabled", nil
 			},
-		}).WaitForStateContext(ctx)
-		if err != nil {
+		}).WaitForStateContext(ctx); err != nil {
 			return fmt.Errorf("waiting for OAuth2 Permission Scopes to be disabled for %s: %+v", applicationId, err)
 		}
 	}
@@ -771,10 +766,7 @@ func flattenApplicationRequiredResourceAccess(in *[]stable.RequiredResourceAcces
 
 	result := make([]map[string]interface{}, 0)
 	for _, requiredResourceAccess := range *in {
-		resourceAppId := ""
-		if requiredResourceAccess.ResourceAppId != nil {
-			resourceAppId = *requiredResourceAccess.ResourceAppId
-		}
+		resourceAppId := pointer.From(requiredResourceAccess.ResourceAppId)
 
 		result = append(result, map[string]interface{}{
 			"resource_app_id": resourceAppId,

--- a/internal/services/applications/parse/redirect_uris.go
+++ b/internal/services/applications/parse/redirect_uris.go
@@ -51,8 +51,7 @@ func ValidateRedirectUrisID(input interface{}, key string) (warnings []string, e
 		return
 	}
 
-	_, err := ParseRedirectUrisID(v)
-	if err != nil {
+	if _, err := ParseRedirectUrisID(v); err != nil {
 		errors = append(errors, err)
 		return
 	}

--- a/internal/services/applications/registration.go
+++ b/internal/services/applications/registration.go
@@ -58,7 +58,6 @@ func (r Registration) Resources() []sdk.Resource {
 		ApplicationApiAccessResource{},
 		ApplicationAppRoleResource{},
 		ApplicationFallbackPublicClientResource{},
-		flexibleFederatedIdentityCredentialResource{},
 		ApplicationFromTemplateResource{},
 		ApplicationIdentifierUriResource{},
 		ApplicationKnownClientsResource{},
@@ -67,5 +66,6 @@ func (r Registration) Resources() []sdk.Resource {
 		ApplicationPermissionScopeResource{},
 		ApplicationRedirectUrisResource{},
 		ApplicationRegistrationResource{},
+		flexibleFederatedIdentityCredentialResource{},
 	}
 }

--- a/internal/services/approleassignments/app_role_assignment_resource.go
+++ b/internal/services/approleassignments/app_role_assignment_resource.go
@@ -52,7 +52,6 @@ func appRoleAssignmentResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceAppRoleAssignmentInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceAppRoleAssignmentInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/conditionalaccess/conditional_access_policy_resource.go
+++ b/internal/services/conditionalaccess/conditional_access_policy_resource.go
@@ -54,7 +54,6 @@ func conditionalAccessPolicyResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceConditionalAccessPolicyInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceConditionalAccessPolicyInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 
@@ -631,7 +630,7 @@ func conditionalAccessPolicyResourceCreate(ctx context.Context, d *pluginsdk.Res
 
 	properties := stable.ConditionalAccessPolicy{
 		DisplayName:     pointer.To(d.Get("display_name").(string)),
-		State:           pointer.To(stable.ConditionalAccessPolicyState(d.Get("state").(string))),
+		State:           pointer.ToEnum[stable.ConditionalAccessPolicyState](d.Get("state").(string)),
 		Conditions:      expandConditionalAccessConditionSet(d.Get("conditions").([]interface{})),
 		GrantControls:   grantControls,
 		SessionControls: sessionControls,
@@ -695,7 +694,7 @@ func conditionalAccessPolicyResourceUpdate(ctx context.Context, d *pluginsdk.Res
 
 	properties := stable.ConditionalAccessPolicy{
 		DisplayName:     pointer.To(d.Get("display_name").(string)),
-		State:           pointer.To(stable.ConditionalAccessPolicyState(d.Get("state").(string))),
+		State:           pointer.ToEnum[stable.ConditionalAccessPolicyState](d.Get("state").(string)),
 		Conditions:      expandConditionalAccessConditionSet(d.Get("conditions").([]interface{})),
 		GrantControls:   grantControls,
 		SessionControls: sessionControls,

--- a/internal/services/conditionalaccess/conditionalaccess.go
+++ b/internal/services/conditionalaccess/conditionalaccess.go
@@ -307,10 +307,7 @@ func flattenCountryNamedLocation(in *stable.CountryNamedLocation) []interface{} 
 		return []interface{}{}
 	}
 
-	includeUnknown := false
-	if in.IncludeUnknownCountriesAndRegions != nil {
-		includeUnknown = *in.IncludeUnknownCountriesAndRegions
-	}
+	includeUnknown := pointer.From(in.IncludeUnknownCountriesAndRegions)
 
 	countryLookupMethod := stable.CountryLookupMethodType_ClientIPAddress
 	if in.CountryLookupMethod != nil {
@@ -331,10 +328,7 @@ func flattenIPNamedLocation(in *stable.IPNamedLocation) []interface{} {
 		return []interface{}{}
 	}
 
-	trusted := false
-	if in.IsTrusted != nil {
-		trusted = *in.IsTrusted
-	}
+	trusted := pointer.From(in.IsTrusted)
 
 	return []interface{}{
 		map[string]interface{}{
@@ -417,7 +411,7 @@ func expandConditionalAccessConditionSet(in []interface{}) *stable.ConditionalAc
 	}
 
 	if insiderRiskLevel, ok := config["insider_risk_levels"]; ok && insiderRiskLevel.(string) != "" {
-		result.InsiderRiskLevels = pointer.To(stable.ConditionalAccessInsiderRiskLevels(insiderRiskLevel.(string)))
+		result.InsiderRiskLevels = pointer.ToEnum[stable.ConditionalAccessInsiderRiskLevels](insiderRiskLevel.(string))
 	}
 
 	result.Applications = expandConditionalAccessApplications(applications)
@@ -609,21 +603,21 @@ func expandConditionalAccessSessionControls(in []interface{}) *stable.Conditiona
 	if cloudAppSecurity := config["cloud_app_security_policy"]; cloudAppSecurity.(string) != "" {
 		result.CloudAppSecurity = &stable.CloudAppSecuritySessionControl{
 			IsEnabled:            nullable.Value(true),
-			CloudAppSecurityType: pointer.To(stable.CloudAppSecuritySessionControlType(cloudAppSecurity.(string))),
+			CloudAppSecurityType: pointer.ToEnum[stable.CloudAppSecuritySessionControlType](cloudAppSecurity.(string)),
 		}
 	}
 
 	if persistentBrowserMode := config["persistent_browser_mode"]; persistentBrowserMode.(string) != "" {
 		result.PersistentBrowser = &stable.PersistentBrowserSessionControl{
 			IsEnabled: nullable.Value(true),
-			Mode:      pointer.To(stable.PersistentBrowserSessionMode(persistentBrowserMode.(string))),
+			Mode:      pointer.ToEnum[stable.PersistentBrowserSessionMode](persistentBrowserMode.(string)),
 		}
 	}
 
 	signInFrequency := stable.SignInFrequencySessionControl{}
 	if frequencyValue := config["sign_in_frequency"].(int); frequencyValue > 0 {
 		signInFrequency.IsEnabled = nullable.Value(true)
-		signInFrequency.Type = pointer.To(stable.SigninFrequencyType(config["sign_in_frequency_period"].(string)))
+		signInFrequency.Type = pointer.ToEnum[stable.SigninFrequencyType](config["sign_in_frequency_period"].(string))
 		signInFrequency.Value = nullable.Value(int64(frequencyValue))
 
 		signInFrequency.AuthenticationType = pointer.To(stable.SignInFrequencyAuthenticationType_PrimaryAndSecondaryAuthentication)
@@ -631,7 +625,7 @@ func expandConditionalAccessSessionControls(in []interface{}) *stable.Conditiona
 	}
 
 	if authenticationType, ok := config["sign_in_frequency_authentication_type"]; ok && authenticationType.(string) != "" {
-		signInFrequency.AuthenticationType = pointer.To(stable.SignInFrequencyAuthenticationType(authenticationType.(string)))
+		signInFrequency.AuthenticationType = pointer.ToEnum[stable.SignInFrequencyAuthenticationType](authenticationType.(string))
 	}
 
 	if interval, ok := config["sign_in_frequency_interval"]; ok && interval.(string) != "" {
@@ -640,7 +634,7 @@ func expandConditionalAccessSessionControls(in []interface{}) *stable.Conditiona
 		if authType := config["sign_in_frequency_authentication_type"].(string); authType != "" {
 			signInFrequency.AuthenticationType = pointer.ToEnum[stable.SignInFrequencyAuthenticationType](authType)
 		}
-		signInFrequency.FrequencyInterval = pointer.To(stable.SignInFrequencyInterval(interval.(string)))
+		signInFrequency.FrequencyInterval = pointer.ToEnum[stable.SignInFrequencyInterval](interval.(string))
 	}
 
 	applicationEnforcedRestrictions := config["application_enforced_restrictions_enabled"].(bool)
@@ -681,7 +675,7 @@ func expandConditionalAccessFilter(in []interface{}) *stable.ConditionalAccessFi
 
 	config := in[0].(map[string]interface{})
 
-	result.Mode = pointer.To(stable.FilterMode(config["mode"].(string)))
+	result.Mode = pointer.ToEnum[stable.FilterMode](config["mode"].(string))
 	result.Rule = pointer.To(config["rule"].(string))
 
 	return &result
@@ -698,7 +692,7 @@ func expandGuestsOrExternalUsers(in []interface{}) *stable.ConditionalAccessGues
 	var guestOrExternalUserTypes *stable.ConditionalAccessGuestOrExternalUserTypes
 	if len(config["guest_or_external_user_types"].([]interface{})) > 0 {
 		values := strings.Join(tf.ExpandStringSlice(config["guest_or_external_user_types"].([]interface{})), ",")
-		guestOrExternalUserTypes = pointer.To(stable.ConditionalAccessGuestOrExternalUserTypes(values))
+		guestOrExternalUserTypes = pointer.ToEnum[stable.ConditionalAccessGuestOrExternalUserTypes](values)
 	}
 
 	result.GuestOrExternalUserTypes = guestOrExternalUserTypes
@@ -748,7 +742,7 @@ func expandCountryNamedLocation(in []interface{}) *stable.CountryNamedLocation {
 	result.IncludeUnknownCountriesAndRegions = pointer.To(includeUnknown.(bool))
 
 	if countryLookupMethodType, ok := config["country_lookup_method"]; ok && countryLookupMethodType.(string) != "" {
-		result.CountryLookupMethod = pointer.To(stable.CountryLookupMethodType(countryLookupMethodType.(string)))
+		result.CountryLookupMethod = pointer.ToEnum[stable.CountryLookupMethodType](countryLookupMethodType.(string))
 	}
 
 	return &result

--- a/internal/services/conditionalaccess/named_location_resource.go
+++ b/internal/services/conditionalaccess/named_location_resource.go
@@ -52,7 +52,6 @@ func namedLocationResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceNamedLocationInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceNamedLocationInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/conditionalaccess/named_location_resource.go
+++ b/internal/services/conditionalaccess/named_location_resource.go
@@ -134,6 +134,9 @@ func namedLocationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("ip"); ok {
 		properties := expandIPNamedLocation(v.([]interface{}))
+		if properties == nil {
+			return tf.ErrorDiagF(errors.New("expanding `ip` block returned nil"), "Could not create named location")
+		}
 		properties.DisplayName = pointer.To(d.Get("display_name").(string))
 
 		resp, err := client.CreateConditionalAccessNamedLocation(ctx, *properties, conditionalaccessnamedlocation.DefaultCreateConditionalAccessNamedLocationOperationOptions())
@@ -163,6 +166,9 @@ func namedLocationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData,
 		d.SetId(id.ID())
 	} else if v, ok = d.GetOk("country"); ok {
 		properties := expandCountryNamedLocation(v.([]interface{}))
+		if properties == nil {
+			return tf.ErrorDiagF(errors.New("expanding `country` block returned nil"), "Could not create named location")
+		}
 		properties.DisplayName = pointer.To(d.Get("display_name").(string))
 
 		resp, err := client.CreateConditionalAccessNamedLocation(ctx, *properties, conditionalaccessnamedlocation.DefaultCreateConditionalAccessNamedLocationOperationOptions())
@@ -205,6 +211,9 @@ func namedLocationResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData,
 
 	if v, ok := d.GetOk("ip"); ok {
 		properties := expandIPNamedLocation(v.([]interface{}))
+		if properties == nil {
+			return tf.ErrorDiagF(errors.New("expanding `ip` block returned nil"), "Updating %s", id)
+		}
 
 		if d.HasChange("display_name") {
 			properties.DisplayName = pointer.To(d.Get("display_name").(string))
@@ -219,6 +228,9 @@ func namedLocationResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData,
 		}
 	} else if v, ok := d.GetOk("country"); ok {
 		properties := expandCountryNamedLocation(v.([]interface{}))
+		if properties == nil {
+			return tf.ErrorDiagF(errors.New("expanding `country` block returned nil"), "Updating %s", id)
+		}
 
 		if d.HasChange("display_name") {
 			properties.DisplayName = pointer.To(d.Get("display_name").(string))

--- a/internal/services/conditionalaccess/registration.go
+++ b/internal/services/conditionalaccess/registration.go
@@ -36,7 +36,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azuread_named_location":            namedLocationResource(),
 		"azuread_conditional_access_policy": conditionalAccessPolicyResource(),
+		"azuread_named_location":            namedLocationResource(),
 	}
 }

--- a/internal/services/directoryroles/custom_directory_role_resource.go
+++ b/internal/services/directoryroles/custom_directory_role_resource.go
@@ -50,7 +50,6 @@ func customDirectoryRoleResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceCustomDirectoryRoleInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceCustomDirectoryRoleInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/directoryroles/directory_role_assignment_resource.go
+++ b/internal/services/directoryroles/directory_role_assignment_resource.go
@@ -49,7 +49,6 @@ func directoryRoleAssignmentResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceDirectoryRoleAssignmentInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceDirectoryRoleAssignmentInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 
@@ -135,7 +134,7 @@ func directoryRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.Res
 		return tf.ErrorDiagF(errors.New("context has no deadline"), "Waiting for directory role %q assignment to principal %q to take effect", roleId, principalId)
 	}
 	timeout := time.Until(deadline)
-	_, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
+	if _, err = (&pluginsdk.StateChangeConf{ //nolint:staticcheck
 		Pending:                   []string{"Waiting"},
 		Target:                    []string{"Done"},
 		Timeout:                   timeout,
@@ -151,8 +150,7 @@ func directoryRoleAssignmentResourceCreate(ctx context.Context, d *pluginsdk.Res
 			}
 			return "stub", "Done", nil
 		},
-	}).WaitForStateContext(ctx)
-	if err != nil {
+	}).WaitForStateContext(ctx); err != nil {
 		return tf.ErrorDiagF(err, "Waiting for role assignment for %q to reflect in directory role %q", principalId, roleId)
 	}
 

--- a/internal/services/directoryroles/directory_role_member_resource.go
+++ b/internal/services/directoryroles/directory_role_member_resource.go
@@ -51,7 +51,6 @@ func directoryRoleMemberResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceDirectoryRoleMemberInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceDirectoryRoleMemberInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/directoryroles/directory_role_resource.go
+++ b/internal/services/directoryroles/directory_role_resource.go
@@ -183,8 +183,7 @@ func (r DirectoryRoleResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving directory role for template ID %q: ID was nil (API error)", templateId)
 			}
 
-			id := stable.NewDirectoryRoleID(*directoryRole.Id)
-			metadata.SetID(id)
+			metadata.SetID(stable.NewDirectoryRoleID(*directoryRole.Id))
 
 			return nil
 		},

--- a/internal/services/directoryroles/registration.go
+++ b/internal/services/directoryroles/registration.go
@@ -30,8 +30,8 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azuread_directory_roles":          directoryRolesDataSource(),
 		"azuread_directory_role_templates": directoryRoleTemplatesDataSource(),
+		"azuread_directory_roles":          directoryRolesDataSource(),
 	}
 }
 
@@ -40,8 +40,8 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azuread_custom_directory_role":                       customDirectoryRoleResource(),
 		"azuread_directory_role_assignment":                   directoryRoleAssignmentResource(),
-		"azuread_directory_role_member":                       directoryRoleMemberResource(),
 		"azuread_directory_role_eligibility_schedule_request": directoryRoleEligibilityScheduleRequestResource(),
+		"azuread_directory_role_member":                       directoryRoleMemberResource(),
 	}
 }
 

--- a/internal/services/domains/domains_data_source.go
+++ b/internal/services/domains/domains_data_source.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/microsoft-graph/domains/stable/domain"
 	"github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azuread/internal/sdk"
@@ -229,10 +230,7 @@ func (r DomainsDataSource) Read() sdk.ResourceFunc {
 				if v.Id != nil {
 					domainNames = append(domainNames, *v.Id)
 
-					var authenticationType string
-					if v.AuthenticationType != nil {
-						authenticationType = *v.AuthenticationType
-					}
+					authenticationType := pointer.From(v.AuthenticationType)
 
 					supportedServices := make([]string, 0)
 					if v.SupportedServices != nil {

--- a/internal/services/groups/group_data_source.go
+++ b/internal/services/groups/group_data_source.go
@@ -489,7 +489,7 @@ func groupDataSourceRead(ctx context.Context, d *pluginsdk.ResourceData, meta in
 		return tf.ErrorDiagF(err, "Could not retrieve group owners for group with object ID: %q", d.Id())
 	}
 	owners := make([]string, 0)
-	for _, object := range *resp.Model {
+	for _, object := range pointer.From(resp.Model) {
 		owners = append(owners, pointer.From(object.DirectoryObject().Id))
 	}
 	tf.Set(d, "owners", owners)

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -68,7 +68,6 @@ func groupResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceGroupInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceGroupInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/groups/group_resource.go
+++ b/internal/services/groups/group_resource.go
@@ -606,14 +606,14 @@ func groupResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta in
 					if response.WasBadRequest(resp.HttpResponse) && regexp.MustCompile(groupDuplicateValueError).MatchString(err.Error()) {
 						// Retry the group creation, without the calling principal as owner
 						ownersWithoutCallingPrincipal := make([]string, 0)
-						for _, o := range *properties.Owners_ODataBind {
+						for _, o := range pointer.From(properties.Owners_ODataBind) {
 							if o != callerODataId {
 								ownersWithoutCallingPrincipal = append(ownersWithoutCallingPrincipal, o)
 							}
 						}
 
 						// No point in retrying if the caller wasn't specified as an owner
-						if len(ownersWithoutCallingPrincipal) == len(*properties.Owners) {
+						if len(ownersWithoutCallingPrincipal) == len(pointer.From(properties.Owners_ODataBind)) {
 							log.Printf("[DEBUG] Not retrying group creation for %q within %s as owner was not specified", displayName, administrativeUnitId)
 							return tf.ErrorDiagF(err, "Creating group in %s", administrativeUnitId)
 						}

--- a/internal/services/groups/group_without_members_resource.go
+++ b/internal/services/groups/group_without_members_resource.go
@@ -580,14 +580,14 @@ func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.Resourc
 					if response.WasBadRequest(resp.HttpResponse) && regexp.MustCompile(groupDuplicateValueError).MatchString(err.Error()) {
 						// Retry the group creation, without the calling principal as owner
 						ownersWithoutCallingPrincipal := make([]string, 0)
-						for _, o := range *properties.Owners_ODataBind {
+						for _, o := range pointer.From(properties.Owners_ODataBind) {
 							if o != callerODataId {
 								ownersWithoutCallingPrincipal = append(ownersWithoutCallingPrincipal, o)
 							}
 						}
 
 						// No point in retrying if the caller wasn't specified as an owner
-						if len(ownersWithoutCallingPrincipal) == len(*properties.Owners) {
+						if len(ownersWithoutCallingPrincipal) == len(pointer.From(properties.Owners_ODataBind)) {
 							log.Printf("[DEBUG] Not retrying group creation for %q within %s as owner was not specified", displayName, administrativeUnitId)
 							return tf.ErrorDiagF(err, "Creating group in %s", administrativeUnitId)
 						}
@@ -648,14 +648,14 @@ func groupWithoutMembersResourceCreate(ctx context.Context, d *pluginsdk.Resourc
 			if response.WasBadRequest(resp.HttpResponse) && regexp.MustCompile(groupDuplicateValueError).MatchString(err.Error()) {
 				// Retry the group creation, without the calling principal as owner
 				ownersWithoutCallingPrincipal := make([]string, 0)
-				for _, o := range *properties.Owners_ODataBind {
+				for _, o := range pointer.From(properties.Owners_ODataBind) {
 					if o != callerODataId {
 						ownersWithoutCallingPrincipal = append(ownersWithoutCallingPrincipal, o)
 					}
 				}
 
 				// No point in retrying if the caller wasn't specified as an owner
-				if len(ownersWithoutCallingPrincipal) == len(pointer.From(properties.Owners)) {
+				if len(ownersWithoutCallingPrincipal) == len(pointer.From(properties.Owners_ODataBind)) {
 					log.Printf("[DEBUG] Not retrying group creation for %q as owner was not specified", displayName)
 					return tf.ErrorDiagF(err, "Creating group %q", displayName)
 				}

--- a/internal/services/groups/registration.go
+++ b/internal/services/groups/registration.go
@@ -36,7 +36,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azuread_group":                 groupResource(),
-		"azuread_group_without_members": groupWithoutMembersResource(),
 		"azuread_group_member":          groupMemberResource(),
+		"azuread_group_without_members": groupWithoutMembersResource(),
 	}
 }

--- a/internal/services/identitygovernance/access_package_assignment_policy_resource.go
+++ b/internal/services/identitygovernance/access_package_assignment_policy_resource.go
@@ -385,6 +385,9 @@ func accessPackageAssignmentPolicyResourceCreate(ctx context.Context, d *plugins
 	if resp.Model == nil {
 		return tf.ErrorDiagF(errors.New("model was nil"), "Creating access package assignment policy")
 	}
+	if resp.Model.Id == nil {
+		return tf.ErrorDiagF(errors.New("model ID was nil"), "Creating access package assignment policy")
+	}
 
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageAssignmentPolicyID(*resp.Model.Id)
 	d.SetId(id.AccessPackageAssignmentPolicyId)

--- a/internal/services/identitygovernance/access_package_catalog_resource.go
+++ b/internal/services/identitygovernance/access_package_catalog_resource.go
@@ -103,6 +103,9 @@ func accessPackageCatalogResourceCreate(ctx context.Context, d *pluginsdk.Resour
 	if catalog == nil {
 		return tf.ErrorDiagF(errors.New("model was nil"), "Creating access package catalog")
 	}
+	if catalog.Id == nil {
+		return tf.ErrorDiagF(errors.New("model ID was nil"), "Creating access package catalog")
+	}
 
 	id := beta.NewIdentityGovernanceEntitlementManagementAccessPackageCatalogID(*catalog.Id)
 	d.SetId(id.AccessPackageCatalogId)

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -70,7 +70,7 @@ func expandRequestorSettings(input []interface{}) (*beta.RequestorSettings, erro
 
 func flattenRequestorSettings(input *beta.RequestorSettings) []map[string]interface{} {
 	if input == nil {
-		return nil
+		return []map[string]interface{}{}
 	}
 
 	return []map[string]interface{}{{
@@ -132,7 +132,7 @@ func expandApprovalSettings(input []interface{}) (*beta.ApprovalSettings, error)
 
 func flattenApprovalSettings(input *beta.ApprovalSettings) []map[string]interface{} {
 	if input == nil {
-		return nil
+		return []map[string]interface{}{}
 	}
 
 	result := []map[string]interface{}{{
@@ -172,7 +172,7 @@ func expandAssignmentReviewSettings(input []interface{}) (*beta.AssignmentReview
 	in := input[0].(map[string]interface{})
 
 	result := beta.AssignmentReviewSettings{
-		AccessReviewTimeoutBehavior:     pointer.To(beta.AccessReviewTimeoutBehavior(in["access_review_timeout_behavior"].(string))),
+		AccessReviewTimeoutBehavior:     pointer.ToEnum[beta.AccessReviewTimeoutBehavior](in["access_review_timeout_behavior"].(string)),
 		DurationInDays:                  nullable.Value(int64(in["duration_in_days"].(int))),
 		IsAccessRecommendationEnabled:   nullable.Value(in["access_recommendation_enabled"].(bool)),
 		IsApprovalJustificationRequired: nullable.Value(in["approver_justification_required"].(bool)),
@@ -202,7 +202,7 @@ func expandAssignmentReviewSettings(input []interface{}) (*beta.AssignmentReview
 
 func flattenAssignmentReviewSettings(input *beta.AssignmentReviewSettings) []map[string]interface{} {
 	if input == nil {
-		return nil
+		return []map[string]interface{}{}
 	}
 
 	return []map[string]interface{}{{
@@ -272,7 +272,7 @@ func expandUserSets(input []interface{}) (*[]beta.UserSet, error) {
 
 func flattenUserSets(input *[]beta.UserSet) []map[string]interface{} {
 	if input == nil || len(*input) == 0 {
-		return nil
+		return []map[string]interface{}{}
 	}
 
 	userSets := make([]map[string]interface{}, 0)
@@ -352,7 +352,7 @@ func expandAccessPackageQuestions(input []interface{}) *[]beta.AccessPackageQues
 
 func flattenAccessPackageQuestions(input *[]beta.AccessPackageQuestion) []map[string]interface{} {
 	if input == nil || len(*input) == 0 {
-		return nil
+		return []map[string]interface{}{}
 	}
 
 	questions := make([]map[string]interface{}, 0)

--- a/internal/services/identitygovernance/identitygovernance.go
+++ b/internal/services/identitygovernance/identitygovernance.go
@@ -142,7 +142,7 @@ func flattenApprovalSettings(input *beta.ApprovalSettings) []map[string]interfac
 	}}
 
 	approvalStages := make([]interface{}, 0)
-	for _, v := range *input.ApprovalStages {
+	for _, v := range pointer.From(input.ApprovalStages) {
 		var alternativeApprovalInDays int
 		if w := v.EscalationTimeInMinutes.GetOrZero(); w > 0 {
 			alternativeApprovalInDays = int(w) / 60 / 24
@@ -411,13 +411,17 @@ func expandAccessPackageLocalizedContent(input map[string]interface{}) *beta.Acc
 }
 
 func flattenAccessPackageLocalizedContent(input *beta.AccessPackageLocalizedContent) []map[string]interface{} {
+	if input == nil {
+		return []map[string]interface{}{}
+	}
+
 	result := []map[string]interface{}{{
 		"default_text": input.DefaultText.GetOrZero(),
 	}}
 
 	texts := make([]map[string]interface{}, 0)
 
-	for _, v := range *input.LocalizedTexts {
+	for _, v := range pointer.From(input.LocalizedTexts) {
 		text := map[string]interface{}{
 			"language_code": v.LanguageCode.GetOrZero(),
 			"content":       v.Text.GetOrZero(),

--- a/internal/services/identitygovernance/parse/privileged_access_group_schedule.go
+++ b/internal/services/identitygovernance/parse/privileged_access_group_schedule.go
@@ -58,8 +58,7 @@ func ValidatePrivilegedAccessGroupScheduleID(input interface{}, key string) (war
 		return
 	}
 
-	_, err := ParsePrivilegedAccessGroupScheduleID(v)
-	if err != nil {
+	if _, err := ParsePrivilegedAccessGroupScheduleID(v); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/internal/services/invitations/invitation_resource.go
+++ b/internal/services/invitations/invitation_resource.go
@@ -158,7 +158,7 @@ func invitationResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, me
 		return tf.ErrorDiagF(errors.New("bad API response"), "Object ID returned for invitation is nil/empty")
 	}
 
-	d.SetId(*invite.Id)
+	d.SetId(*invite.Id) //nolint:azproviderlint // AZR001: the SDK has no ID type for invitations and this ID is never parsed
 
 	if invite.InvitedUser == nil || invite.InvitedUser.Id == nil || *invite.InvitedUser.Id == "" {
 		return tf.ErrorDiagF(errors.New("bad API response"), "Invited user object ID returned for invitation is nil/empty")

--- a/internal/services/policies/authentication_strength_policy_resource.go
+++ b/internal/services/policies/authentication_strength_policy_resource.go
@@ -56,7 +56,6 @@ func authenticationStrengthPolicyResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceAuthenticationStrengthPolicyInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceAuthenticationStrengthPolicyInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/policies/claims_mapping_policy_resource.go
+++ b/internal/services/policies/claims_mapping_policy_resource.go
@@ -50,7 +50,6 @@ func claimsMappingPolicyResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceClaimsMappingPolicyInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceClaimsMappingPolicyInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/policies/parse/role_management_policy.go
+++ b/internal/services/policies/parse/role_management_policy.go
@@ -60,8 +60,7 @@ func ValidateRoleManagementPolicyID(input interface{}, key string) (warnings []s
 		return
 	}
 
-	_, err := ParseRoleManagementPolicyID(v)
-	if err != nil {
+	if _, err := ParseRoleManagementPolicyID(v); err != nil {
 		errors = append(errors, err)
 	}
 

--- a/internal/services/policies/policies.go
+++ b/internal/services/policies/policies.go
@@ -55,7 +55,7 @@ func tryGetPolicyId(ctx context.Context, metadata sdk.ResourceMetaData, scopeId,
 // getPolicyId reliably fetches the policy ID, waiting for eventual consistency
 func getPolicyId(ctx context.Context, metadata sdk.ResourceMetaData, scopeId, roleDefinitionId string) (*parse.RoleManagementPolicyId, error) {
 	var policyId *parse.RoleManagementPolicyId
-	err := consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
+	if err := consistency.WaitForUpdate(ctx, func(ctx context.Context) (*bool, error) {
 		id, exists, err := tryGetPolicyId(ctx, metadata, scopeId, roleDefinitionId)
 		if err != nil {
 			return nil, err
@@ -64,8 +64,7 @@ func getPolicyId(ctx context.Context, metadata sdk.ResourceMetaData, scopeId, ro
 			policyId = id
 		}
 		return &exists, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("waiting for policy assignment to become available: %v", err)
 	}
 

--- a/internal/services/serviceprincipals/migrations/service_principal_resource.go
+++ b/internal/services/serviceprincipals/migrations/service_principal_resource.go
@@ -222,9 +222,8 @@ func ResourceServicePrincipalInstanceResourceV0() *pluginsdk.Resource {
 			},
 
 			"oauth2_permission_scopes": {
-				Description: "",
-				Type:        pluginsdk.TypeList,
-				Computed:    true,
+				Type:     pluginsdk.TypeList,
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"id": {

--- a/internal/services/serviceprincipals/schema.go
+++ b/internal/services/serviceprincipals/schema.go
@@ -7,9 +7,8 @@ import "github.com/hashicorp/terraform-provider-azuread/internal/helpers/tf/plug
 
 func schemaAppRolesComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Description: "",
-		Type:        pluginsdk.TypeList,
-		Computed:    true,
+		Type:     pluginsdk.TypeList,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"id": {
@@ -57,9 +56,8 @@ func schemaAppRolesComputed() *pluginsdk.Schema {
 
 func schemaOauth2PermissionScopesComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
-		Description: "",
-		Type:        pluginsdk.TypeList,
-		Computed:    true,
+		Type:     pluginsdk.TypeList,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"id": {

--- a/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_resource.go
+++ b/internal/services/serviceprincipals/service_principal_claims_mapping_policy_assignment_resource.go
@@ -47,7 +47,6 @@ func servicePrincipalClaimsMappingPolicyAssignmentResource() *pluginsdk.Resource
 			{
 				Type:    migrations.ResourceServicePrincipalClaimsMappingPolicyAssignmentInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceServicePrincipalClaimsMappingPolicyAssignmentInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/serviceprincipals/service_principal_delegated_permission_grant_resource.go
+++ b/internal/services/serviceprincipals/service_principal_delegated_permission_grant_resource.go
@@ -55,7 +55,6 @@ func servicePrincipalDelegatedPermissionGrantResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceServicePrincipalDelegatedPermissionGrantInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceServicePrincipalDelegatedPermissionGrantInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/serviceprincipals/service_principal_password_resource.go
+++ b/internal/services/serviceprincipals/service_principal_password_resource.go
@@ -41,7 +41,6 @@ func servicePrincipalPasswordResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceServicePrincipalPasswordInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceServicePrincipalPasswordInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/serviceprincipals/service_principal_resource.go
+++ b/internal/services/serviceprincipals/service_principal_resource.go
@@ -63,7 +63,6 @@ func servicePrincipalResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceServicePrincipalInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceServicePrincipalInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/synchronization/synchronization.go
+++ b/internal/services/synchronization/synchronization.go
@@ -32,7 +32,7 @@ func emptySynchronizationSecretKeyStringValuePair(in []interface{}) *[]stable.Sy
 		item := raw.(map[string]interface{})
 
 		result = append(result, stable.SynchronizationSecretKeyStringValuePair{
-			Key:   pointer.To(stable.SynchronizationSecret(item["key"].(string))),
+			Key:   pointer.ToEnum[stable.SynchronizationSecret](item["key"].(string)),
 			Value: nullable.Value(""),
 		})
 	}
@@ -50,7 +50,7 @@ func expandSynchronizationSecretKeyStringValuePair(in []interface{}) *[]stable.S
 		item := raw.(map[string]interface{})
 
 		result = append(result, stable.SynchronizationSecretKeyStringValuePair{
-			Key:   pointer.To(stable.SynchronizationSecret(item["key"].(string))),
+			Key:   pointer.ToEnum[stable.SynchronizationSecret](item["key"].(string)),
 			Value: nullable.Value(item["value"].(string)),
 		})
 	}

--- a/internal/services/synchronization/synchronization_job_provision_on_demand_resource.go
+++ b/internal/services/synchronization/synchronization_job_provision_on_demand_resource.go
@@ -31,8 +31,6 @@ func synchronizationJobProvisionOnDemandResource() *schema.Resource {
 			Read:   schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
-		SchemaVersion: 0,
-
 		Schema: map[string]*schema.Schema{
 			"service_principal_id": {
 				Description:  "The object ID of the service principal for which this synchronization job should be provisioned",

--- a/internal/services/synchronization/synchronization_job_resource.go
+++ b/internal/services/synchronization/synchronization_job_resource.go
@@ -53,7 +53,6 @@ func synchronizationJobResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceSynchronizationJobInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceSynchronizationJobInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/synchronization/synchronization_secret_resource.go
+++ b/internal/services/synchronization/synchronization_secret_resource.go
@@ -51,7 +51,6 @@ func synchronizationSecretResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceSynchronizationSecretInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceSynchronizationSecretInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 

--- a/internal/services/userflows/user_flow_attribute_resource.go
+++ b/internal/services/userflows/user_flow_attribute_resource.go
@@ -54,7 +54,6 @@ func userFlowAttributeResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceUserFlowAttributeInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceUserFlowAttributeInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 
@@ -109,7 +108,7 @@ func userFlowAttributeResourceCreate(ctx context.Context, d *pluginsdk.ResourceD
 	}
 
 	attr := stable.BaseIdentityUserFlowAttributeImpl{
-		DataType:    pointer.To(stable.IdentityUserFlowAttributeDataType(d.Get("data_type").(string))),
+		DataType:    pointer.ToEnum[stable.IdentityUserFlowAttributeDataType](d.Get("data_type").(string)),
 		Description: nullable.NoZero(d.Get("description").(string)),
 		DisplayName: nullable.NoZero(displayName),
 	}

--- a/internal/services/users/user_resource.go
+++ b/internal/services/users/user_resource.go
@@ -61,7 +61,6 @@ func userResource() *pluginsdk.Resource {
 			{
 				Type:    migrations.ResourceUserInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: migrations.ResourceUserInstanceStateUpgradeV0,
-				Version: 0,
 			},
 		},
 
@@ -483,8 +482,7 @@ func userResourceCreate(ctx context.Context, d *pluginsdk.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("employee_hire_date"); ok {
-		_, err := time.Parse(time.RFC3339, v.(string))
-		if err != nil {
+		if _, err := time.Parse(time.RFC3339, v.(string)); err != nil {
 			tf.ErrorDiagF(err, "Unable to parse the provided employee_hire_date %q: %+v", v, err)
 		}
 		properties.EmployeeHireDate = nullable.NoZero(v.(string))
@@ -627,8 +625,7 @@ func userResourceUpdate(ctx context.Context, d *pluginsdk.ResourceData, meta int
 	}
 
 	if d.HasChange("employee_hire_date") {
-		_, err := time.Parse(time.RFC3339, d.Get("employee_hire_date").(string))
-		if err != nil {
+		if _, err := time.Parse(time.RFC3339, d.Get("employee_hire_date").(string)); err != nil {
 			tf.ErrorDiagF(err, "Unable to parse the provided employee_hire_date %q: %+v", d.Get("employee_hire_date"), err)
 		}
 		properties.EmployeeHireDate = nullable.NoZero(d.Get("employee_hire_date").(string))

--- a/internal/tools/changelog-formatter/main.go
+++ b/internal/tools/changelog-formatter/main.go
@@ -285,9 +285,7 @@ func main() {
 		fmt.Println("Usage: go run main.go <path to changelog>")
 		return
 	}
-	filePath := os.Args[1]
-
-	if err := formatChangelog(filePath); err != nil {
+	if err := formatChangelog(os.Args[1]); err != nil {
 		fmt.Println(fmt.Errorf("formatting changelog: %+v", err))
 		return
 	}

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -180,7 +180,6 @@ var services = mapOf(
 	for _, service := range provider.SupportedTypedServices() {
 		info := reflect.TypeOf(service)
 		packageSegments := strings.Split(info.PkgPath(), "/")
-		packageName := packageSegments[len(packageSegments)-1]
 		serviceName := service.Name()
 
 		// Service Registrations are reused across Typed and Untyped Services now
@@ -188,13 +187,12 @@ var services = mapOf(
 			continue
 		}
 
-		services[serviceName] = packageName
+		services[serviceName] = packageSegments[len(packageSegments)-1]
 		serviceNames = append(serviceNames, serviceName)
 	}
 	for _, service := range provider.SupportedUntypedServices() {
 		info := reflect.TypeOf(service)
 		packageSegments := strings.Split(info.PkgPath(), "/")
-		packageName := packageSegments[len(packageSegments)-1]
 		serviceName := service.Name()
 
 		// Service Registrations are reused across Typed and Untyped Services now
@@ -202,7 +200,7 @@ var services = mapOf(
 			continue
 		}
 
-		services[serviceName] = packageName
+		services[serviceName] = packageSegments[len(packageSegments)-1]
 		serviceNames = append(serviceNames, serviceName)
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ func main() {
 	flag.Parse()
 
 	opts := &plugin.ServeOpts{
-		Debug:        false,
 		ProviderAddr: "registry.terraform.io/hashicorp/azuread",
 		ProviderFunc: provider.AzureADProvider,
 	}

--- a/scripts/.custom-gcl.yml
+++ b/scripts/.custom-gcl.yml
@@ -1,0 +1,11 @@
+# The single source of truth for the golangci-lint version - the GNUmakefile (and via
+# 'make golangci-with-modules', the CI workflows) derive it from this field.
+version: v2.12.2
+name: golangci-with-modules
+plugins:
+  - module: "github.com/katbyte/azproviderlint"
+    import: "github.com/katbyte/azproviderlint/plugin"
+    version: v0.8.0
+  - module: "github.com/katbyte/tfproviderlint-golangci"
+    import: "github.com/katbyte/tfproviderlint-golangci/plugin"
+    version: v0.31.0


### PR DESCRIPTION
Enables the `azproviderlint` custom golangci-lint module plugin (built via `scripts/.custom-gcl.yml` into `scripts/golangci-with-modules`), turns on AZG008 and AZR010, and fixes every finding the plugin reports so `make lint` is clean.

### Build / CI
- `GNUmakefile` derives the golangci-lint version from `scripts/.custom-gcl.yml`, builds `scripts/golangci-with-modules` with `golangci-lint custom` (from `make tools`, and automatically when the config changes), and runs `lint` / `lint-fix` through it. New `make azproviderlint` target runs just those checks.
- Regenerated `.teamcity/components/generated/services.kt`; its copyright header was stale since the compliance update, which was also failing gencheck on main.

### Real bug fixes surfaced by AZG008
- `internal/clients/client.go`: an inverted nil check let a nil `ListServicePrincipals` model reach the index expression and panic.
- `azuread_group` / `azuread_group_without_members`: the duplicate-owner retry compared against `properties.Owners`, which is never populated. It now compares against `Owners_ODataBind`, the list actually sent.

### Behaviour preserved with nolint
- `azuread_application` read keeps its `passwordCredentials != nil` guard (AZR010): dropping it would clear `password` from state when the API omits credentials.
- `azuread_administrative_unit` and `azuread_application_template` data sources keep their bare object-ID `id` (AZR001), which users reference directly.
- `azuread_invitation` keeps its bare ID (AZR001); the SDK has no ID type for invitations and the ID is never parsed.

### Everything else
Mechanical: `pointer.From` / `pointer.ToEnum` swaps, redundant zero-value struct fields removed, err assignments folded into `if` init statements, flatten helpers return empty slices instead of nil, registration maps sorted, `RequestedAccessTokenVersion` typed as `int64`. The `azuread_application` data source's `feature_tags` children drop `Optional`/`Default` flags that have no effect inside a computed-only block (AZS009); no runtime change.