### PR TITLE
teamcity: regenerate services.kt to fix gencheck on main

### DIFF
--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2023, 2026
 // SPDX-License-Identifier: MPL-2.0
 // NOTE: this is Generated from the Service Definitions - manual changes will be lost
 //       to re-generate this file, run 'make generate' in the root of the repository


### PR DESCRIPTION
gencheck has been failing on `main` since #1870: the copyright header in the `generator-services` template was updated, but the committed `.teamcity/components/generated/services.kt` was not regenerated.

This is the output of `make generate` with no other changes. The same regeneration is also carried in #1939 and #1942; whichever lands first makes the others a no-op.